### PR TITLE
커스텀 인증 어노테이션 인식 오류 수정 및 SecurityContext 통합 보강

### DIFF
--- a/bc/auth/src/main/java/app/giftify/auth/support/filter/MemberPrincipalFilter.java
+++ b/bc/auth/src/main/java/app/giftify/auth/support/filter/MemberPrincipalFilter.java
@@ -1,6 +1,8 @@
 package app.giftify.auth.support.filter;
 
 import app.giftify.auth.client.MemberApiClient;
+import app.giftify.security.common.MemberAuthenticationToken;
+import app.giftify.security.common.MemberPrincipal;
 import app.giftify.shared.domain.vo.MemberInfo;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,10 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -19,8 +18,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
 
 @Slf4j
 @Component
@@ -71,30 +68,7 @@ public class MemberPrincipalFilter extends OncePerRequestFilter {
 	}
 
 	private Authentication createAuthentication(MemberInfo member) {
-		// 🚨 중요: DB에 저장된 role이 "SELLER"라면 "ROLE_SELLER"로 변환해야 hasRole('SELLER')가 작동함
-		// 만약 member.getRole()이 Enum이라면 .name()을 사용하세요.
-		String roleName = "ROLE_" + member.role();
-		List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(roleName));
-
-		// 컨트롤러의 @CurrentMemberId가 참조할 객체
-		// member.getId(), member.getEmail() 등 실제 Member 객체의 메서드 호출
-		MemberPrincipal principal = new MemberPrincipal(
-				member.memberId(),
-				member.email(),
-				authorities
-		);
-
-		return new UsernamePasswordAuthenticationToken(
-				principal,
-				null,
-				authorities
-		);
+		MemberPrincipal principal = MemberPrincipal.from(member);
+		return new MemberAuthenticationToken(principal);
 	}
-
-	// DTO 역할의 내부 Record
-	public record MemberPrincipal(
-			Long memberId,
-			String email,
-			Collection<? extends GrantedAuthority> authorities
-	) {}
 }

--- a/bc/member/src/main/java/app/giftify/member/adapter/in/web/controller/MemberController.java
+++ b/bc/member/src/main/java/app/giftify/member/adapter/in/web/controller/MemberController.java
@@ -14,6 +14,7 @@ import app.giftify.security.common.context.AuthenticatedMember;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -26,6 +27,7 @@ import java.util.Optional;
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 public class MemberController {
 
     private final GetMemberUseCase getMemberUseCase;
@@ -38,13 +40,20 @@ public class MemberController {
     public ResponseEntity<?> checkRegistration(
             @AuthenticatedMember String authSub
     ) {
+        log.debug("[Controller] checkRegistration called with authSub: {}", authSub);
         if (authSub == null) {
             return ResponseEntity.status(401).body(Map.of("message", "인증 정보(JWT)가 누락되었습니다."));
         }
 
         return getMemberUseCase.getMemberByAuthSub(authSub)
-                .map(member -> ResponseEntity.ok().body((Object) member))
-                .orElseGet(() -> ResponseEntity.ok().body(Map.of("status", "NOT_REGISTERED")));
+                .map(member -> {
+                    log.debug("[Controller] Member found for authSub: {}", authSub);
+                    return ResponseEntity.ok().body((Object) member);
+                })
+                .orElseGet(() -> {
+                    log.debug("[Controller] Member NOT found for authSub: {}", authSub);
+                    return ResponseEntity.ok().body(Map.of("status", "NOT_REGISTERED"));
+                });
     }
 
     // 신규 회원 가입 (추가 정보 입력)

--- a/support/security/src/main/java/app/giftify/security/common/resolver/AuthenticatedMemberArgumentResolver.java
+++ b/support/security/src/main/java/app/giftify/security/common/resolver/AuthenticatedMemberArgumentResolver.java
@@ -67,6 +67,13 @@ public class AuthenticatedMemberArgumentResolver implements HandlerMethodArgumen
 			return null;
 		}
 
+		// Case 3: Authentication 자체가 Principal인 경우 (드문 케이스지만 방어적 코드)
+		if (authentication.getPrincipal() instanceof MemberPrincipal memberPrincipal) {
+			if (paramType.equals(String.class)) {
+				return memberPrincipal.authSub();
+			}
+		}
+
 		return null;
 	}
 }


### PR DESCRIPTION
## What's Changed

> `@AuthenticatedMember` 인식 실패 문제를 해결하고, 전역적으로 일관된 인증 객체를 사용하도록 `MemberPrincipalFilter` 로직을 개선했습니다.

### 1. 전역 인증 객체 통합 및 타입 불일치 해결
*   **기존 문제**: `MemberPrincipalFilter` 내부에서 정의된 로컬 Record를 Principal로 사용함에 따라, `Shared` 모듈의 `ArgumentResolver`에서 타입 체크(`instanceof`) 실패 및 인식 오류 발생.
*   **변경 사항**: 모든 모듈이 공유하는 `app.giftify.security.common.MemberPrincipal` 클래스를 사용하도록 수정했습니다. 이로써 `bc-auth`, `bc-member` 등 서비스 전반에서 동일한 인증 컨텍스트를 공유합니다.

### 2. 커스텀 인증 어노테이션 기능 복구
*   `@AuthenticatedMember` 및 `@CurrentMemberId`가 정상적으로 동작하지 않던 현상을 수정했습니다.
*   `MemberPrincipalFilter`에서 `MemberAuthenticationToken`을 명시적으로 생성하여 SecurityContext에 주입함으로써, 커스텀 `HandlerMethodArgumentResolver`가 인증 정보를 올바르게 추출할 수 있도록 보장했습니다.

### 3. @CurrentMemberId SpEL 표현식 안정화
*   `@AuthenticationPrincipal(expression = "memberId")`가 필터 교체 전/후(Jwt vs MemberPrincipal) 모든 상황에서 안전하게 동작하도록 내부 로직의 정합성을 맞추었습니다.

### 4. 보안 컨텍스트 보강
*   인증 객체 생성 시 DB의 Role 정보를 기반으로 `ROLE_` 접두사를 포함한 `GrantedAuthority`를 생성하여 `@PreAuthorize` 등의 인가 로직이 정상 동작하도록 보강했습니다.

---

**테스트 결과**: 
- [x] Talend API Tester를 통한 JWT 인증 시 `@CurrentMemberId` 값 정상 주입 확인
- [x] 가입되지 않은 사용자의 JWT 요청 시 `null` 주입 및 예외 처리 확인
- [x] 내부 서비스 간 통신 시 `MemberInfo` 기반 인증 정상 작동 확인

---

### Linked Issues

- closes #
