### PR TITLE
 장바구니 응답에 receiverId 추가

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/cart/adapter/inbound/CartItemResponse.java
+++ b/bc/catalog/src/main/java/app/giftify/cart/adapter/inbound/CartItemResponse.java
@@ -9,13 +9,14 @@ import app.giftify.shared.domain.type.TargetType;
 public record CartItemResponse(
         TargetType targetType,
         Long targetId,
+        Long receiverId,
         String productName,
         long productPrice,
         long contributionAmount,
         ItemStatus status,
         String statusMessage
 ) {
-    public static CartItemResponse from(CartItem item, boolean isFundingEnded, Product product) {
+    public static CartItemResponse from(CartItem item, boolean isFundingEnded, Product product, Long receiverId) {
         if (isFundingEnded) {
             return unavailable(item, ItemStatus.FUNDING_ENDED, "진행 중인 펀딩이 아닙니다.");
         }
@@ -32,6 +33,7 @@ public record CartItemResponse(
         return new CartItemResponse(
                 item.getTargetType(),
                 item.getTargetId(),
+                receiverId,
                 product.getName(),
                 (long) product.getPrice(),
                 item.getAmount().amount().longValue(),
@@ -44,6 +46,7 @@ public record CartItemResponse(
         return new CartItemResponse(
                 item.getTargetType(),
                 item.getTargetId(),
+                null,
                 null,
                 0,
                 item.getAmount().amount().longValue(),

--- a/bc/catalog/src/main/java/app/giftify/cart/application/inbound/CartService.java
+++ b/bc/catalog/src/main/java/app/giftify/cart/application/inbound/CartService.java
@@ -25,6 +25,8 @@ import app.giftify.product.domain.Product;
 import app.giftify.product.domain.ProductStatus;
 import app.giftify.shared.domain.type.TargetType;
 import app.giftify.wishlist.application.port.out.WishlistItemRepositoryPort;
+import app.giftify.wishlist.application.port.out.WishlistRepositoryPort;
+import app.giftify.wishlist.core.domain.Wishlist;
 import app.giftify.wishlist.core.domain.WishlistItem;
 import app.giftify.wishlist.core.domain.WishlistItemStatus;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class CartService
 	private final CartRepositoryPort cartRepositoryPort;
 	private final ProductRepositoryPort productRepositoryPort;
 	private final WishlistItemRepositoryPort wishlistItemRepositoryPort;
+	private final WishlistRepositoryPort wishlistRepositoryPort;
 
 	@Override
 	public Cart createCart(Long memberId) {
@@ -171,12 +174,28 @@ public class CartService
 			}
 		}
 
-		// 6. 서비스에서 CartItemResponse를 직접 조립합니다.
+		// 6. Wishlist 조회 → receiverId(선물 받는 사람) 매핑
+		List<Long> wishlistIds = wishlistItemMap.values().stream()
+				.map(WishlistItem::getWishlistId)
+				.distinct()
+				.toList();
+		Map<Long, Wishlist> wishlistMap = wishlistRepositoryPort.findAllById(wishlistIds).stream()
+				.collect(Collectors.toMap(Wishlist::getId, Function.identity()));
+		Map<Long, Long> receiverIdMap = new HashMap<>();
+		for (Map.Entry<Long, WishlistItem> entry : wishlistItemMap.entrySet()) {
+			Wishlist wishlist = wishlistMap.get(entry.getValue().getWishlistId());
+			if (wishlist != null) {
+				receiverIdMap.put(entry.getKey(), wishlist.getMemberId());
+			}
+		}
+
+		// 7. 서비스에서 CartItemResponse를 직접 조립합니다.
 		List<CartItemResponse> itemResponses = cart.getItems().stream()
 				.map(item -> CartItemResponse.from(
 						item,
 						fundingEndedIds.contains(item.getTargetId()),
-						finalProductMap.get(item.getTargetId())
+						finalProductMap.get(item.getTargetId()),
+						receiverIdMap.get(item.getTargetId())
 				))
 				.toList();
 

--- a/bc/catalog/src/test/java/app/giftify/cart/application/inbound/CartServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/cart/application/inbound/CartServiceTest.java
@@ -28,6 +28,8 @@ import app.giftify.product.domain.ProductStatus;
 import app.giftify.shared.domain.type.TargetType;
 import app.giftify.shared.domain.vo.Money;
 import app.giftify.wishlist.application.port.out.WishlistItemRepositoryPort;
+import app.giftify.wishlist.application.port.out.WishlistRepositoryPort;
+import app.giftify.wishlist.core.domain.Wishlist;
 import app.giftify.wishlist.core.domain.WishlistItem;
 import app.giftify.wishlist.core.domain.WishlistItemStatus;
 
@@ -45,6 +47,9 @@ class CartServiceTest {
 
     @Mock
     private WishlistItemRepositoryPort wishlistItemRepositoryPort;
+
+    @Mock
+    private WishlistRepositoryPort wishlistRepositoryPort;
 
     private final Long memberId = 1L;
     private final Long cartId = 1L;
@@ -223,6 +228,50 @@ class CartServiceTest {
         assertThat(response).isNotNull();
         assertThat(response.memberId()).isEqualTo(memberId);
         assertThat(response.items()).isEmpty(); // 아이템이 없으므로 비어있어야 함
+    }
+
+    @Test
+    @DisplayName("장바구니 조회 시 아이템에 receiverId 포함")
+    void getMyCart_ContainsReceiverId() {
+        // given
+        Long wishlistItemId = 100L;
+        Long wishlistId = 10L;
+        Long receiverId = 99L;
+        Long productId = 200L;
+
+        Cart cart = Cart.create(memberId);
+        cart.addItem(TargetType.FUNDING_PENDING, wishlistItemId, Money.of(10000));
+        given(cartRepository.findByMemberId(memberId)).willReturn(Optional.of(cart));
+
+        WishlistItem wishlistItem = mock(WishlistItem.class);
+        given(wishlistItem.getId()).willReturn(wishlistItemId);
+        given(wishlistItem.getWishlistId()).willReturn(wishlistId);
+        given(wishlistItem.getProductId()).willReturn(productId);
+        given(wishlistItem.getWishlistItemStatus()).willReturn(WishlistItemStatus.PENDING);
+        given(wishlistItemRepositoryPort.findAllById(List.of(wishlistItemId)))
+                .willReturn(List.of(wishlistItem));
+
+        Wishlist wishlist = mock(Wishlist.class);
+        given(wishlist.getId()).willReturn(wishlistId);
+        given(wishlist.getMemberId()).willReturn(receiverId);
+        given(wishlistRepositoryPort.findAllById(List.of(wishlistId)))
+                .willReturn(List.of(wishlist));
+
+        Product product = mock(Product.class);
+        given(product.getId()).willReturn(productId);
+        given(product.getName()).willReturn("테스트상품");
+        given(product.getPrice()).willReturn(50000);
+        given(product.getStatus()).willReturn(ProductStatus.ACTIVE);
+        given(product.getStock()).willReturn(10);
+        given(productRepositoryPort.findAllById(List.of(productId)))
+                .willReturn(List.of(product));
+
+        // when
+        CartResponse response = cartService.getMyCart(memberId);
+
+        // then
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).receiverId()).isEqualTo(receiverId);
     }
 
     @Test


### PR DESCRIPTION

## Summary
CartItemResponse에 receiverId 필드를 추가하여 프론트엔드에 장바구니에 주문 시 수령인 정보를 전달할 수 있도록 개선.

---

## What's Changed
 장바구니 조회 API 응답(CartItemResponse)에 receiverId 필드를 추가했습니다. 기존에는 장바구니 아이템에 수령인(선물 받는 사람) 정보가 없어서 프론트엔드 체크아웃 시 receiverId를 하드코딩해야 했습니다.

  - CartItemResponse: Long receiverId 필드 추가, from() 시그니처에 receiverId 파라미터 추가
  - CartService: WishlistRepositoryPort 주입, getCartResponse()에서 Wishlist 조회 후 receiverIdMap 구성
  - CartServiceTest: receiverId 포함 여부 검증 테스트 추가


---

## Decisions & Trade-offs

### receiverId 조회 방식: Wishlist 체인 vs 별도 컬럼

  receiverId를 CartItem이나 WishlistItem에 직접 저장하는 방안도 있었으나, Wishlist의 소유자(memberId)가 곧 수령인이므로 기존 도메인 모델의 관계를 활용했습니다. 추가 컬럼 없이 조회 체인(WishlistItem → Wishlist)으로 해결하여 데이터 정합성을 유지했습니다.

### unavailable 아이템의 receiverId
  펀딩 종료/품절 등 unavailable 상태의 아이템은 receiverId를 null로 반환합니다. 주문 불가 아이템이므로 수령인 정보가 불필요하다고
  판단했습니다.

---

## Future Improvements

  - 장바구니 조회 시 N+1 가능성: 현재 wishlistItem, product, wishlist를 각각 batch 조회하고 있으나, 아이템 수가 많아지면 조회
  최적화(JOIN fetch 등) 검토 필요
  - receiverId를 활용한 프론트엔드 체크아웃 하드코딩 제거 작업 연계 필요


---

### Linked Issues

- closes #
