### PR TITLE
[HOTFIX] FundingWishlistItem에 @BatchSize 추가 및 Funding에서는 제거

### DIFF
--- a/bc/funding/src/main/java/app/giftify/domain/funding/Funding.java
+++ b/bc/funding/src/main/java/app/giftify/domain/funding/Funding.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
-
 import java.time.LocalDateTime;
 
 @Entity
@@ -15,7 +13,6 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Funding extends BaseJpaEntity {
 
-    @BatchSize(size = 100)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "funding_wishlist_item_id", nullable = false)
     private FundingWishlistItem fundingWishlistItem;

--- a/bc/funding/src/main/java/app/giftify/domain/funding/FundingWishlistItem.java
+++ b/bc/funding/src/main/java/app/giftify/domain/funding/FundingWishlistItem.java
@@ -1,8 +1,13 @@
 package app.giftify.domain.funding;
 
+import org.hibernate.annotations.BatchSize;
 
 import app.giftify.support.jpa.BaseJpaEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "FUNDING_WISHLIST_ITEM")
 @Getter
+@BatchSize(size = 100)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FundingWishlistItem extends BaseJpaEntity {
 


### PR DESCRIPTION
## Summary
- Hibernate 6.x의 @BatchSize 제약: @BatchSize는 컬렉션(@OneToMany, @ManyToMany)이나 엔티티 클래스 레벨에서만 사용 가능합니다. @ManyToOne이나 @OneToOne 같은 단일 값 연관관계에는 사용할 수       
  없습니다.                                                                                                                                                                                        
- Batch Fetching 대안: 이 연관관계에서 배치 페칭이 필요하다면, FundingWishlistItem 엔티티 클래스에 @BatchSize를 적용해야 합니다.   

---

## What's Changed

- `FundingWishlistItem` 클래스에 `@BatchSize(size = 100)` 어노테이션 추가
- `Funding` 클래스에서 불필요한 `@BatchSize` 어노테이션 제거

---

