### PR TITLE
elasticsearch 이미지 태그를 amd64 빌드 버전으로 변경

### DIFF
--- a/infra/k3s/overlays/prod/kustomization.yaml
+++ b/infra/k3s/overlays/prod/kustomization.yaml
@@ -9,7 +9,7 @@ images:
     newTag: latest
   - name: giftify-elasticsearch
     newName: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/elasticsearch
-    newTag: 9.2.4-custom
+    newTag: 9.2.4-custom-v2
 
 patches:
   - target:


### PR DESCRIPTION
 ## Summary

  elasticsearch 이미지 아키텍처 불일치(arm64→amd64) 해결을 위해 이미지 태그 변경

  ## What's Changed

  - prod overlay elasticsearch 이미지 태그: `9.2.4-custom` → `9.2.4-custom-v2`
  - EC2(amd64) 노드에 캐시된 arm64 이미지를 새 태그로 강제 교체
