### PR TITLE
 jacoco 테스트 커버리지 그래들 플러그인을 도입

### DIFF
--- a/.github/actions/gradle-build-module/action.yml
+++ b/.github/actions/gradle-build-module/action.yml
@@ -57,27 +57,32 @@ runs:
       run: ./gradlew ${{ inputs.module-path }}:build
 
     # 5. 지정된 모듈의 테스트를 실행합니다.
-    # 예: ./gradlew :bounded-context:subscription:subscription-bootstrap:external-api:test
+    # 테스트 완료 후 JaCoCo 리포트가 자동 생성됩니다 (finalizedBy 설정)
     - name: Run tests
       shell: bash
       run: ./gradlew ${{ inputs.module-path }}:test
 
     # 6. 테스트 결과를 아티팩트로 업로드합니다.
     # always(): 테스트 실패 여부와 관계없이 항상 실행
-    # upload-artifacts가 'true'일 때만 업로드합니다.
     - name: Upload test results
       if: ${{ always() && inputs.upload-artifacts == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ inputs.module-path != '' && inputs.module-path || 'root' }}
-        path: '**/build/test-results/test/*.xml'  # JUnit XML 형식 테스트 결과
+        path: '**/build/test-results/test/*.xml'
 
-    # 7. 빌드 실패 시 상세 리포트를 업로드합니다.
-    # failure(): 이전 스텝이 실패했을 때만 실행
-    # upload-artifacts가 'true'일 때만 업로드합니다.
+    # 7. JaCoCo 커버리지 리포트를 업로드합니다.
+    - name: Upload JaCoCo Reports
+      if: ${{ always() && inputs.upload-artifacts == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: jacoco-report-${{ inputs.module-path != '' && inputs.module-path || 'root' }}
+        path: '**/build/reports/jacoco/test/html/**'
+
+    # 8. 빌드 실패 시 상세 리포트를 업로드합니다.
     - name: Upload build reports
       if: ${{ failure() && inputs.upload-artifacts == 'true' }}
       uses: actions/upload-artifact@v4
       with:
         name: build-reports-${{ inputs.module-path != '' && inputs.module-path || 'root' }}
-        path: '**/build/reports/'  # HTML 형식의 빌드/테스트 리포트
+        path: '**/build/reports/'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ subprojects {
     // 부모 모듈이 아닌 경우에만 java 플러그인 적용
     if (name !in parentModules) {
         apply(plugin = "java")
+        apply(plugin = "jacoco")
         apply(plugin = "io.spring.dependency-management")
 
         // Java 21 설정
@@ -52,6 +53,15 @@ subprojects {
         // 테스트 설정
         tasks.withType<Test> {
             useJUnitPlatform()
+            finalizedBy(tasks.named("jacocoTestReport"))
+        }
+
+        // JaCoCo 리포트 설정
+        tasks.withType<JacocoReport> {
+            reports {
+                xml.required.set(true)
+                html.required.set(true)
+            }
         }
 
         // 공통 테스트 의존성


### PR DESCRIPTION


## Summary

테스트 코드 작성을 생활화하고, 프로덕트 품질을 보장하기 위하여 Jacoco 코드 커버리지 플러그인을 도입합니다.
10% 부터 시작하여 차차 커버리지 수준을 높여가는 것이 목표입니다.
프로젝트 루트의 gradle.build.kts 와 ci.yml, 컴포짓 액션 스크립트인 actions/action.yml 에서 확인하실 수 있습니다.

---

## What's Changed

- 커버리지 기준은 우선 10%로 지정하였습니다.
- 레포트가 통과하지 않으면 머지할 수 없습니다.
- 컴포짓 액션을 통해 한번에 ci.yml 에서 호출됩니다.

---

### Linked Issues

- closes #32 
