### PR TITLE
TossPaymentResponse에 결제 스펙 필드 확장

### DIFF
--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsApi.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsApi.java
@@ -57,7 +57,13 @@ public interface TossPaymentsApi {
 		String paymentKey,
 		String orderId,
 		String status,
+		String method,
 		String lastTransactionKey,
+		Long totalAmount,
+		Long balanceAmount,
+		Long suppliedAmount,
+		Long vat,
+		String requestedAt,
 		String approvedAt,
 		CardInfo card,
 		java.util.List<CancelInfo> cancels,
@@ -69,7 +75,15 @@ public interface TossPaymentsApi {
 		}
 
 		@JsonIgnoreProperties(ignoreUnknown = true)
-		record CardInfo(String approveNo) {}
+		record CardInfo(
+			String issuerCode,
+			String acquirerCode,
+			String number,
+			Integer installmentPlanMonths,
+			String approveNo,
+			String cardType,
+			String ownerType
+		) {}
 
 		@JsonIgnoreProperties(ignoreUnknown = true)
 		record CancelInfo(


### PR DESCRIPTION
## Summary
- TossPaymentResponse에 method, totalAmount, balanceAmount, suppliedAmount, vat, requestedAt 필드 추가
- CardInfo 세부 필드 확장 (issuerCode, acquirerCode, installmentPlanMonths, cardType, ownerType)
- @JsonIgnoreProperties(ignoreUnknown=true) 기존 적용으로 하위호환 유지

## 변경 파일
- `TossPaymentsApi.java` — TossPaymentResponse, CardInfo 레코드 필드 확장

## Test plan
- [ ] 결제 승인 API 호출 시 확장 필드가 정상 매핑되는지 확인
- [ ] 기존 필드(paymentKey, orderId, status 등) 정상 동작 확인
- [ ] 알 수 없는 필드가 응답에 포함되어도 역직렬화 오류 없음 확인