### PR TITLE
@Valid 중복 선언으로 인한 HV000151 에러 수정

### DIFF
--- a/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/FriendshipV2ApiSpec.java
+++ b/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/FriendshipV2ApiSpec.java
@@ -14,52 +14,44 @@ import app.giftify.shared.api.response.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 
 @Tag(name = "FriendShip V2", description = "소셜 기능 관련 API")
 public interface FriendshipV2ApiSpec {
 
 	@Operation(summary = "친구 요청 전송")
-	@ApiResponses({
-		@ApiResponse(responseCode = "201", description = "친구 요청 생성 성공"),
-		@ApiResponse(responseCode = "400", description = "자기 자신에게 요청 / 탈퇴 회원에게 요청"),
-		@ApiResponse(responseCode = "404", description = "대상 회원을 찾을 수 없음"),
-		@ApiResponse(responseCode = "409", description = "이미 친구 관계가 존재함")
-	})
+	@ApiResponse(responseCode = "201", description = "친구 요청 생성 성공")
+	@ApiResponse(responseCode = "400", description = "자기 자신에게 요청 / 탈퇴 회원에게 요청")
+	@ApiResponse(responseCode = "404", description = "대상 회원을 찾을 수 없음")
+	@ApiResponse(responseCode = "409", description = "이미 친구 관계가 존재함")
 	ResponseEntity<RsData<FriendshipResponse>> sendRequest(
 		@Parameter(hidden = true) @CurrentMemberId Long memberId,
-		SendFriendRequestDto request
+		@Valid SendFriendRequestDto request
 	);
 
 	@Operation(summary = "친구 요청 수락")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "수락 성공"),
-		@ApiResponse(responseCode = "400", description = "수신자만 수락 가능 / PENDING 상태가 아님"),
-		@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
-	})
+	@ApiResponse(responseCode = "200", description = "수락 성공")
+	@ApiResponse(responseCode = "400", description = "수신자만 수락 가능 / PENDING 상태가 아님")
+	@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
 	ResponseEntity<RsData<FriendshipResponse>> accept(
 		@Parameter(hidden = true) @CurrentMemberId Long memberId,
 		@PathVariable Long friendshipId
 	);
 
 	@Operation(summary = "친구 요청 거절")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "거절 성공"),
-		@ApiResponse(responseCode = "400", description = "수신자만 거절 가능 / PENDING 상태가 아님"),
-		@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
-	})
+	@ApiResponse(responseCode = "200", description = "거절 성공")
+	@ApiResponse(responseCode = "400", description = "수신자만 거절 가능 / PENDING 상태가 아님")
+	@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
 	ResponseEntity<RsData<Void>> reject(
 		@Parameter(hidden = true) @CurrentMemberId Long memberId,
 		@PathVariable Long friendshipId
 	);
 
 	@Operation(summary = "친구 삭제")
-	@ApiResponses({
-		@ApiResponse(responseCode = "200", description = "삭제 성공"),
-		@ApiResponse(responseCode = "400", description = "당사자만 삭제 가능"),
-		@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
-	})
+	@ApiResponse(responseCode = "200", description = "삭제 성공")
+	@ApiResponse(responseCode = "400", description = "당사자만 삭제 가능")
+	@ApiResponse(responseCode = "404", description = "친구 관계를 찾을 수 없음")
 	ResponseEntity<RsData<Void>> remove(
 		@Parameter(hidden = true) @CurrentMemberId Long memberId,
 		@PathVariable Long friendshipId

--- a/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/FriendshipV2Controller.java
+++ b/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/FriendshipV2Controller.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,12 +25,10 @@ import app.giftify.friendship.application.port.in.SendFriendRequestUseCase;
 import app.giftify.friendship.domain.Friendship;
 import app.giftify.security.common.CurrentMemberId;
 import app.giftify.shared.api.response.RsData;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@Validated
 public class FriendshipV2Controller implements FriendshipV2ApiSpec {
 
 	private final SendFriendRequestUseCase sendFriendRequestUseCase;
@@ -44,7 +42,7 @@ public class FriendshipV2Controller implements FriendshipV2ApiSpec {
 	@PostMapping("/api/v2/friends/request")
 	public ResponseEntity<RsData<FriendshipResponse>> sendRequest(
 		@CurrentMemberId Long memberId,
-		@RequestBody @Valid SendFriendRequestDto request) {
+		@Valid @RequestBody SendFriendRequestDto request) {
 		Friendship friendship = sendFriendRequestUseCase.sendRequest(memberId, request.receiverId());
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(RsData.success(FriendshipResponse.from(friendship)));


### PR DESCRIPTION
 ## Summary
  - FriendshipV2Controller에 @Validated + @Valid 중복 선언으로 Hibernate Validator가 HV000151을
  발생시켜 모든 friendship API가 500을 반환하던 문제 해결

  ## What's Changed
  - `FriendshipV2Controller`: 클래스 레벨 `@Validated` 제거, 파라미터 `@Valid`는 ApiSpec
  인터페이스에서 선언하도록 이동
  - `FriendshipV2ApiSpec`: `sendRequest` 파라미터에 `@Valid` 추가, `@ApiResponses` 래퍼 제거하고
  `@ApiResponse` 개별 선언으로 정리

  ## Decisions & Trade-offs

  - `@Validated`(Spring) 대신 `@Valid`(Jakarta)만 사용: 현재 메서드 레벨 제약조건(`@PathVariable`에
   `@Min` 등)을 쓰지 않으므로 `@Validated`가 불필요. `@Valid`만으로 `@RequestBody` DTO 검증이
  충분함

  - `@Valid`를 인터페이스(ApiSpec)에 선언: Controller 구현체가 아닌 인터페이스에 validation
  어노테이션을 두어 스펙과 구현의 일관성 확보

  - `@ApiResponses` → `@ApiResponse` 개별 선언: Swagger 3.x에서 반복 어노테이션을 직접 지원하므로
  래퍼가 불필요

  ## Future Improvements

  - 다른 Controller에도 `@Validated` + `@Valid` 중복이 있는지 점검 필요
  - 전역 예외 핸들러에서 `HV000151` 같은 Validator 내부 에러를 적절히 처리하는 방어 로직 검토
