### PR TITLE
JaCoCo code coverage 를 적용,  ci 플로우에 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,35 @@ on:
     branches: [ "main", "develop" ]
 
 jobs:
-  build-module:
+  build-and-verify:
     runs-on: ubuntu-latest
     steps:
-      # 1. Check out code FIRST (Caller Responsibility)
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. Call the Composite Action
-      - name: Build Module
-        uses: ./.github/actions/gradle-build-module
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          module-path: ':' # Root build (or specify specific module like :member-service)
-          gradle-cache: 'false' # Disabled until Gradle is initialized
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build and Test with Gradle
+        run: ./gradlew clean build
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/build/reports/tests/test/**'
+
+      - name: Upload JaCoCo Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: '**/build/reports/jacoco/test/html/**'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ allprojects {
 // =============================================================================
 // 부모 모듈 목록
 val parentModules = setOf("bc", "support", "bootstrap")
+val jacocoVersion = libs.versions.jacoco.get()
 
 subprojects {
     // 부모 모듈이 아닌 경우에만 java 플러그인 적용
@@ -52,6 +53,86 @@ subprojects {
         // 테스트 설정
         tasks.withType<Test> {
             useJUnitPlatform()
+            finalizedBy("jacocoTestReport")
+        }
+
+        apply(plugin = "jacoco")
+
+        extensions.configure<JacocoPluginExtension> {
+            toolVersion = jacocoVersion
+        }
+
+        tasks.withType<JacocoReport> {
+            reports {
+                html.required.set(true)
+                xml.required.set(true)
+                csv.required.set(false)
+            }
+            // 정말 필요없는 경우 제외하고 테스트 채워서 통과하게끔 하여야 함!!!!!!!
+            val exclusions = listOf(
+                "**/Q*",
+                "**/*Application*",
+                "**/*Config*",
+                "**/*Configuration*",
+                "**/*Dto*",
+                "**/*Request*",
+                "**/*Response*",
+                "**/*Exception*",
+                "**/*Interceptor*",
+                "**/*Filter*",
+                "**/*Entity*",
+                "**/*Mapper*",
+                "**/*Command*",
+                "**/*Query*",
+                "**/*Policy*",
+                "**/*Context*",
+                "**/*Snapshot*"
+            )
+
+            classDirectories.setFrom(
+                files(classDirectories.files.map {
+                    fileTree(it).matching {
+                        exclude(exclusions)
+                    }
+                })
+            )
+            
+            finalizedBy("jacocoTestCoverageVerification")
+        }
+
+        tasks.withType<JacocoCoverageVerification> {
+            val exclusions = listOf(
+                "*.Q*",
+                "*.Application",
+                "*Config*",
+                "*Configuration",
+                "*Dto",
+                "*Request",
+                "*Response",
+                "*Exception",
+                "*Interceptor",
+                "*Filter",
+                "*Entity",
+                "*Mapper",
+                "*Command",
+                "*Query",
+                "*Policy",
+                "*Context",
+                "*Snapshot"
+            )
+
+            violationRules {
+                rule {
+                    element = "BUNDLE"
+                    enabled = true
+                    limit {
+                        counter = "LINE"
+                        value = "COVEREDRATIO"
+                        minimum = 0.10.toBigDecimal()
+                    }
+                    excludes = exclusions
+                }
+            }
         }
 
         // 공통 테스트 의존성

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ restAssured = "5.4.0"
 
 # Monitoring
 micrometer = "1.12.2"
+jacoco = "0.8.11"
 
 [libraries]
 # --- Spring Boot ---


### PR DESCRIPTION
## Summary

- 테스트 코드 작성을 생활화하고, 프로덕트 품질을 보장하기 위하여 Jacoco 코드 커버리지 플러그인을 도입합니다.
- 10% 부터 시작하여 차차 커버리지 수준을 높여가는 것이 목표입니다.
- 프로젝트 루트의 gradle.build.kts 와 ci.yml 에서 확인하실 수 있습니다.


---

### Linked Issues

- closes #32
