### PR TITLE
refactor: CommonResponse를 RsData로 대체 및 예외 처리 구조 개선

### DIFF
--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/web/PaymentController.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/web/PaymentController.java
@@ -24,7 +24,7 @@ import app.giftify.payment.application.inbound.PaymentCreatedResult;
 import app.giftify.payment.application.inbound.QueryPaymentUseCase;
 import app.giftify.payment.domain.PaymentMethod;
 import app.giftify.security.common.CurrentMemberId;
-import app.giftify.shared.api.response.CommonResponse;
+import app.giftify.shared.api.response.RsData;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 import lombok.RequiredArgsConstructor;
@@ -41,7 +41,7 @@ public class PaymentController implements PaymentV2Api {
 
 	@Override
 	@PostMapping("/charge")
-	public ResponseEntity<CommonResponse<PaymentChargeResponse>> charge(
+	public ResponseEntity<RsData<PaymentChargeResponse>> charge(
 		@CurrentMemberId Long memberId,
 		@Valid @RequestBody PaymentChargeRequest request
 	) {
@@ -63,14 +63,14 @@ public class PaymentController implements PaymentV2Api {
 
 		PaymentCreatedResult result = createPaymentUseCase.create(command);
 
-		return ResponseEntity.ok(CommonResponse.success(
+		return ResponseEntity.ok(RsData.success(
 			PaymentChargeResponse.from(result, requestedAmount))
 		);
 	}
 
 	@Override
 	@PostMapping("/confirm")
-	public ResponseEntity<CommonResponse<PaymentConfirmResponse>> confirm(
+	public ResponseEntity<RsData<PaymentConfirmResponse>> confirm(
 		@CurrentMemberId Long memberId,
 		@Valid @RequestBody PaymentConfirmRequest request
 	) {
@@ -87,11 +87,11 @@ public class PaymentController implements PaymentV2Api {
 		ConfirmPaymentResult result = confirmPaymentUseCase.confirm(command);
 
 		if (result.success()) {
-			return ResponseEntity.ok(CommonResponse.success(
+			return ResponseEntity.ok(RsData.success(
 				PaymentConfirmResponse.success(result.paymentId())
 			));
 		} else {
-			return ResponseEntity.ok(CommonResponse.success(
+			return ResponseEntity.ok(RsData.success(
 				PaymentConfirmResponse.failure(result.errorCode(), result.errorMessage())
 			));
 		}

--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/web/PaymentV2Api.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/web/PaymentV2Api.java
@@ -7,7 +7,7 @@ import app.giftify.payment.adapter.inbound.web.dto.PaymentChargeRequest;
 import app.giftify.payment.adapter.inbound.web.dto.PaymentChargeResponse;
 import app.giftify.payment.adapter.inbound.web.dto.PaymentConfirmRequest;
 import app.giftify.payment.adapter.inbound.web.dto.PaymentConfirmResponse;
-import app.giftify.shared.api.response.CommonResponse;
+import app.giftify.shared.api.response.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -49,7 +49,7 @@ public interface PaymentV2Api {
             description = "인증 토큰 누락 또는 유효하지 않음",
             content = @Content
     )
-    ResponseEntity<CommonResponse<PaymentChargeResponse>> charge(
+    ResponseEntity<RsData<PaymentChargeResponse>> charge(
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid PaymentChargeRequest request
     );
@@ -91,7 +91,7 @@ public interface PaymentV2Api {
             description = "결제 정보를 찾을 수 없음",
             content = @Content
     )
-    ResponseEntity<CommonResponse<PaymentConfirmResponse>> confirm(
+    ResponseEntity<RsData<PaymentConfirmResponse>> confirm(
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid PaymentConfirmRequest request
     );

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletController.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import app.giftify.security.common.CurrentMemberId;
-import app.giftify.shared.api.response.CommonResponse;
+import app.giftify.shared.api.response.RsData;
 import app.giftify.shared.domain.vo.Money;
 import app.giftify.wallet.adapter.inbound.web.dto.WalletBalanceResponse;
 import app.giftify.wallet.adapter.inbound.web.dto.WalletHistoryResponse;
@@ -42,7 +42,7 @@ public class WalletController implements WalletV2Api {
 
 	@Override
 	@PostMapping("/withdraw")
-	public ResponseEntity<CommonResponse<WithdrawWalletResponse>> withdraw(
+	public ResponseEntity<RsData<WithdrawWalletResponse>> withdraw(
 		@CurrentMemberId Long memberId,
 		@Valid @RequestBody WithdrawWalletRequest request
 	) {
@@ -56,24 +56,24 @@ public class WalletController implements WalletV2Api {
 		);
 
 		WithdrawWalletResult result = withdrawWalletUseCase.withdraw(command);
-		return ResponseEntity.ok(CommonResponse.success(WithdrawWalletResponse.from(result)));
+		return ResponseEntity.ok(RsData.success(WithdrawWalletResponse.from(result)));
 	}
 
 	@Override
 	@GetMapping("/balance")
-	public ResponseEntity<CommonResponse<WalletBalanceResponse>> getBalance(
+	public ResponseEntity<RsData<WalletBalanceResponse>> getBalance(
 		@CurrentMemberId Long memberId
 	) {
 		log.debug("[WalletController] 잔액 조회. memberId={}", memberId);
 
 		WalletBalanceResult result = queryWalletUseCase.getBalance(memberId);
-		return ResponseEntity.ok(CommonResponse.success(WalletBalanceResponse.from(result)));
+		return ResponseEntity.ok(RsData.success(WalletBalanceResponse.from(result)));
 	}
 
 
 	@Override
 	@GetMapping("/history")
-	public ResponseEntity<CommonResponse<Page<WalletHistoryResponse>>> getHistory(
+	public ResponseEntity<RsData<Page<WalletHistoryResponse>>> getHistory(
 		@CurrentMemberId Long memberId,
 		@RequestParam(name = "type", required = false) TransactionType type,
 		@RequestParam(name = "page", defaultValue = "0") int page,
@@ -85,6 +85,6 @@ public class WalletController implements WalletV2Api {
 		Page<WalletHistoryResult> result = queryWalletHistoryUseCase.getHistory(query);
 		Page<WalletHistoryResponse> response = result.map(WalletHistoryResponse::from);
 
-		return ResponseEntity.ok(CommonResponse.success(response));
+		return ResponseEntity.ok(RsData.success(response));
 	}
 }

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletV2Api.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletV2Api.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import app.giftify.shared.api.response.CommonResponse;
+import app.giftify.shared.api.response.RsData;
 import app.giftify.wallet.adapter.inbound.web.dto.WalletBalanceResponse;
 import app.giftify.wallet.adapter.inbound.web.dto.WalletHistoryResponse;
 import app.giftify.wallet.adapter.inbound.web.dto.WithdrawWalletRequest;
@@ -60,7 +60,7 @@ public interface WalletV2Api {
             description = "지갑을 찾을 수 없음",
             content = @Content
     )
-    ResponseEntity<CommonResponse<WithdrawWalletResponse>> withdraw(
+    ResponseEntity<RsData<WithdrawWalletResponse>> withdraw(
             @Parameter(hidden = true) Long memberId,
             @RequestBody @Valid WithdrawWalletRequest request
     );
@@ -84,7 +84,7 @@ public interface WalletV2Api {
             description = "지갑을 찾을 수 없음 (회원가입 후 첫 조회 시 자동 생성)",
             content = @Content
     )
-    ResponseEntity<CommonResponse<WalletBalanceResponse>> getBalance(
+    ResponseEntity<RsData<WalletBalanceResponse>> getBalance(
             @Parameter(hidden = true) Long memberId
     );
 
@@ -114,7 +114,7 @@ public interface WalletV2Api {
             description = "인증 토큰 누락 또는 유효하지 않음",
             content = @Content
     )
-    ResponseEntity<CommonResponse<Page<WalletHistoryResponse>>> getHistory(
+    ResponseEntity<RsData<Page<WalletHistoryResponse>>> getHistory(
             @Parameter(hidden = true) Long memberId,
             @Parameter(description = "거래 유형 필터 (선택)", example = "CHARGE")
             @RequestParam(required = false) TransactionType type,

--- a/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/web/WalletControllerTest.java
+++ b/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/web/WalletControllerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import app.giftify.wallet.adapter.inbound.web.dto.*;
-import app.giftify.shared.api.response.CommonResponse;
+import app.giftify.shared.api.response.RsData;
 
 import java.math.BigDecimal;
 
@@ -69,13 +69,13 @@ class WalletControllerTest {
 			given(withdrawWalletUseCase.withdraw(any(WithdrawWalletCommand.class))).willReturn(result);
 
 			// when
-			ResponseEntity<CommonResponse<WithdrawWalletResponse>> response =
+			ResponseEntity<RsData<WithdrawWalletResponse>> response =
 				walletController.withdraw(TEST_MEMBER_ID, request);
 
 			// then
 			assertThat(response.getStatusCode().value()).isEqualTo(200);
 			assertThat(response.getBody()).isNotNull();
-			assertThat(response.getBody().getResult()).isEqualTo(CommonResponse.Result.SUCCESS);
+			assertThat(response.getBody().getResult()).isEqualTo(RsData.Result.SUCCESS);
 			assertThat(response.getBody().getData().walletId()).isEqualTo(1L);
 			assertThat(response.getBody().getData().status()).isEqualTo("PENDING");
 			verify(withdrawWalletUseCase).withdraw(any(WithdrawWalletCommand.class));
@@ -94,13 +94,13 @@ class WalletControllerTest {
 			given(queryWalletUseCase.getBalance(anyLong())).willReturn(result);
 
 			// when
-			ResponseEntity<CommonResponse<WalletBalanceResponse>> response =
+			ResponseEntity<RsData<WalletBalanceResponse>> response =
 				walletController.getBalance(TEST_MEMBER_ID);
 
 			// then
 			assertThat(response.getStatusCode().value()).isEqualTo(200);
 			assertThat(response.getBody()).isNotNull();
-			assertThat(response.getBody().getResult()).isEqualTo(CommonResponse.Result.SUCCESS);
+			assertThat(response.getBody().getResult()).isEqualTo(RsData.Result.SUCCESS);
 			assertThat(response.getBody().getData().walletId()).isEqualTo(1L);
 			assertThat(response.getBody().getData().balance()).isEqualTo(BigDecimal.valueOf(50000));
 			verify(queryWalletUseCase).getBalance(TEST_MEMBER_ID);
@@ -123,13 +123,13 @@ class WalletControllerTest {
 			given(queryWalletHistoryUseCase.getHistory(any(WalletHistoryQuery.class))).willReturn(result);
 
 			// when
-			ResponseEntity<CommonResponse<Page<WalletHistoryResponse>>> response =
+			ResponseEntity<RsData<Page<WalletHistoryResponse>>> response =
 				walletController.getHistory(TEST_MEMBER_ID, null, 0, 20);
 
 			// then
 			assertThat(response.getStatusCode().value()).isEqualTo(200);
 			assertThat(response.getBody()).isNotNull();
-			assertThat(response.getBody().getResult()).isEqualTo(CommonResponse.Result.SUCCESS);
+			assertThat(response.getBody().getResult()).isEqualTo(RsData.Result.SUCCESS);
 			assertThat(response.getBody().getData().getContent()).hasSize(1);
 			assertThat(response.getBody().getData().getContent().get(0).type()).isEqualTo("CHARGE");
 			verify(queryWalletHistoryUseCase).getHistory(any(WalletHistoryQuery.class));
@@ -147,7 +147,7 @@ class WalletControllerTest {
 			given(queryWalletHistoryUseCase.getHistory(any(WalletHistoryQuery.class))).willReturn(result);
 
 			// when
-			ResponseEntity<CommonResponse<Page<WalletHistoryResponse>>> response =
+			ResponseEntity<RsData<Page<WalletHistoryResponse>>> response =
 				walletController.getHistory(TEST_MEMBER_ID, TransactionType.WITHDRAW, 0, 20);
 
 			// then

--- a/bc/shared/src/main/java/app/giftify/shared/api/errorCode/InfraErrorCode.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/errorCode/InfraErrorCode.java
@@ -1,0 +1,39 @@
+package app.giftify.shared.api.errorCode;
+
+import app.giftify.shared.api.exception.ErrorCode;
+
+public enum InfraErrorCode implements ErrorCode {
+
+    DB_LOCK_TIMEOUT("INFRA_DB_001", "DB 락 획득에 실패했습니다.", true),
+    DB_TEMPORARY_ERROR("INFRA_DB_002", "일시적인 DB 오류입니다.", true),
+    DB_CONSTRAINT_VIOLATION("INFRA_DB_003", "DB 제약 조건 위반입니다.", false),
+
+    EXTERNAL_API_TIMEOUT("INFRA_EXT_001", "외부 API 응답 지연", true),
+    EXTERNAL_API_ERROR("INFRA_EXT_002", "외부 API 호출 실패", true),
+
+    UNKNOWN_INFRA_ERROR("INFRA_999", "알 수 없는 인프라 오류", false);
+
+    private final String code;
+    private final String message;
+    private final boolean retryable;
+
+    InfraErrorCode(String code, String message, boolean retryable) {
+        this.code = code;
+        this.message = message;
+        this.retryable = retryable;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isRetryable() {
+        return retryable;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/BaseException.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/BaseException.java
@@ -1,0 +1,25 @@
+package app.giftify.shared.api.exception;
+
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    protected BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    protected BaseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    protected BaseException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/BusinessException.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package app.giftify.shared.api.exception;
+
+/**
+ * "의도된 실패"의 최상위
+ */
+public abstract class BusinessException extends BaseException {
+    protected BusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    protected BusinessException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    protected BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(errorCode, message, cause);
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/DomainException.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/DomainException.java
@@ -1,24 +1,18 @@
 package app.giftify.shared.api.exception;
 
-public class DomainException extends RuntimeException {
-    private final ErrorCode errorCode;
-
+/**
+ * 도메인 검증 실패
+ */
+public class DomainException extends BusinessException {
     public DomainException(ErrorCode errorCode) {
-        super(errorCode.getMessage());
-        this.errorCode = errorCode;
+        super(errorCode);
     }
 
     public DomainException(ErrorCode errorCode, String message) {
-        super(message);
-        this.errorCode = errorCode;
+        super(errorCode, message);
     }
 
     public DomainException(ErrorCode errorCode, String message, Throwable cause) {
-        super(message, cause);
-        this.errorCode = errorCode;
-    }
-
-    public ErrorCode getErrorCode() {
-        return errorCode;
+        super(errorCode, message, cause);
     }
 }

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/ErrorCode.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/ErrorCode.java
@@ -1,5 +1,6 @@
 package app.giftify.shared.api.exception;
 
+// todo: 추후 재시도 여부(isRetryable) 필드 추가
 public interface ErrorCode {
     String getCode();
     String getMessage();

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/InfraException.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/InfraException.java
@@ -1,0 +1,15 @@
+package app.giftify.shared.api.exception;
+
+/**
+ * 시스템이 일을 못한 것
+ */
+public class InfraException extends BaseException {
+    public InfraException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InfraException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode);
+        initCause(cause);
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/api/exception/PolicyException.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/exception/PolicyException.java
@@ -1,0 +1,10 @@
+package app.giftify.shared.api.exception;
+
+/**
+ * 값은 올바르나 정책 상 실패
+ */
+public class PolicyException extends BusinessException {
+    public PolicyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/api/response/RsData.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/response/RsData.java
@@ -1,13 +1,13 @@
 package app.giftify.shared.api.response;
 
 // API 공통 응답 규격
-public final class CommonResponse<T> {
+public final class RsData<T> {
     private final Result result;
     private final T data;
     private final String message;
     private final String errorCode;
 
-    private CommonResponse(Result result, T data, String message, String errorCode) {
+    private RsData(Result result, T data, String message, String errorCode) {
         this.result = result;
         this.data = data;
         this.message = message;
@@ -18,16 +18,16 @@ public final class CommonResponse<T> {
         SUCCESS, FAIL
     }
 
-    public static <T> CommonResponse<T> success(T data) {
-        return new CommonResponse<>(Result.SUCCESS, data, null, null);
+    public static <T> RsData<T> success(T data) {
+        return new RsData<>(Result.SUCCESS, data, null, null);
     }
 
-    public static <T> CommonResponse<T> success(T data, String message) {
-        return new CommonResponse<>(Result.SUCCESS, data, message, null);
+    public static <T> RsData<T> success(T data, String message) {
+        return new RsData<>(Result.SUCCESS, data, message, null);
     }
 
-    public static CommonResponse<Void> fail(String message, String errorCode) {
-        return new CommonResponse<>(Result.FAIL, null, message, errorCode);
+    public static RsData<Void> fail(String message, String errorCode) {
+        return new RsData<>(Result.FAIL, null, message, errorCode);
     }
 
     public Result getResult() {

--- a/support/web/build.gradle.kts
+++ b/support/web/build.gradle.kts
@@ -6,6 +6,13 @@ plugins {
 
 dependencies {
     implementation(project(":support:common"))
+    implementation(project(":bc:shared"))
+
     implementation(libs.spring.boot.starter.web)
+
+    // Lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+
     api(libs.springdoc.openapi)
 }

--- a/support/web/src/main/java/giftify/support/web/handler/GlobalExceptionHandler.java
+++ b/support/web/src/main/java/giftify/support/web/handler/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package giftify.support.web.handler;
+
+import app.giftify.shared.api.exception.ErrorCode;
+import app.giftify.shared.api.response.RsData;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<RsData<Void>> handleException(Exception e) {
+        log.error("[Global] 알 수 없는 예외 발생", e);
+
+        GlobalErrorCode errorCode = GlobalErrorCode.UNKNOWN_ERROR;
+
+        RsData<Void> body = RsData.fail(errorCode.getMessage(), errorCode.getCode());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(body);
+    }
+
+    // todo: 추후 확장 가능하면 분리
+    enum GlobalErrorCode implements ErrorCode {
+        UNKNOWN_ERROR("GLOBAL_001", "알 수 없는 오류가 발생했습니다.")
+        ;
+
+        private final String code;
+        private final String message;
+
+        GlobalErrorCode(String code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        @Override
+        public String getMessage() {
+            return message;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

이번 PR은 API 응답 구조를 통일하고 전역 예외 처리 메커니즘을 도입하는 내용을 담고 있어요.
기존에 각 기능에서 사용되던 CommonResponse를 RsData로 교체해 응답 형식을 일관되게 만들고, 예외 처리도 글로벌 레벨에서 표준화해 유지보수성과 설계 일관성을 높이기 위한 변경입니다. 

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

- API 응답 포맷을 통일하기 위해 CommonResponse를 RsData로 대체했습니다.
- WalletController, PaymentController 등에서 반환하는 응답도 RsData 기반으로 수정했습니다.
- 전역 예외 처리기(GlobalExceptionHandler) 를 구현해 애플리케이션 전반의 예외를 중앙에서 처리할 수 있게 했습니다.
- 예외 계층을 개선하기 위해 BaseException, BusinessException, PolicyException 등 예외 구조를 정리·추가했습니다.
- 인프라 관련 예외 코드 표준화를 위해 InfraErrorCode와 InfraException을 정의했습니다.
- 변경된 구조에 맞춰 테스트 코드도 RsData 기반으로 검증하도록 수정했습니다.  ￼

```
BaseException (extends RuntimeException)
├─ BusinessException (abstract)
│   ├─ DomainException
│   └─ PolicyException
└─ InfraException
```

#### BaseException
- 최상위 예외 클래스
- 모든 커스텀 예외가 여기를 상속
- ErrorCode를 들고 있음

#### BusinessException (추상)
- “비즈니스/도메인 기반 예외”의 최상위
- 구체 비즈니스 예외(도메인 검증 실패, 정책 실패 등)를 묶기 위해 존재

#### DomainException
- 도메인 검증 실패
- 비즈니스 규칙(도메인 룰) 위반에 대한 예외

#### PolicyException
- 값 자체는 유효하지만 “정책 상 허용되지 않는 경우”에 대한 예외
- 예: 같은 주문을 두 번 못 만드는 정책

#### InfraException
- 시스템/인프라 문제를 나타내는 예외
- 비즈니스가 아닌 외부/내부 서비스 장애 등

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.

- API 응답을 RsData로 통일하면서 기존 컨트롤러/서비스 일부를 수정해야 했습니다.
이는 구조는 더 깔끔해지지만 한 번에 많은 코드 변경이 수반됩니다.
- 예외 계층을 더 세분화해 예외 분류는 좋아졌지만, 처리해야 할 예외 클래스가 늘어났습니다. 이런 구조는 장기적 유지보수에는 유리하지만 초기 설계 복잡도는 약간 증가합니다.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.

---

### Linked Issues

- closes #184
