### PR TITLE
feat(member): 탈퇴 회원 재로그인 시 자동 재활성화 처리

### DIFF
--- a/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
+++ b/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
@@ -46,11 +46,17 @@ public class MemberService
 
 	@Override
 	public Member registerMember(RegisterCommand command) {
-		// [중복 가입 방지] 이미 가입된 회원인지 한 번 더 검증
-		memberRepositoryPort.findByAuthSub(command.authSub())
-			.ifPresent(m -> {
-				throw new DuplicateMemberException(command.authSub());
-			});
+		Optional<Member> existingMember = memberRepositoryPort.findByAuthSub(command.authSub());
+		if (existingMember.isPresent()) {
+			Member member = existingMember.get();
+			if (member.isWithdrawn()) {
+				member.reactivate();
+				Member reactivated = memberRepositoryPort.save(member);
+				log.info("[MemberService] 탈퇴 회원 재활성화: memberId={}", reactivated.getId());
+				return reactivated;
+			}
+			throw new DuplicateMemberException(command.authSub());
+		}
 
 		// 닉네임이 없으면 자동 생성
 		String nickname = command.nickname();

--- a/bc/member/src/main/java/app/giftify/member/domain/member/Member.java
+++ b/bc/member/src/main/java/app/giftify/member/domain/member/Member.java
@@ -103,6 +103,14 @@ public class Member extends BaseDomainModel {
 		this.status = MemberStatus.WITHDRAWN;
 	}
 
+	public void reactivate() {
+		this.status = MemberStatus.ACTIVE;
+	}
+
+	public boolean isWithdrawn() {
+		return this.status == MemberStatus.WITHDRAWN;
+	}
+
 	// 회원이 활성 상태가 아닐 경우 예외를 던집니다. (검증 및 흐름 제어용)
 	public void validateActiveStatus() {
 		if (this.status != MemberStatus.ACTIVE) {


### PR DESCRIPTION
## Summary
- Member 도메인에 reactivate(), isWithdrawn() 메서드 추가
- registerMember()에서 WITHDRAWN 상태 기존 회원 감지 시 재활성화
- DuplicateMemberException 전에 탈퇴 여부를 먼저 확인하는 방어 로직

## 변경 파일
- `Member.java` — reactivate(), isWithdrawn() 도메인 메서드 추가
- `MemberService.java` — registerMember()에서 탈퇴 회원 재활성화 분기 추가

## Test plan
- [ ] WITHDRAWN 상태 회원이 재로그인 → ACTIVE로 전환 확인
- [ ] 이미 ACTIVE인 회원이 중복 가입 시도 → DuplicateMemberException 유지 확인
- [ ] 신규 회원 정상 가입 플로우 확인