### PR TITLE
PaymentGateway PG 중립화 및 PaymentHistoryRepository 포트 추가

### DIFF
--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListener.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListener.java
@@ -7,8 +7,7 @@ import java.time.ZoneId;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
-import app.giftify.payment.adapter.outbound.jpa.JpaPaymentHistoryRepository;
-import app.giftify.payment.adapter.outbound.jpa.entity.JpaPaymentHistory;
+import app.giftify.payment.application.outbound.PaymentHistoryRepository;
 import app.giftify.payment.domain.PaymentEventType;
 import app.giftify.payment.domain.PaymentHistory;
 import app.giftify.payment.domain.PaymentHistoryKeyGenerator;
@@ -24,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class PaymentHistoryEventListener {
 
-	private final JpaPaymentHistoryRepository historyRepository;
+	private final PaymentHistoryRepository historyRepository;
 
 	@ApplicationModuleListener
 	public void onPaymentSucceeded(PaymentSucceededEvent event) {
@@ -57,7 +56,7 @@ public class PaymentHistoryEventListener {
 		PaymentHistory history = metadata != null
 			? PaymentHistory.withMetadata(paymentId, historyKey, eventType, occurredAt, metadata)
 			: PaymentHistory.create(paymentId, historyKey, eventType, occurredAt);
-		historyRepository.save(JpaPaymentHistory.from(history, paymentId));
+		historyRepository.save(history);
 
 		log.debug("[PaymentHistoryEventListener] paymentId={}, eventType={}", paymentId, eventType);
 	}

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentHistoryRepositoryAdapter.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentHistoryRepositoryAdapter.java
@@ -1,0 +1,37 @@
+package app.giftify.payment.adapter.outbound.jpa;
+
+import app.giftify.payment.adapter.outbound.jpa.entity.JpaPaymentHistory;
+import app.giftify.payment.application.outbound.PaymentHistoryRepository;
+import app.giftify.payment.domain.PaymentHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentHistoryRepositoryAdapter implements PaymentHistoryRepository {
+
+	private final JpaPaymentHistoryRepository jpaRepository;
+
+	@Override
+	public PaymentHistory save(PaymentHistory history) {
+		JpaPaymentHistory entity = JpaPaymentHistory.from(history, history.getPaymentId());
+		JpaPaymentHistory saved = jpaRepository.save(entity);
+		return saved.toDomain();
+	}
+
+	@Override
+	public List<PaymentHistory> findByPaymentId(Long paymentId) {
+		return jpaRepository.findByPaymentIdOrderByOccurredAtAsc(paymentId).stream()
+			.map(JpaPaymentHistory::toDomain)
+			.toList();
+	}
+
+	@Override
+	public Optional<PaymentHistory> findByHistoryKey(String historyKey) {
+		return jpaRepository.findByHistoryKey(historyKey)
+			.map(JpaPaymentHistory::toDomain);
+	}
+}

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsGatewayAdapter.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsGatewayAdapter.java
@@ -3,6 +3,8 @@ package app.giftify.payment.adapter.outbound.pg;
 import org.springframework.stereotype.Component;
 
 import app.giftify.payment.application.outbound.PaymentGateway;
+import app.giftify.payment.application.outbound.PgCancelResult;
+import app.giftify.payment.application.outbound.PgConfirmResult;
 import app.giftify.shared.domain.vo.Money;
 
 @Component
@@ -15,13 +17,23 @@ public class TossPaymentsGatewayAdapter implements PaymentGateway {
 	}
 
 	@Override
-	public TossConfirmResult confirm(String paymentKey, String orderId, Money amount) {
-		return tossPaymentsClient.confirm(paymentKey, orderId, amount.amount());
+	public PgConfirmResult confirm(String paymentKey, String orderId, Money amount) {
+		TossConfirmResult toss = tossPaymentsClient.confirm(paymentKey, orderId, amount.amount());
+		return toss.success()
+			? PgConfirmResult.success(toss.paymentKey(), toss.lastTransactionKey(), toss.approveNo())
+			: PgConfirmResult.failure(toss.errorCode(), toss.errorMessage());
 	}
 
 	@Override
-	public TossCancelResult cancel(String paymentKey, String cancelReason, Money cancelAmount) {
+	public PgCancelResult cancel(String paymentKey, String cancelReason, Money cancelAmount) {
 		Long amountValue = cancelAmount != null ? cancelAmount.amount().longValue() : null;
-		return tossPaymentsClient.cancelPayment(paymentKey, cancelReason, amountValue);
+		TossCancelResult toss = tossPaymentsClient.cancelPayment(paymentKey, cancelReason, amountValue);
+		if (!toss.success()) {
+			return PgCancelResult.failure(toss.errorCode(), toss.errorMessage());
+		}
+		var cancels = toss.cancels().stream()
+			.map(c -> new PgCancelResult.CancelDetail(c.transactionKey(), c.cancelAmount(), c.canceledAt()))
+			.toList();
+		return PgCancelResult.success(toss.paymentKey(), toss.lastTransactionKey(), cancels);
 	}
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/ConfirmPaymentService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/ConfirmPaymentService.java
@@ -5,13 +5,13 @@ import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import app.giftify.payment.adapter.outbound.pg.TossConfirmResult;
 import app.giftify.payment.application.inbound.ConfirmPaymentCommand;
 import app.giftify.payment.application.inbound.ConfirmPaymentResult;
 import app.giftify.payment.application.inbound.ConfirmPaymentUseCase;
 import app.giftify.payment.application.outbound.PaymentFieldEncryptor;
 import app.giftify.payment.application.outbound.PaymentGateway;
 import app.giftify.payment.application.outbound.PaymentRepository;
+import app.giftify.payment.application.outbound.PgConfirmResult;
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
@@ -68,7 +68,7 @@ public class ConfirmPaymentService implements ConfirmPaymentUseCase {
 		}
 
 		// 4. PG 승인 요청 (DB에서 조회한 금액 사용)
-		TossConfirmResult pgResult = paymentGateway.confirm(
+		PgConfirmResult pgResult = paymentGateway.confirm(
 			command.paymentKey(),
 			command.orderNumber(),
 			payment.getPaidAmount()

--- a/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentGateway.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentGateway.java
@@ -1,13 +1,11 @@
 package app.giftify.payment.application.outbound;
 
-import app.giftify.payment.adapter.outbound.pg.TossCancelResult;
-import app.giftify.payment.adapter.outbound.pg.TossConfirmResult;
 import app.giftify.shared.domain.vo.Money;
 
 /**
  * PG 에 대한 추상화
  */
 public interface PaymentGateway {
-	TossConfirmResult confirm(String paymentKey, String orderId, Money amount);
-	TossCancelResult cancel(String paymentKey, String cancelReason, Money cancelAmount);
+	PgConfirmResult confirm(String paymentKey, String orderId, Money amount);
+	PgCancelResult cancel(String paymentKey, String cancelReason, Money cancelAmount);
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentHistoryRepository.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentHistoryRepository.java
@@ -1,0 +1,12 @@
+package app.giftify.payment.application.outbound;
+
+import app.giftify.payment.domain.PaymentHistory;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentHistoryRepository {
+	PaymentHistory save(PaymentHistory history);
+	List<PaymentHistory> findByPaymentId(Long paymentId);
+	Optional<PaymentHistory> findByHistoryKey(String historyKey);
+}

--- a/bc/core/src/main/java/app/giftify/payment/application/outbound/PgCancelResult.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/outbound/PgCancelResult.java
@@ -1,0 +1,26 @@
+package app.giftify.payment.application.outbound;
+
+import java.util.List;
+
+public record PgCancelResult(
+	boolean success,
+	String paymentKey,
+	String lastTransactionKey,
+	List<CancelDetail> cancels,
+	String errorCode,
+	String errorMessage
+) {
+	public record CancelDetail(
+		String transactionKey,
+		long cancelAmount,
+		String canceledAt
+	) {}
+
+	public static PgCancelResult success(String paymentKey, String lastTransactionKey, List<CancelDetail> cancels) {
+		return new PgCancelResult(true, paymentKey, lastTransactionKey, cancels, null, null);
+	}
+
+	public static PgCancelResult failure(String errorCode, String errorMessage) {
+		return new PgCancelResult(false, null, null, List.of(), errorCode, errorMessage);
+	}
+}

--- a/bc/core/src/main/java/app/giftify/payment/application/outbound/PgConfirmResult.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/outbound/PgConfirmResult.java
@@ -1,0 +1,18 @@
+package app.giftify.payment.application.outbound;
+
+public record PgConfirmResult(
+	boolean success,
+	String paymentKey,
+	String lastTransactionKey,
+	String approveNo,
+	String errorCode,
+	String errorMessage
+) {
+	public static PgConfirmResult success(String paymentKey, String lastTransactionKey, String approveNo) {
+		return new PgConfirmResult(true, paymentKey, lastTransactionKey, approveNo, null, null);
+	}
+
+	public static PgConfirmResult failure(String errorCode, String errorMessage) {
+		return new PgConfirmResult(false, null, null, null, errorCode, errorMessage);
+	}
+}


### PR DESCRIPTION
## Summary
- PaymentGateway 반환 타입을 PgConfirmResult/PgCancelResult로 PG 중립화
- TossPaymentsGatewayAdapter에서 Toss→PG 변환 로직 캡슐화
- PaymentHistoryRepository 포트 인터페이스 + JPA 어댑터 신규 생성
- PaymentHistoryEventListener의 인프라 계층 직접 의존(JpaPaymentHistoryRepository) 제거

## 변경 파일
- `PaymentGateway.java` — 인터페이스 시그니처 PG 중립 타입으로 변경
- `PgConfirmResult.java` / `PgCancelResult.java` — 신규 (application/outbound)
- `TossPaymentsGatewayAdapter.java` — Toss 결과 → PG 중립 결과 변환
- `ConfirmPaymentService.java` — PgConfirmResult 사용으로 변경
- `PaymentHistoryRepository.java` — 신규 포트 인터페이스
- `PaymentHistoryRepositoryAdapter.java` — 신규 JPA 어댑터
- `PaymentHistoryEventListener.java` — 포트 인터페이스 의존으로 전환

## Test plan
- [ ] 결제 승인 플로우 정상 동작 (PgConfirmResult 변환 검증)
- [ ] 결제 취소 플로우 정상 동작 (PgCancelResult 변환 검증)
- [ ] 결제 이벤트 발생 시 PaymentHistory 정상 저장 확인
- [ ] 기존 테스트 통과 확인