### PR TITLE
릴리스 파이프라인 정비 및 k3s kubeconfig 권한 자동화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify tag is on develop
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          git fetch --unshallow origin develop || git fetch origin develop
+          TAG_SHA=$(git rev-parse HEAD)
+          DEV_SHA=$(git rev-parse origin/develop)
+          echo "Tag SHA:     $TAG_SHA"
+          echo "Develop SHA: $DEV_SHA"
+          if [ "$TAG_SHA" != "$DEV_SHA" ]; then
+            echo "::error::Tag must be created from develop HEAD. Tag points to $TAG_SHA but develop is at $DEV_SHA"
+            exit 1
+          fi
+          echo "Tag is on develop HEAD"
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/infra/k3s/base/apps/argocd/application.yaml
+++ b/infra/k3s/base/apps/argocd/application.yaml
@@ -13,7 +13,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/prgrms-be-adv-devcourse/beadv4_4_team201_be.git
-    targetRevision: main
+    targetRevision: develop
     path: infra/k3s/overlays/prod
   destination:
     server: https://kubernetes.default.svc

--- a/infra/k3s/scripts/k3s-ec2-setup.sh
+++ b/infra/k3s/scripts/k3s-ec2-setup.sh
@@ -56,6 +56,36 @@ else
     echo ">>> registries.yaml 이미 존재: $REGISTRIES_FILE"
 fi
 
+# k3s kubeconfig 권한 자동 수정 서비스 등록
+KUBECONFIG_SCRIPT="/usr/local/bin/k3s-kubeconfig-fix.sh"
+KUBECONFIG_SERVICE="/etc/systemd/system/k3s-kubeconfig-fix.service"
+
+if [ ! -f "$KUBECONFIG_SERVICE" ]; then
+    echo ">>> k3s kubeconfig 권한 수정 서비스 등록중..."
+    sudo cp "${SCRIPT_DIR}/k3s-kubeconfig-fix.sh" "$KUBECONFIG_SCRIPT"
+    sudo chmod +x "$KUBECONFIG_SCRIPT"
+
+    sudo tee "$KUBECONFIG_SERVICE" > /dev/null << 'UNIT'
+[Unit]
+Description=Fix k3s kubeconfig file permissions after restart
+After=k3s.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/k3s-kubeconfig-fix.sh
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable k3s-kubeconfig-fix.service
+    echo ">>> k3s kubeconfig 권한 수정 서비스 등록 완료"
+else
+    echo ">>> k3s kubeconfig 권한 수정 서비스 이미 존재"
+fi
+
 # ArgoCD pod cleanup 서비스 등록 (k3s 재시작 시 stuck pod 자동 정리)
 CLEANUP_SCRIPT="/usr/local/bin/argocd-pod-cleanup.sh"
 CLEANUP_SERVICE="/etc/systemd/system/argocd-pod-cleanup.service"

--- a/infra/k3s/scripts/k3s-kubeconfig-fix.sh
+++ b/infra/k3s/scripts/k3s-kubeconfig-fix.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# k3s 재시작 후 kubeconfig 파일 권한을 644로 설정
+# systemd 서비스(k3s-kubeconfig-fix.service)로 등록하여 사용
+set -e
+
+K3S_YAML="/etc/rancher/k3s/k3s.yaml"
+
+# k3s.yaml이 생성될 때까지 대기 (최대 60초)
+TIMEOUT=60
+ELAPSED=0
+until [ -f "$K3S_YAML" ]; do
+    if [ $ELAPSED -ge $TIMEOUT ]; then
+        echo "ERROR: $K3S_YAML not found after ${TIMEOUT}s"
+        exit 1
+    fi
+    sleep 2
+    ELAPSED=$((ELAPSED + 2))
+done
+
+chmod 644 "$K3S_YAML"
+echo ">>> kubeconfig permission fixed: $(ls -la "$K3S_YAML")"


### PR DESCRIPTION
## Summary
- ArgoCD `targetRevision`을 `main`에서 `develop`으로 변경하여 매니페스트 동기화 문제 해결
- CI docker job에 태그가 develop HEAD인지 검증하는 step 추가하여 구 코드 배포 방지
- k3s 재시작 시 kubeconfig 권한(`/etc/rancher/k3s/k3s.yaml`)을 자동으로 644로 설정하는 systemd 서비스 추가

## 배경
- v0.0.15 릴리스에서 develop HEAD가 아닌 커밋에 태그가 찍혀 구 코드 이미지가 배포됨
- ArgoCD가 main 브랜치 매니페스트를 바라보고 있어 develop의 infra 변경이 반영되지 않음
- EC2 인스턴스 재시작 시 매번 `sudo chmod 644 /etc/rancher/k3s/k3s.yaml` 수동 실행 필요

## 변경 파일
| 파일 | 변경 |
|------|------|
| `infra/k3s/base/apps/argocd/application.yaml` | `targetRevision: develop` |
| `.github/workflows/ci.yml` | develop HEAD 검증 step 추가 |
| `infra/k3s/scripts/k3s-kubeconfig-fix.sh` | 신규 - 권한 수정 스크립트 |
| `infra/k3s/scripts/k3s-ec2-setup.sh` | systemd 서비스 등록 코드 추가 |

## Test plan
- [x] ArgoCD Application이 develop 브랜치 매니페스트를 정상 추적하는지 확인
- [x] develop HEAD가 아닌 커밋에서 태그 생성 시 CI docker job 실패하는지 확인
- [x] EC2에서 k3s-kubeconfig-fix 서비스 등록 후 재시작 시 kubectl 정상 동작 확인