### PR TITLE
fix: 배포 스크립트 git 의존성 제거 및 rollback 통합

### DIFF
--- a/.github/workflows/deploy-k3s.yml
+++ b/.github/workflows/deploy-k3s.yml
@@ -12,12 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: read
   packages: read
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}/api-server
 
 jobs:
   deploy:
@@ -29,12 +24,8 @@ jobs:
       || github.event_name == 'workflow_dispatch'
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set image tag
         run: |
-          IMAGE_NAME_LOWER=$(echo "${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           if [ -n "${{ inputs.image_tag }}" ]; then
             IMAGE_TAG="${{ inputs.image_tag }}"
           elif [[ "${{ github.event.workflow_run.head_branch }}" == v* ]]; then
@@ -43,30 +34,11 @@ jobs:
             IMAGE_TAG="${{ github.event.workflow_run.head_sha }}"
             IMAGE_TAG="${IMAGE_TAG::7}"
           fi
-          echo "IMAGE=${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:${IMAGE_TAG}" >> $GITHUB_ENV
-          echo ">>> 배포 이미지: ${{ env.REGISTRY }}/${IMAGE_NAME_LOWER}:${IMAGE_TAG}"
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+          echo ">>> 배포 이미지 태그: ${IMAGE_TAG}"
 
-      - name: Deploy to K3s
-        run: |
-          cd infra/k3s/overlays/prod
-          kustomize edit set image \
-            ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server=${{ env.IMAGE }}
-          kubectl apply -k .
-
-      - name: Wait for rollout
-        id: rollout
-        run: |
-          if ! kubectl rollout status deployment/api-server -n giftify --timeout=240s; then
-            kubectl get pods -n giftify -l app=api-server
-            kubectl logs -l app=api-server -n giftify --tail=50 || true
-            exit 1
-          fi
-
-      - name: Rollback on failure
-        if: failure() && steps.rollout.outcome == 'failure'
-        run: |
-          kubectl rollout undo deployment/api-server -n giftify
-          kubectl rollout status deployment/api-server -n giftify --timeout=240s
+      - name: Deploy
+        run: ~/giftify-k3s/infra/k3s/scripts/k3s-ec2-deploy.sh "${{ env.IMAGE_TAG }}"
 
       - name: Show status
         if: always()

--- a/infra/k3s/scripts/k3s-ec2-deploy.sh
+++ b/infra/k3s/scripts/k3s-ec2-deploy.sh
@@ -38,11 +38,19 @@ cd "$OVERLAY_DIR"
 kustomize edit set image \
     "ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server=ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server:$IMAGE_TAG"
 kubectl apply -k .
-git checkout -- kustomization.yaml
 
 echo ">>> Rollout 대기중..."
-kubectl rollout status deployment/api-server -n giftify --timeout=600s
-
-echo ""
-echo "=== 배포 완료 ==="
-kubectl get pods -n giftify
+if kubectl rollout status deployment/api-server -n giftify --timeout=600s; then
+    echo ""
+    echo "=== 배포 완료 ==="
+    kubectl get pods -n giftify
+else
+    echo "!!! Rollout 실패 - 자동 롤백 수행"
+    kubectl get pods -n giftify -l app=api-server
+    kubectl logs -l app=api-server -n giftify --tail=50 || true
+    kubectl rollout undo deployment/api-server -n giftify
+    kubectl rollout status deployment/api-server -n giftify --timeout=240s
+    echo "=== 롤백 완료 ==="
+    kubectl get pods -n giftify
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- k3s-ec2-deploy.sh에서 git checkout -- kustomization.yaml 제거
- rollout 실패 시 자동 롤백 로직을 스크립트에 통합
- deploy-k3s.yml에서 actions/checkout 제거, EC2 로컬 스크립트 호출로 전환

---
 ---
  0. 사전 확인
  - EC2 SSH 접속 정보, Cloudflare Tunnel Token, 현재 .env 파일 위치 확인
  - GitHub Actions runner가 Docker 컨테이너인지 시스템 서비스인지 파악
  - GHCR PAT (read:packages 권한) 발급

  1. 사전 준비 (EC2 외부, 다운타임 전)
  - infra/k3s/base/secrets.yaml.template을 복사하여 secrets.yaml 작성
  - 기존 Docker Compose .env의 값을 K8s Secret 형식으로 매핑
    (DB, Redis, Auth0, Toss, Cloudflare Token 등 6개 Secret)
  - prod 환경 값 주의: S3_ENDPOINT는 AWS S3 URL, SPRING_PROFILES_ACTIVE는 prod
  - infra/k3s/configs/registries.yaml.template을 복사하여 GHCR PAT 기입
  - 세 항목을 EC2에 SCP 전송:
      scp -r infra/k3s/ ec2-user@<IP>: `~/giftify-k3s/infra/k3s/`
      scp secrets.yaml registries.yaml `ec2-user@<IP>: ~/`

  2. EC2 현재 상태 백업 (5분)
  - SSH 접속 후 .env 파일 백업: cp .env .env.backup.$(date +%Y%m%d)
  - docker ps 결과를 파일로 저장하여 현재 실행 중인 컨테이너 기록
  - Cloudflare Tunnel과 GitHub Actions Runner가 Docker인지 systemd인지 확인하여 기록

  3. Docker Compose 중지 -- 다운타임 시작 (5분)
  - docker compose down으로 기존 서비스 전체 중지
  - nginx 중지 및 disable, Portainer 중지, Cloudflare Tunnel 중지
  - 기존 Blue-Green 컨테이너(api-server-blue, api-server-green) 중지.
    Docker 데몬 자체는 유지

  4. k3s 설치 (5분)
  - SCP로 전송한 ~/giftify-k3s/infra/k3s/scripts/k3s-ec2-setup.sh 실행
    (k3s v1.31.5, kubeconfig 복사, kustomize 설치까지 자동)
  - kubectl get nodes로 클러스터 Ready 확인
  - EC2에 git 설치 불필요 (인프라 코드는 SCP로 전달 완료)

  5. GHCR 레지스트리 인증 (3분)
  - SCP로 전송한 registries.yaml을 /etc/rancher/k3s/registries.yaml에 복사
    후 sudo systemctl restart k3s
  - 이 파일은 k3s containerd 레벨에서 GHCR 인증을 처리하여
    프라이빗 이미지 pull을 가능하게 함
  - 추가로 kubectl create secret docker-registry ghcr-secret -n giftify로
    imagePullSecrets용 Secret 생성

  6. Secrets 적용 및 첫 배포 (10분)
  - SCP로 전송한 secrets.yaml을 infra/k3s/base/secrets.yaml에 복사
    (기존 dev 값을 prod로 덮어씀)
  - ~/giftify-k3s/infra/k3s/scripts/k3s-ec2-deploy.sh latest 실행
    (namespace 생성 -> secrets 적용 -> kustomize 배포 -> rollout 대기
     -> 실패 시 자동 롤백까지 스크립트가 처리)
  - watch kubectl get pods -n giftify로 전체 Pod Running 확인.
    prod에서 MinIO는 replicas=0 (AWS S3 직접 사용)

  7. Cloudflare Tunnel 전환 (5분)
  - secrets.yaml에 기존 Tunnel Token을 넣었으면 cloudflared Pod이
    자동으로 터널에 연결됨
  - Cloudflare Dashboard에서 Service URL을
    http://api-server.giftify.svc.cluster.local:8080으로 변경
    (기존 localhost 대신 K8s Service DNS 사용)
  - kubectl logs -l app=cloudflared -n giftify에서
    "Connection registered" 메시지 확인

  8. 검증 -- 다운타임 종료 (5분)
  - kubectl exec deploy/api-server -n giftify -- \
      wget -qO- http://localhost:8080/actuator/health
    로 Pod 내부 헬스체크
  - curl -sf http://localhost:80/actuator/health
    로 Traefik IngressRoute 라우팅 확인
  - curl -sf https://<도메인>/actuator/health
    로 Cloudflare Tunnel 통한 외부 접근 최종 확인

  9. GitHub Actions 설정 (10분, 서비스 운영 중 가능)
  - deploy-k3s.yml은 CI 성공 시 workflow_run으로 자동 트리거되어
    self-hosted runner에서 ~/giftify-k3s/infra/k3s/scripts/k3s-ec2-deploy.sh 호출
    (git checkout 없이 EC2 로컬 파일 사용)
  - runner 사용자가 kubectl, kustomize에 접근 가능한지 확인,
    안 되면 kubeconfig 복사
  - 기존 cd-ghcr-amazon-linux.yml (Docker blue-green 배포) 비활성화 또는 삭제

  10. 정리 (5분, 선택)
  - 기존 Docker 컨테이너 정리: docker rm -f api-server-blue api-server-green portainer
  - nginx 제거 (sudo yum remove nginx -y), 기존 프로젝트 디렉토리 백업 후 이동
  - Docker 자체는 유지 (self-hosted runner가 Docker 빌드에 사용)
  - 인프라 매니페스트 변경 시 로컬에서 다시 scp -r infra/k3s/ 로 갱신


---
