### PR TITLE
refactor:FundingAcceptedEvent에 confirmedAt 추가

### DIFF
--- a/bc/catalog/src/test/java/app/giftify/wishlist/adapter/in/event/WishlistEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/wishlist/adapter/in/event/WishlistEventListenerTest.java
@@ -341,7 +341,7 @@ class WishlistEventListenerTest {
 			void handleFundingAccepted_ChangesStatusToCompleted() {
 				// given
 				Long wishlistItemId = 1L;
-				FundingAcceptedEvent event = new FundingAcceptedEvent(100L, wishlistItemId);
+				FundingAcceptedEvent event = new FundingAcceptedEvent(100L, wishlistItemId, LocalDateTime.now());
 
 				WishlistItem wishlistItem = WishlistItem.builder()
 					.id(wishlistItemId)

--- a/bc/core/src/main/java/app/giftify/funding/app/funding/FundingAcceptUseCase.java
+++ b/bc/core/src/main/java/app/giftify/funding/app/funding/FundingAcceptUseCase.java
@@ -11,6 +11,8 @@ import app.giftify.shared.domain.event.funding.FundingAcceptedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class FundingAcceptUseCase {
@@ -34,7 +36,8 @@ public class FundingAcceptUseCase {
         // 이벤트 발행
         eventPublisher.publish(new FundingAcceptedEvent(
                 funding.getId(),
-                wishlistItem.getWishlistId()
+                wishlistItem.getWishlistId(),
+                LocalDateTime.now()
         ));
 
         return FundingCompleteResponseDto.fromEntity(funding);

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/funding/FundingAcceptedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/funding/FundingAcceptedEvent.java
@@ -2,17 +2,22 @@ package app.giftify.shared.domain.event.funding;
 
 import app.giftify.shared.domain.event.BaseDomainEvent;
 
+import java.time.LocalDateTime;
+
 public class FundingAcceptedEvent extends BaseDomainEvent {
     private final Long fundingId;
     private final Long wishlistItemId;
+    private final LocalDateTime confirmedAt;
 
     public FundingAcceptedEvent(
             Long fundingId,
-            Long wishlistItemId
+            Long wishlistItemId,
+            LocalDateTime confirmedAt
     ) {
         super();
         this.fundingId = fundingId;
         this.wishlistItemId = wishlistItemId;
+        this.confirmedAt = confirmedAt;
     }
 
     public Long getFundingId() {
@@ -21,12 +26,14 @@ public class FundingAcceptedEvent extends BaseDomainEvent {
     public Long getWishlistItemId() {
         return wishlistItemId;
     }
+    public LocalDateTime getConfirmedAt() { return confirmedAt;}
 
     @Override
     public String toString() {
         return "FundingAcceptedEvent{" +
                 "fundingId=" + fundingId +
                 ", wishlistItemId=" + wishlistItemId +
+                ", confirmedAt=" + confirmedAt +
                 ", eventId='" + getEventId() + "'" +
                 ", occurredAt=" + getOccurredAt() +
                 '}';


### PR DESCRIPTION


## Summary

### FundingAcceptedEvent에 confirmedAt 필드 추가
- FundingReceivedConfirmedEvent에서 사용하기 위함
- 필드 추가에 따라 위시리스트 테스트에도 수령확정 시간 추가
  - (handleFundingAccepted_ChangesStatusToCompleted() 펀딩 수락 이벤트 - 위시리스트 아이템 상태가 COMPLETED로 변경된다)

