### PR TITLE
로그아웃 API에 토큰 블랙리스트 기능 추가

### DIFF
--- a/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/AuthController.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/AuthController.java
@@ -2,59 +2,52 @@ package app.giftify.auth.adapter.inbound.web;
 
 import app.giftify.auth.adapter.inbound.web.dto.LoginRequest;
 import app.giftify.auth.adapter.inbound.web.dto.LoginResponse;
-import app.giftify.auth.application.TokenBlacklistService;
+import app.giftify.auth.adapter.inbound.web.dto.LogoutRequest;
 import app.giftify.auth.application.inbound.LoginUseCase;
+import app.giftify.auth.application.inbound.LogoutUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.Duration;
-import java.time.Instant;
 
 @RestController
 @RequestMapping("/api/v2/auth")
 @RequiredArgsConstructor
 public class AuthController implements AuthV2ApiSpec {
 
-    private final LoginUseCase loginUseCase;
-    private final TokenBlacklistService tokenBlacklistService;
-    private final JwtDecoder jwtDecoder;
+	private final LoginUseCase loginUseCase;
+	private final LogoutUseCase logoutUseCase;
 
-    @Override
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(
-            @RequestBody @Valid LoginRequest request
-    ) {
-        LoginUseCase.LoginResult result = loginUseCase.login(new LoginUseCase.LoginCommand(request.idToken()));
+	@Override
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(
+		@RequestBody @Valid LoginRequest request
+	) {
+		LoginUseCase.LoginResult result = loginUseCase.login(new LoginUseCase.LoginCommand(request.idToken()));
 
-        LoginResponse response;
-        if (result.isNewUser()) {
-            response = LoginResponse.newUser(
-                    result.authSub(),
-                    result.email(),
-                    result.nickname()
-            );
-        } else {
-            response = LoginResponse.existingMember(result.member().orElseThrow());
-        }
+		LoginResponse response;
+		if (result.isNewUser()) {
+			response = LoginResponse.newUser(
+				result.authSub(),
+				result.email(),
+				result.nickname()
+			);
+		} else {
+			response = LoginResponse.existingMember(result.member().orElseThrow());
+		}
 
-        return ResponseEntity.ok(response);
-    }
+		return ResponseEntity.ok(response);
+	}
 
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
-        String token = authorization.replace("Bearer ", "");
-        Jwt jwt = jwtDecoder.decode(token);
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(
+		@RequestHeader("Authorization") String authorization,
+		@RequestBody(required = false) LogoutRequest request
+	) {
+		String token = authorization.replace("Bearer ", "");
+		String refreshToken = (request != null) ? request.refreshToken() : null;
 
-        Duration ttl = Duration.between(Instant.now(), jwt.getExpiresAt());
-        if (ttl.isNegative()) {
-            ttl = Duration.ZERO;
-        }
-
-        tokenBlacklistService.revokeToken(jwt.getId(), ttl, "logout");
-        return ResponseEntity.noContent().build();
-    }
+		logoutUseCase.logout(new LogoutUseCase.LogoutCommand(token, refreshToken));
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/AuthController.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/AuthController.java
@@ -2,14 +2,17 @@ package app.giftify.auth.adapter.inbound.web;
 
 import app.giftify.auth.adapter.inbound.web.dto.LoginRequest;
 import app.giftify.auth.adapter.inbound.web.dto.LoginResponse;
+import app.giftify.auth.application.TokenBlacklistService;
 import app.giftify.auth.application.inbound.LoginUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Duration;
+import java.time.Instant;
 
 @RestController
 @RequestMapping("/api/v2/auth")
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController implements AuthV2ApiSpec {
 
     private final LoginUseCase loginUseCase;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final JwtDecoder jwtDecoder;
 
     @Override
     @PostMapping("/login")
@@ -37,5 +42,19 @@ public class AuthController implements AuthV2ApiSpec {
         }
 
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
+        String token = authorization.replace("Bearer ", "");
+        Jwt jwt = jwtDecoder.decode(token);
+
+        Duration ttl = Duration.between(Instant.now(), jwt.getExpiresAt());
+        if (ttl.isNegative()) {
+            ttl = Duration.ZERO;
+        }
+
+        tokenBlacklistService.revokeToken(jwt.getId(), ttl, "logout");
+        return ResponseEntity.noContent().build();
     }
 }

--- a/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/dto/LogoutRequest.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/inbound/web/dto/LogoutRequest.java
@@ -1,0 +1,5 @@
+package app.giftify.auth.adapter.inbound.web.dto;
+
+public record LogoutRequest(
+	String refreshToken
+) {}

--- a/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/ApiClientConfig.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/ApiClientConfig.java
@@ -31,12 +31,25 @@ public class ApiClientConfig {
     public WalletApiClient walletInternalApi(
             RestClient.Builder builder,
             @Value("${app.service.wallet.url:http://localhost:8080}") String baseUrl) {
-        
+
         RestClient restClient = builder.baseUrl(baseUrl).build();
 
         return HttpServiceProxyFactory
                 .builderFor(RestClientAdapter.create(restClient))
                 .build()
                 .createClient(WalletApiClient.class);
+    }
+
+    @Bean
+    public Auth0ApiClient auth0Api(
+            RestClient.Builder builder,
+            @Value("${spring.security.oauth2.client.provider.auth0.issuer-uri}") String issuerUri) {
+
+        RestClient restClient = builder.baseUrl(issuerUri).build();
+
+        return HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build()
+                .createClient(Auth0ApiClient.class);
     }
 }

--- a/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/Auth0ApiClient.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/Auth0ApiClient.java
@@ -1,0 +1,12 @@
+package app.giftify.auth.adapter.outbound.client;
+
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.PostExchange;
+
+public interface Auth0ApiClient {
+
+	@PostExchange(url = "/oauth/revoke", contentType = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+	void revokeToken(@RequestBody MultiValueMap<String, String> params);
+}

--- a/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/Auth0RevokeClient.java
+++ b/bc/member/src/main/java/app/giftify/auth/adapter/outbound/client/Auth0RevokeClient.java
@@ -1,0 +1,37 @@
+package app.giftify.auth.adapter.outbound.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class Auth0RevokeClient {
+
+	private final Auth0ApiClient auth0ApiClient;
+	private final String clientId;
+	private final String clientSecret;
+
+	public Auth0RevokeClient(
+		Auth0ApiClient auth0ApiClient,
+		@Value("${spring.security.oauth2.client.registration.auth0.client-id}") String clientId,
+		@Value("${spring.security.oauth2.client.registration.auth0.client-secret}") String clientSecret
+	) {
+		this.auth0ApiClient = auth0ApiClient;
+		this.clientId = clientId;
+		this.clientSecret = clientSecret;
+	}
+
+	public void revokeRefreshToken(String refreshToken) {
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("client_id", clientId);
+		body.add("client_secret", clientSecret);
+		body.add("token", refreshToken);
+
+		auth0ApiClient.revokeToken(body);
+		log.info("[Auth0] Refresh token revoked successfully");
+	}
+}

--- a/bc/member/src/main/java/app/giftify/auth/application/LogoutService.java
+++ b/bc/member/src/main/java/app/giftify/auth/application/LogoutService.java
@@ -1,0 +1,43 @@
+package app.giftify.auth.application;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Service;
+
+import app.giftify.auth.adapter.outbound.client.Auth0RevokeClient;
+import app.giftify.auth.application.inbound.LogoutUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LogoutService implements LogoutUseCase {
+
+	private final JwtDecoder jwtDecoder;
+	private final TokenBlacklistService tokenBlacklistService;
+	private final Auth0RevokeClient auth0RevokeClient;
+
+	@Override
+	public void logout(LogoutCommand command) {
+		Jwt jwt = jwtDecoder.decode(command.accessToken());
+
+		Duration ttl = Duration.between(Instant.now(), jwt.getExpiresAt());
+		if (ttl.isNegative()) {
+			ttl = Duration.ZERO;
+		}
+
+		tokenBlacklistService.revokeToken(jwt.getId(), ttl, "logout");
+
+		if (command.refreshToken() != null) {
+			try {
+				auth0RevokeClient.revokeRefreshToken(command.refreshToken());
+			} catch (Exception e) {
+				log.warn("[Logout] Auth0 refresh token revoke failed, continuing. reason={}", e.getMessage());
+			}
+		}
+	}
+}

--- a/bc/member/src/main/java/app/giftify/auth/application/inbound/LogoutUseCase.java
+++ b/bc/member/src/main/java/app/giftify/auth/application/inbound/LogoutUseCase.java
@@ -1,0 +1,11 @@
+package app.giftify.auth.application.inbound;
+
+public interface LogoutUseCase {
+
+	void logout(LogoutCommand command);
+
+	record LogoutCommand(
+		String accessToken,
+		String refreshToken
+	) {}
+}

--- a/bc/member/src/test/java/app/giftify/auth/adapter/inbound/web/AuthControllerTest.java
+++ b/bc/member/src/test/java/app/giftify/auth/adapter/inbound/web/AuthControllerTest.java
@@ -1,136 +1,151 @@
 package app.giftify.auth.adapter.inbound.web;
 
-import app.giftify.auth.application.TokenBlacklistService;
-import app.giftify.auth.application.inbound.LoginUseCase;
-import app.giftify.shared.domain.type.MemberRole;
-import app.giftify.shared.domain.vo.MemberInfo;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.time.Duration;
-import java.time.Instant;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import app.giftify.auth.application.inbound.LoginUseCase;
+import app.giftify.auth.application.inbound.LogoutUseCase;
+import app.giftify.shared.domain.type.MemberRole;
+import app.giftify.shared.domain.vo.MemberInfo;
 
 @DisplayName("AuthController 테스트")
 class AuthControllerTest {
 
-    private MockMvc mockMvc;
-    private LoginUseCase loginUseCase;
-    private TokenBlacklistService tokenBlacklistService;
-    private JwtDecoder jwtDecoder;
+	private MockMvc mockMvc;
+	private LoginUseCase loginUseCase;
+	private LogoutUseCase logoutUseCase;
 
-    @BeforeEach
-    void setUp() {
-        loginUseCase = org.mockito.Mockito.mock(LoginUseCase.class);
-        tokenBlacklistService = org.mockito.Mockito.mock(TokenBlacklistService.class);
-        jwtDecoder = org.mockito.Mockito.mock(JwtDecoder.class);
+	@BeforeEach
+	void setUp() {
+		loginUseCase = org.mockito.Mockito.mock(LoginUseCase.class);
+		logoutUseCase = org.mockito.Mockito.mock(LogoutUseCase.class);
 
-        mockMvc = MockMvcBuilders
-                .standaloneSetup(new AuthController(loginUseCase, tokenBlacklistService, jwtDecoder))
-                .build();
-    }
+		mockMvc = MockMvcBuilders
+			.standaloneSetup(new AuthController(loginUseCase, logoutUseCase))
+			.build();
+	}
 
-    @Nested
-    @DisplayName("POST /api/v2/auth/login")
-    class LoginTests {
+	@Nested
+	@DisplayName("POST /api/v2/auth/login")
+	class LoginTests {
 
-        @Test
-        @DisplayName("신규 사용자 로그인 성공")
-        void login_NewUser_Success() throws Exception {
-            // given
-            String idToken = "valid.id.token";
-            String authSub = "auth0|newuser";
-            String email = "new@example.com";
-            String nickname = "신규유저";
+		@Test
+		@DisplayName("신규 사용자 로그인 성공")
+		void login_NewUser_Success() throws Exception {
+			// given
+			String idToken = "valid.id.token";
+			String authSub = "auth0|newuser";
+			String email = "new@example.com";
+			String nickname = "신규유저";
 
-            LoginUseCase.LoginResult result = LoginUseCase.LoginResult.newUser(authSub, email, nickname);
-            given(loginUseCase.login(any(LoginUseCase.LoginCommand.class))).willReturn(result);
+			LoginUseCase.LoginResult result = LoginUseCase.LoginResult.newUser(authSub, email, nickname);
+			given(loginUseCase.login(any(LoginUseCase.LoginCommand.class))).willReturn(result);
 
-            // when & then
-            mockMvc.perform(post("/api/v2/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"idToken\":\"" + idToken + "\"}"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.isNewUser").value(true))
-                    .andExpect(jsonPath("$.authSub").value(authSub))
-                    .andExpect(jsonPath("$.email").value(email));
-        }
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"idToken\":\"" + idToken + "\"}"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isNewUser").value(true))
+				.andExpect(jsonPath("$.authSub").value(authSub))
+				.andExpect(jsonPath("$.email").value(email));
+		}
 
-        @Test
-        @DisplayName("기존 회원 로그인 성공")
-        void login_ExistingMember_Success() throws Exception {
-            // given
-            String idToken = "valid.id.token";
-            String authSub = "auth0|existing";
-            Long memberId = 1L;
+		@Test
+		@DisplayName("기존 회원 로그인 성공")
+		void login_ExistingMember_Success() throws Exception {
+			// given
+			String idToken = "valid.id.token";
+			String authSub = "auth0|existing";
+			Long memberId = 1L;
 
-            MemberInfo memberInfo = MemberInfo.of(memberId, authSub, MemberRole.BUYER, "existing@example.com", "기존회원");
-            LoginUseCase.LoginResult result = LoginUseCase.LoginResult.existingMember(memberInfo);
-            given(loginUseCase.login(any(LoginUseCase.LoginCommand.class))).willReturn(result);
+			MemberInfo memberInfo = MemberInfo.of(memberId, authSub, MemberRole.BUYER, "existing@example.com", "기존회원");
+			LoginUseCase.LoginResult result = LoginUseCase.LoginResult.existingMember(memberInfo);
+			given(loginUseCase.login(any(LoginUseCase.LoginCommand.class))).willReturn(result);
 
-            // when & then
-            mockMvc.perform(post("/api/v2/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{\"idToken\":\"" + idToken + "\"}"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.isNewUser").value(false))
-                    .andExpect(jsonPath("$.member.memberId").value(memberId))
-                    .andExpect(jsonPath("$.authSub").value(authSub));
-        }
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"idToken\":\"" + idToken + "\"}"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.isNewUser").value(false))
+				.andExpect(jsonPath("$.member.memberId").value(memberId))
+				.andExpect(jsonPath("$.authSub").value(authSub));
+		}
 
-        @Test
-        @DisplayName("idToken 누락 시 400 에러")
-        void login_MissingIdToken_BadRequest() throws Exception {
-            // when & then
-            mockMvc.perform(post("/api/v2/auth/login")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content("{}"))
-                    .andExpect(status().isBadRequest());
-        }
-    }
+		@Test
+		@DisplayName("idToken 누락 시 400 에러")
+		void login_MissingIdToken_BadRequest() throws Exception {
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/login")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{}"))
+				.andExpect(status().isBadRequest());
+		}
+	}
 
-    @Nested
-    @DisplayName("POST /api/v2/auth/logout")
-    class LogoutTests {
+	@Nested
+	@DisplayName("POST /api/v2/auth/logout")
+	class LogoutTests {
 
-        @Test
-        @DisplayName("로그아웃 성공 - 토큰 블랙리스트 등록")
-        void logout_Success() throws Exception {
-            // given
-            String token = "valid.jwt.token";
-            String jti = "token-id-123";
-            Instant expiresAt = Instant.now().plusSeconds(3600);
+		@Test
+		@DisplayName("로그아웃 성공 — refreshToken 포함")
+		void logout_WithRefreshToken_DelegatesToUseCase() throws Exception {
+			// given
+			String token = "valid.jwt.token";
+			String refreshToken = "refresh_token_123";
 
-            Jwt jwt = Jwt.withTokenValue(token)
-                    .header("alg", "RS256")
-                    .claim("sub", "auth0|user1")
-                    .jti(jti)
-                    .expiresAt(expiresAt)
-                    .issuedAt(Instant.now())
-                    .build();
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/logout")
+					.header("Authorization", "Bearer " + token)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"refreshToken\":\"" + refreshToken + "\"}"))
+				.andExpect(status().isNoContent());
 
-            given(jwtDecoder.decode(token)).willReturn(jwt);
+			then(logoutUseCase).should().logout(
+				new LogoutUseCase.LogoutCommand(token, refreshToken));
+		}
 
-            // when & then
-            mockMvc.perform(post("/api/v2/auth/logout")
-                            .header("Authorization", "Bearer " + token))
-                    .andExpect(status().isNoContent());
+		@Test
+		@DisplayName("로그아웃 성공 — refreshToken 없이")
+		void logout_WithoutRefreshToken_DelegatesToUseCase() throws Exception {
+			// given
+			String token = "valid.jwt.token";
 
-            verify(tokenBlacklistService).revokeToken(eq(jti), any(Duration.class), eq("logout"));
-        }
-    }
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/logout")
+					.header("Authorization", "Bearer " + token)
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{}"))
+				.andExpect(status().isNoContent());
+
+			then(logoutUseCase).should().logout(
+				new LogoutUseCase.LogoutCommand(token, null));
+		}
+
+		@Test
+		@DisplayName("로그아웃 — body 없이 Authorization 헤더만으로도 성공")
+		void logout_NoBody_DelegatesToUseCase() throws Exception {
+			// given
+			String token = "valid.jwt.token";
+
+			// when & then
+			mockMvc.perform(post("/api/v2/auth/logout")
+					.header("Authorization", "Bearer " + token))
+				.andExpect(status().isNoContent());
+
+			then(logoutUseCase).should().logout(
+				new LogoutUseCase.LogoutCommand(token, null));
+		}
+	}
 }

--- a/bc/member/src/test/java/app/giftify/auth/adapter/inbound/web/AuthControllerTest.java
+++ b/bc/member/src/test/java/app/giftify/auth/adapter/inbound/web/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package app.giftify.auth.adapter.inbound.web;
 
+import app.giftify.auth.application.TokenBlacklistService;
 import app.giftify.auth.application.inbound.LoginUseCase;
 import app.giftify.shared.domain.type.MemberRole;
 import app.giftify.shared.domain.vo.MemberInfo;
@@ -8,11 +9,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.Duration;
+import java.time.Instant;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,13 +30,17 @@ class AuthControllerTest {
 
     private MockMvc mockMvc;
     private LoginUseCase loginUseCase;
+    private TokenBlacklistService tokenBlacklistService;
+    private JwtDecoder jwtDecoder;
 
     @BeforeEach
     void setUp() {
         loginUseCase = org.mockito.Mockito.mock(LoginUseCase.class);
+        tokenBlacklistService = org.mockito.Mockito.mock(TokenBlacklistService.class);
+        jwtDecoder = org.mockito.Mockito.mock(JwtDecoder.class);
 
         mockMvc = MockMvcBuilders
-                .standaloneSetup(new AuthController(loginUseCase))
+                .standaloneSetup(new AuthController(loginUseCase, tokenBlacklistService, jwtDecoder))
                 .build();
     }
 
@@ -88,6 +100,37 @@ class AuthControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("{}"))
                     .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v2/auth/logout")
+    class LogoutTests {
+
+        @Test
+        @DisplayName("로그아웃 성공 - 토큰 블랙리스트 등록")
+        void logout_Success() throws Exception {
+            // given
+            String token = "valid.jwt.token";
+            String jti = "token-id-123";
+            Instant expiresAt = Instant.now().plusSeconds(3600);
+
+            Jwt jwt = Jwt.withTokenValue(token)
+                    .header("alg", "RS256")
+                    .claim("sub", "auth0|user1")
+                    .jti(jti)
+                    .expiresAt(expiresAt)
+                    .issuedAt(Instant.now())
+                    .build();
+
+            given(jwtDecoder.decode(token)).willReturn(jwt);
+
+            // when & then
+            mockMvc.perform(post("/api/v2/auth/logout")
+                            .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isNoContent());
+
+            verify(tokenBlacklistService).revokeToken(eq(jti), any(Duration.class), eq("logout"));
         }
     }
 }

--- a/bc/member/src/test/java/app/giftify/auth/application/LogoutServiceTest.java
+++ b/bc/member/src/test/java/app/giftify/auth/application/LogoutServiceTest.java
@@ -1,0 +1,141 @@
+package app.giftify.auth.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+import app.giftify.auth.adapter.outbound.client.Auth0RevokeClient;
+import app.giftify.auth.application.inbound.LogoutUseCase;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+
+	@Mock
+	private JwtDecoder jwtDecoder;
+
+	@Mock
+	private TokenBlacklistService tokenBlacklistService;
+
+	@Mock
+	private Auth0RevokeClient auth0RevokeClient;
+
+	@InjectMocks
+	private LogoutService logoutService;
+
+	@Test
+	@DisplayName("로그아웃 성공 — 토큰 블랙리스트 등록 + Auth0 리프레시 토큰 무효화")
+	void logout_WithRefreshToken_BlacklistsAndRevokes() {
+		// given
+		String accessToken = "valid.jwt.token";
+		String refreshToken = "refresh_token_123";
+		String jti = "token-id-123";
+
+		Jwt jwt = Jwt.withTokenValue(accessToken)
+			.header("alg", "RS256")
+			.claim("sub", "auth0|user1")
+			.jti(jti)
+			.expiresAt(Instant.now().plusSeconds(3600))
+			.issuedAt(Instant.now())
+			.build();
+
+		given(jwtDecoder.decode(accessToken)).willReturn(jwt);
+
+		// when
+		logoutService.logout(new LogoutUseCase.LogoutCommand(accessToken, refreshToken));
+
+		// then
+		then(tokenBlacklistService).should().revokeToken(eq(jti), any(Duration.class), eq("logout"));
+		then(auth0RevokeClient).should().revokeRefreshToken(refreshToken);
+	}
+
+	@Test
+	@DisplayName("로그아웃 성공 — refreshToken 없으면 블랙리스트만 등록")
+	void logout_WithoutRefreshToken_BlacklistsOnly() {
+		// given
+		String accessToken = "valid.jwt.token";
+		String jti = "token-id-456";
+
+		Jwt jwt = Jwt.withTokenValue(accessToken)
+			.header("alg", "RS256")
+			.claim("sub", "auth0|user2")
+			.jti(jti)
+			.expiresAt(Instant.now().plusSeconds(3600))
+			.issuedAt(Instant.now())
+			.build();
+
+		given(jwtDecoder.decode(accessToken)).willReturn(jwt);
+
+		// when
+		logoutService.logout(new LogoutUseCase.LogoutCommand(accessToken, null));
+
+		// then
+		then(tokenBlacklistService).should().revokeToken(eq(jti), any(Duration.class), eq("logout"));
+		then(auth0RevokeClient).should(never()).revokeRefreshToken(any());
+	}
+
+	@Test
+	@DisplayName("로그아웃 — 만료된 토큰이면 TTL을 Duration.ZERO로 설정")
+	void logout_ExpiredToken_UseZeroTtl() {
+		// given
+		String accessToken = "expired.jwt.token";
+		String jti = "token-id-789";
+
+		Jwt jwt = Jwt.withTokenValue(accessToken)
+			.header("alg", "RS256")
+			.claim("sub", "auth0|user3")
+			.jti(jti)
+			.expiresAt(Instant.now().minusSeconds(60))
+			.issuedAt(Instant.now().minusSeconds(7200))
+			.build();
+
+		given(jwtDecoder.decode(accessToken)).willReturn(jwt);
+
+		// when
+		logoutService.logout(new LogoutUseCase.LogoutCommand(accessToken, null));
+
+		// then
+		ArgumentCaptor<Duration> ttlCaptor = ArgumentCaptor.forClass(Duration.class);
+		then(tokenBlacklistService).should().revokeToken(eq(jti), ttlCaptor.capture(), eq("logout"));
+		assertThat(ttlCaptor.getValue()).isEqualTo(Duration.ZERO);
+	}
+
+	@Test
+	@DisplayName("Auth0 revoke 실패해도 블랙리스트는 등록됨")
+	void logout_Auth0RevokeFails_BlacklistStillApplied() {
+		// given
+		String accessToken = "valid.jwt.token";
+		String refreshToken = "bad_refresh_token";
+		String jti = "token-id-abc";
+
+		Jwt jwt = Jwt.withTokenValue(accessToken)
+			.header("alg", "RS256")
+			.claim("sub", "auth0|user4")
+			.jti(jti)
+			.expiresAt(Instant.now().plusSeconds(3600))
+			.issuedAt(Instant.now())
+			.build();
+
+		given(jwtDecoder.decode(accessToken)).willReturn(jwt);
+		willThrow(new RuntimeException("Auth0 API error"))
+			.given(auth0RevokeClient).revokeRefreshToken(refreshToken);
+
+		// when — should not throw
+		logoutService.logout(new LogoutUseCase.LogoutCommand(accessToken, refreshToken));
+
+		// then
+		then(tokenBlacklistService).should().revokeToken(eq(jti), any(Duration.class), eq("logout"));
+	}
+}


### PR DESCRIPTION
 ## Summary

JWT 기반 인증에서 클라이언트가 명시적으로 로그아웃할 수 있는 API가 없었습니다.
  토큰 블랙리스트 인프라(`TokenBlacklistService`, `TokenBlacklistFilter`)는 이미 구현되어 있었지만, 이를 호출하는 로그아웃 엔드포인트가 빠져 있었습니다.

  `POST /api/v2/auth/logout`을 추가하고, 헥사고날 아키텍처에 맞게
  `LogoutUseCase` 인터페이스를 통해 서비스에 접근하도록 설계했습니다.

  로그아웃 시 두 가지 작업을 수행합니다:

  1. **Access Token 블랙리스트 등록** — `jti` 기반으로 Redis에 등록, TTL은 토큰 남은 만료 시간
  2. **Auth0 Refresh Token 무효화** (선택) — 프론트엔드에서 `refreshToken`을 전달하면 Auth0 `/oauth/revoke` 호출

  ---

  ## What's Changed

  ### 1. `LogoutUseCase` / `LogoutService` — 로그아웃 비즈니스 로직
  - `LogoutUseCase` 인바운드 포트 인터페이스 + `LogoutCommand(accessToken, refreshToken)` record
  - `LogoutService` 구현체:
    - Access Token 디코딩 → `jti`, TTL 계산 → `TokenBlacklistService.revokeToken()`
    - `refreshToken` != null이면 `Auth0RevokeClient.revokeRefreshToken()` (best-effort)
    - Auth0 호출 실패 시 로그만 남기고 정상 리턴 (블랙리스트는 이미 등록된 상태)

  ### 2. `Auth0ApiClient` / `Auth0RevokeClient` — Auth0 Revocation API 연동
  - `Auth0ApiClient`: HttpInterface (`@PostExchange /oauth/revoke`, form-urlencoded)
  - `Auth0RevokeClient`: `@Component` 래퍼 (client_id/client_secret credential 주입)
  - `ApiClientConfig`에 `auth0Api` 빈 추가

  ### 3. `AuthController` — UseCase 패턴으로 리팩토링
  - **Before**: `TokenBlacklistService` + `JwtDecoder` 직접 의존
  - **After**: `LogoutUseCase` 인터페이스만 의존
  - `LogoutRequest` DTO 추가 — `refreshToken` 필드 (nullable, 하위 호환)
  - `@RequestBody(required = false)` — body 없이 Authorization 헤더만으로도 동작

  ### 4. 테스트
  - `LogoutServiceTest` (4건): refreshToken 유/무, 만료 토큰 TTL, Auth0 실패 시 블랙리스트 보장
  - `AuthControllerTest` LogoutTests (3건): refreshToken 포함/미포함/body 없음

  ### 기존 인프라 (이번 PR에서 변경 없음, 참고용)

  | 컴포넌트 | 역할 |
  |----------|------|
  | `TokenBlacklistService` | 3계층 무효화 (개별/사용자/글로벌) + Micrometer 메트릭 + fail-open |
  | `TokenBlacklistFilter` | Security Filter에서 블랙리스트 토큰 401 거부 |

  ---

  ## Decisions & Trade-offs

  ### TTL = 토큰 남은 만료 시간
  블랙리스트 항목의 Redis TTL을 토큰의 남은 만료 시간(`expiresAt - now`)으로 설정했습니다. 토큰이 자연 만료되면 어차피 인증에 실패하므로, 그 이후까지 블랙리스트에 유지할 필요가 없습니다.

  ### Auth0 Refresh Token Revoke = best-effort
  블랙리스트 등록(critical)을 먼저 수행한 뒤 Auth0 `/oauth/revoke`(best-effort)를 호출합니다. Auth0 API 장애 시에도 access token은 이미 블랙리스트에
  등록된 상태이므로 즉각적인 보안 효과는 유지됩니다. Refresh token은 자체 만료 시간이 있어 최종적으로는 만료됩니다.

  ### refreshToken은 프론트엔드 선택적 전달
  현재 백엔드는 refresh token을 저장하지 않고 프론트엔드가 직접 보유합니다. 로그아웃 시 프론트엔드가 `{ "refreshToken": "..." }`을 body에 포함하면 Auth0 revoke를 수행하고, 포함하지 않으면 블랙리스트만 등록합니다. 기존 프론트엔드 코드와 하위 호환됩니다.

  ---

  ## Future Improvements
  - **다중 기기 로그아웃**: `revokeAllUserTokens()`가 이미 구현되어 있으나, 이를 호출하는 엔드포인트는 미구현
