### PR TITLE
FriendResponse에 friendshipId 필드 추가

### DIFF
--- a/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/dto/FriendRequestResponse.java
+++ b/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/dto/FriendRequestResponse.java
@@ -11,7 +11,7 @@ public record FriendRequestResponse(
     public static FriendRequestResponse from(FriendRequestInfo info) {
         return new FriendRequestResponse(
                 info.friendshipId(),
-                new FriendResponse(info.requesterId(), info.requesterNickname(), null),
+                new FriendResponse(null, info.requesterId(), info.requesterNickname(), null),
                 info.createdAt()
         );
     }

--- a/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/dto/FriendResponse.java
+++ b/bc/member/src/main/java/app/giftify/friendship/adapter/in/web/dto/FriendResponse.java
@@ -3,12 +3,14 @@ package app.giftify.friendship.adapter.in.web.dto;
 import app.giftify.friendship.application.port.in.FriendInfo;
 
 public record FriendResponse(
+        Long friendshipId,
         Long id,
         String nickname,
         String avatarUrl
 ) {
     public static FriendResponse from(FriendInfo info) {
         return new FriendResponse(
+                info.friendshipId(),
                 info.memberId(),
                 info.nickname(),
                 null

--- a/bc/member/src/main/java/app/giftify/friendship/application/port/in/FriendInfo.java
+++ b/bc/member/src/main/java/app/giftify/friendship/application/port/in/FriendInfo.java
@@ -1,6 +1,7 @@
 package app.giftify.friendship.application.port.in;
 
 public record FriendInfo(
+        Long friendshipId,
         Long memberId,
         String nickname
 ) {

--- a/bc/member/src/main/java/app/giftify/friendship/application/service/FriendshipService.java
+++ b/bc/member/src/main/java/app/giftify/friendship/application/service/FriendshipService.java
@@ -97,6 +97,10 @@ public class FriendshipService implements
     public List<FriendInfo> getFriends(Long memberId) {
         List<Friendship> friendships = friendshipRepository.findAllByMemberIdAndStatus(
                 memberId, FriendshipStatus.ACCEPTED);
+        Map<Long, Long> friendIdToFriendshipId = friendships.stream()
+                .collect(Collectors.toMap(
+                        f -> f.getFriendId(memberId),
+                        Friendship::getId));
         List<Long> friendIds = friendships.stream()
                 .map(f -> f.getFriendId(memberId))
                 .toList();
@@ -107,7 +111,7 @@ public class FriendshipService implements
                 .filter(memberMap::containsKey)
                 .map(id -> {
                     Member m = memberMap.get(id);
-                    return new FriendInfo(m.getId(), m.getNickname());
+                    return new FriendInfo(friendIdToFriendshipId.get(id), m.getId(), m.getNickname());
                 })
                 .toList();
     }

--- a/bc/member/src/test/java/app/giftify/friendship/adapter/in/web/FriendshipV2ControllerTest.java
+++ b/bc/member/src/test/java/app/giftify/friendship/adapter/in/web/FriendshipV2ControllerTest.java
@@ -231,16 +231,17 @@ class FriendshipV2ControllerTest {
 	class GetFriends {
 
 		@Test
-		@DisplayName("내 친구 목록 조회 성공 시 200 OK 반환")
-		void success_Returns200() throws Exception {
+		@DisplayName("내 친구 목록 조회 성공 시 200 OK + friendshipId 포함")
+		void success_Returns200WithFriendshipId() throws Exception {
 			// given
 			given(getFriendListUseCase.getFriends(MEMBER_ID))
-				.willReturn(List.of(new FriendInfo(RECEIVER_ID, "친구")));
+				.willReturn(List.of(new FriendInfo(FRIENDSHIP_ID, RECEIVER_ID, "친구")));
 
 			// when & then
 			mockMvc.perform(get("/api/v2/friends"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.result").value("SUCCESS"))
+				.andExpect(jsonPath("$.data[0].friendshipId").value(FRIENDSHIP_ID))
 				.andExpect(jsonPath("$.data[0].id").value(RECEIVER_ID))
 				.andExpect(jsonPath("$.data[0].nickname").value("친구"));
 		}

--- a/bc/member/src/test/java/app/giftify/friendship/application/service/FriendshipServiceTest.java
+++ b/bc/member/src/test/java/app/giftify/friendship/application/service/FriendshipServiceTest.java
@@ -127,6 +127,7 @@ class FriendshipServiceTest {
         List<FriendInfo> result = service.getFriends(1L);
 
         assertThat(result).hasSize(1);
+        assertThat(result.get(0).friendshipId()).isEqualTo(10L);
         assertThat(result.get(0).memberId()).isEqualTo(2L);
         assertThat(result.get(0).nickname()).isEqualTo("test");
     }


### PR DESCRIPTION
## Summary

친구 목록 조회 시 응답 객체에 friendshipId가 없어 친구 삭제 API 호출이 불가능한 문제를 해결하기 위해  FriendInfo → FriendResponse 변환 체인에 friendshipId 전달을 추가합니다.


---

## What's Changed

 - FriendInfo record에 friendshipId 필드 추가
  - FriendshipService.getFriends()에서 Friendship → friendId 매핑 시 friendshipId도 함께 전달
  - FriendResponse record에 friendshipId 필드 추가 + from() 팩토리 반영
  - FriendRequestResponse.from()에서 FriendResponse 생성자 변경에 맞춰 null 전달 (요청자 정보에는 friendshipId 불필요)
  - 컨트롤러 테스트에 friendshipId 검증 추가, 서비스 테스트에 friendshipId assertion 추가

```
  FriendshipService.getFriends()
    └─ Friendship.getId() ──┐
                             ▼
    FriendInfo(friendshipId, memberId, nickname)
         │
         ▼
    FriendResponse(friendshipId, id, nickname, avatarUrl)
         │
         ▼
    프론트엔드: DELETE /api/v2/friends/{friendshipId}
```

---

## Decisions & Trade-offs

 - FriendResponse에 friendshipId를 nullable(Long)로 두었는데, 이는 FriendRequestResponse 내부의 requester 정보 생성 시 friendshipId가
   불필요하여 null을 전달하기 위함
  - friendIdToFriendshipId Map을 별도로 구성하여 O(1) 조회. 친구 수가 많지 않으므로 메모리 부담 없음
---

## Future Improvements

  - avatarUrl이 현재 항상 null 반환 — 프로필 이미지 기능 구현 시 연동 필요
  - FriendRequestResponse 내부의 FriendResponse에 friendshipId를 null로 넘기는 패턴이 다소 어색함. 향후 RequesterInfo 같은 별도 DTO 분리 고려

---

### Linked Issues

- closes #
