### PR TITLE
참여 펀딩 조회 시 PostgreSQL GROUP BY 오류 수정

### DIFF
--- a/bc/core/src/main/java/app/giftify/funding/application/FundingGetUseCase.java
+++ b/bc/core/src/main/java/app/giftify/funding/application/FundingGetUseCase.java
@@ -114,7 +114,7 @@ public class FundingGetUseCase {
      * 내가 참여한 펀딩 목록 조회
      */
     public PageResponse<ContributeFundingResponseDto> getParticipatedFundings(int page, int size, Long memberId, FundingStatus status) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "funding.createdAt"));
 
         Page<MyFundingInfo> myFundingInfoPage = participantMemberRepository.findAllMyFundingInfos(memberId, status, pageable);
         List<MyFundingInfo> myFundingInfos = myFundingInfoPage.getContent();


### PR DESCRIPTION
## Summary
- `getParticipatedFundings` 쿼리에서 `ORDER BY fpm.createdAt`이 `GROUP BY` 절에 없어 PostgreSQL에서 오류 발생
- Sort 대상을 `funding.createdAt`으로 변경하여 GROUP BY에 포함된 컬럼으로 정렬

## 원인
- H2는 GROUP BY 규칙이 느슨하여 로컬/CI 테스트에서는 통과
- PostgreSQL(프로덕션)은 엄격하여 `column must appear in the GROUP BY clause or be used in an aggregate function` 오류

## 변경 파일
- `FundingGetUseCase.java:117` — `createdAt` → `funding.createdAt`

## Test plan
- [ ] 프로덕션 배포 후 메인 페이지 참여 펀딩 목록 정상 로딩 확인
- [ ] SQL 에러 로그 미발생 확인