### PR TITLE
fix(member): 회원가입 시 사용자 입력 닉네임이 무시되는 버그 수정

### DIFF
--- a/bc/member/src/main/java/app/giftify/member/adapter/in/web/dto/SignupRequest.java
+++ b/bc/member/src/main/java/app/giftify/member/adapter/in/web/dto/SignupRequest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
  * 닉네임은 미입력 시 서버에서 자동 생성됩니다.
  */
 public record SignupRequest(
+        String nickname,
         LocalDate birthday,
         String address,
         String phoneNum

--- a/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
+++ b/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
@@ -89,6 +89,10 @@ public class MemberService
 
 		member.updateProfile(request.birthday(), request.address(), request.phoneNum());
 
+		if (request.nickname() != null && !request.nickname().isBlank()) {
+			member.updateInfo(request.nickname(), null, null, null);
+		}
+
 		Member updatedMember = memberRepositoryPort.save(member);
 
 		log.info("[MemberService] 프로필 정보 업데이트 완료: memberId={}", updatedMember.getId());


### PR DESCRIPTION
## Summary
- SignupRequest에 nickname 필드 추가
- MemberService.signup()에서 사용자 닉네임이 존재하면 자동생성 닉네임 대신 적용
- 기존 자동생성 로직(registerMember)은 유지하되, signup 시 override

## 변경 파일
- `SignupRequest.java` — nickname 필드 추가
- `MemberService.java` — signup() 메서드에서 닉네임 업데이트 로직 추가

## Test plan
- [ ] 닉네임 입력하여 회원가입 → 입력한 닉네임이 저장되는지 확인
- [ ] 닉네임 미입력(null/blank)으로 회원가입 → 기존 자동생성 닉네임 유지 확인
- [ ] 기존 회원가입 플로우 정상 동작 확인