### PR TITLE
fix: OrderSnapshot 생성 시 id 누락 해결 및 WishlistClient 파라미터명 수정

### DIFF
--- a/bc/core/src/main/java/app/giftify/orderDemo/adapter/outbound/client/WishlistClient.java
+++ b/bc/core/src/main/java/app/giftify/orderDemo/adapter/outbound/client/WishlistClient.java
@@ -9,5 +9,5 @@ import org.springframework.web.service.annotation.HttpExchange;
 public interface WishlistClient {
 
     @GetExchange(url = "/items/{wishlistItemId}/snapshot")
-    WishlistItemSnapshot getWishlistItemSnapshot(@PathVariable("wishlistItemId") Long wishlistId);
+    WishlistItemSnapshot getWishlistItemSnapshot(@PathVariable("wishlistItemId") Long wishlistItemId);
 }

--- a/bc/core/src/main/java/app/giftify/orderDemo/domain/Order.java
+++ b/bc/core/src/main/java/app/giftify/orderDemo/domain/Order.java
@@ -132,13 +132,14 @@ public class Order extends BaseAggregateRoot {
                 .toList();
 
         return OrderSnapshot.builder()
+                .orderId(id)
                 .orderNumber(orderNumber)
                 .buyerId(buyerId)
+                .orderItemSnapshots(itemSnapshots)
+                .totalAmount(totalAmount)
                 .paymentMethod(paymentMethod)
                 .status(status)
-                .totalAmount(totalAmount)
                 .createdAt(createdAt)
-                .orderItemSnapshots(itemSnapshots)
                 .build();
     }
 

--- a/bc/settlement/src/main/java/app/giftify/settlement/domain/OrderSnapshot.java
+++ b/bc/settlement/src/main/java/app/giftify/settlement/domain/OrderSnapshot.java
@@ -1,9 +1,6 @@
 package app.giftify.settlement.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
- `OrderSnapshot` 생성 코드에서 필드 순서 조정 (`orderId` 및 `orderItemSnapshots` 재배치)
- `WishlistClient`의 `PathVariable` 매개변수명을 `wishlistId`에서 `wishlistItemId`로 수정
- JPA import 정리 (`OrderSnapshot` 엔티티)

## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

```
java.lang.IllegalArgumentException: Name for argument of type [java.lang.Long] not specified, and parameter name information not available via reflection. Ensure that the compiler uses the '-parameters' flag.
```
- 

#### 문제
- WishlistClient 인터페이스 안에 변수명 불일치
- `Order` 내부 `OrderSnapshot` 생성 시 orderId 누락

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

- WishlistClient 인터페이스 내 파라미터 wishlistId -> wishlistItemId 수정
- `Order` 내부 `OrderSnapshot` 생성 시 orderId 포함

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.

- 클라이언트에서 중복 요청 시 멱등성 보장 수행

---

### Linked Issues

- closes #
