### PR TITLE
Argo CD 연결 오류 방지를 위한 자동 재시작 스케줄러 추가

### DIFF
--- a/infra/k3s/base/apps/argocd/restart-cronjob.yaml
+++ b/infra/k3s/base/apps/argocd/restart-cronjob.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-restart-sa
+  namespace: argocd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-restart-role
+  namespace: argocd
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "patch", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-restart-rb
+  namespace: argocd
+subjects:
+  - kind: ServiceAccount
+    name: argocd-restart-sa
+    namespace: argocd
+roleRef:
+  kind: Role
+  name: argocd-restart-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: argocd-morning-refresher
+  namespace: argocd
+spec:
+  schedule: "5 9 * * *"
+  timeZone: "Asia/Seoul"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: argocd-restart-sa
+          containers:
+            - name: kubectl
+              image: bitnami/kubectl:latest
+              command:
+                - /bin/sh
+                - -c
+                - "kubectl rollout restart deployment -n argocd"
+          restartPolicy: OnFailure


### PR DESCRIPTION
- 서버 가동 시 발생하는 repo-server 연결 오류 자동 해결
- 매일 KST 09:05 실행 (Asia/Seoul 타임존 설정)
- kubectl 실행을 위한 ServiceAccount 및 Role 권한 포함

## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

매일 아침 서버 가동(09:00) 직후 Argo CD의 repo-server 캐시 및 네트워크 연결이 꼬여 배포가 중단되는 현상을 해결하기 위해 자동 재시작 스케줄러를 도입합니다.

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

- **CronJob 추가**: 매일 오전 09:05에 argocd 네임스페이스의 모든 Deployment를 순차적으로 재시작합니다.
- **RBAC 설정**: CronJob 내의 kubectl 컨테이너가 Deployment를 관리할 수 있도록 전용 ServiceAccount, Role, RoleBinding을 추가했습니다.
- **타임존 설정**: 서버 인프라 시간대와 무관하게 동작하도록 Asia/Seoul 타임존을 명시했습니다.

```bash
# CronJob 목록 확인 (LAST SCHEDULE에 시간이 나오는지 확인)
sudo kubectl get cronjob -n argocd

# 테스트로 한 번 실행해보기
sudo kubectl create job --from=cronjob/argocd-morning-refresher test-restart -n argocd

# 테스트용 Job 삭제 (실제 Argo CD 서비스에는 영향 없음)
sudo kubectl delete job test-restart -n argocd
```

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
