### PR TITLE
FundingController close/expire 엔드포인트에 @PreAuthorize ADMIN 추가

### DIFF
--- a/bc/core/src/main/java/app/giftify/funding/adpater/inbound/web/FundingController.java
+++ b/bc/core/src/main/java/app/giftify/funding/adpater/inbound/web/FundingController.java
@@ -9,6 +9,7 @@ import app.giftify.shared.api.response.RsData;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -37,20 +38,18 @@ public class FundingController implements FundingV2ApiSpec {
         return ResponseEntity.ok(RsData.success(fundings));
     }
 
-    // 펀딩 종료 처리
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}/close")
     public ResponseEntity<RsData<FundingCompleteResponseDto>> closeFunding(@PathVariable("id") Long id) {
-        // TODO: 관리자 권한 체크 필요
         FundingCompleteResponseDto funding = fundingFacade.closeFunding(id);
         return ResponseEntity.ok(RsData.success(funding));
     }
 
-    // 펀딩 만료 처리
     @Override
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}/expire")
     public ResponseEntity<RsData<FundingCompleteResponseDto>> expireFunding(@PathVariable("id") Long id) {
-        // TODO: 관리자 권한 체크 필요
         FundingCompleteResponseDto funding = fundingFacade.expireFunding(id);
         return ResponseEntity.ok(RsData.success(funding));
     }

--- a/bc/core/src/test/java/app/giftify/funding/adpater/inbound/web/FundingControllerTest.java
+++ b/bc/core/src/test/java/app/giftify/funding/adpater/inbound/web/FundingControllerTest.java
@@ -1,0 +1,115 @@
+package app.giftify.funding.adpater.inbound.web;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import app.giftify.funding.adpater.inbound.dto.FundingCompleteResponseDto;
+import app.giftify.funding.application.FundingFacade;
+import app.giftify.funding.domain.FundingStatus;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FundingController 테스트")
+class FundingControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Mock
+	private FundingFacade fundingFacade;
+
+	private static final Long FUNDING_ID = 1L;
+
+	@BeforeEach
+	void setUp() {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		FundingController controller = new FundingController(fundingFacade);
+
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(controller)
+			.setMessageConverters(new MappingJackson2HttpMessageConverter(mapper))
+			.build();
+	}
+
+	private FundingCompleteResponseDto dummyCompleteResponse(FundingStatus status) {
+		return new FundingCompleteResponseDto(FUNDING_ID, 10L, status, LocalDateTime.of(2025, 6, 1, 12, 0));
+	}
+
+	@Nested
+	@DisplayName("PUT /api/v2/fundings/{id}/close")
+	class CloseFunding {
+
+		@Test
+		@DisplayName("closeFunding 메서드에 @PreAuthorize ADMIN 어노테이션이 존재한다")
+		void hasPreAuthorizeAdmin() throws NoSuchMethodException {
+			Method method = FundingController.class.getDeclaredMethod("closeFunding", Long.class);
+			PreAuthorize annotation = method.getAnnotation(PreAuthorize.class);
+
+			assertThat(annotation).isNotNull();
+			assertThat(annotation.value()).contains("ADMIN");
+		}
+
+		@Test
+		@DisplayName("펀딩 종료 성공 시 200 OK 반환")
+		void success_Returns200() throws Exception {
+			given(fundingFacade.closeFunding(FUNDING_ID))
+				.willReturn(dummyCompleteResponse(FundingStatus.CLOSED));
+
+			mockMvc.perform(put("/api/v2/fundings/{id}/close", FUNDING_ID))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.result").value("SUCCESS"))
+				.andExpect(jsonPath("$.data.fundingId").value(FUNDING_ID))
+				.andExpect(jsonPath("$.data.status").value("CLOSED"));
+		}
+	}
+
+	@Nested
+	@DisplayName("PUT /api/v2/fundings/{id}/expire")
+	class ExpireFunding {
+
+		@Test
+		@DisplayName("expireFunding 메서드에 @PreAuthorize ADMIN 어노테이션이 존재한다")
+		void hasPreAuthorizeAdmin() throws NoSuchMethodException {
+			Method method = FundingController.class.getDeclaredMethod("expireFunding", Long.class);
+			PreAuthorize annotation = method.getAnnotation(PreAuthorize.class);
+
+			assertThat(annotation).isNotNull();
+			assertThat(annotation.value()).contains("ADMIN");
+		}
+
+		@Test
+		@DisplayName("펀딩 만료 처리 성공 시 200 OK 반환")
+		void success_Returns200() throws Exception {
+			given(fundingFacade.expireFunding(FUNDING_ID))
+				.willReturn(dummyCompleteResponse(FundingStatus.EXPIRED));
+
+			mockMvc.perform(put("/api/v2/fundings/{id}/expire", FUNDING_ID))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.result").value("SUCCESS"))
+				.andExpect(jsonPath("$.data.fundingId").value(FUNDING_ID))
+				.andExpect(jsonPath("$.data.status").value("EXPIRED"));
+		}
+	}
+}


### PR DESCRIPTION
## Summary

  펀딩 close/expire API에 관리자 권한 체크가 없어 인증된 사용자 누구나 호출 가능한 문제를 수정합니다.
  두 엔드포인트 모두 스케줄러/관리자가 호출하는 시스템 API이므로 `@PreAuthorize("hasRole('ADMIN')")` 을 추가합니다.

  ## What's Changed

  - `PUT /api/v2/fundings/{id}/close` — `@PreAuthorize("hasRole('ADMIN')")` 추가, TODO 주석 제거
  - `PUT /api/v2/fundings/{id}/expire` — `@PreAuthorize("hasRole('ADMIN')")` 추가, TODO 주석 제거
  - `FundingControllerTest` 신규 — 리플렉션 기반 어노테이션 검증 + 정상 응답 테스트

  ## Decisions & Trade-offs

  - close는 "달성 후 2주간 미수락/미거절 시 자동 종료", expire는 "기한 만료 시 자동 종료"로
    둘 다 스케줄러/관리자가 호출하는 동작이므로 ADMIN only가 적절
  - 펀딩을 연 사람이 직접 종료하는 기능은 현재 미지원이며, 별도 이슈로 추가 예정

  ## Future Improvements

  - 펀딩 소유자(receiverId)가 직접 펀딩을 종료할 수 있는 엔드포인트 추가 검토
  - 스케줄러에서 호출하는 close/expire를 Internal API로 분리하여 외부 노출 최소화
