### PR TITLE
Traefik X-Forwarded-Port, Protocol 헤더 추가

### DIFF
--- a/infra/k3s/base/traefik/middleware/forwarded-proto.yaml
+++ b/infra/k3s/base/traefik/middleware/forwarded-proto.yaml
@@ -6,3 +6,4 @@ spec:
   headers:
     customRequestHeaders:
       X-Forwarded-Proto: "https"
+      X-Forwarded-Port: "443"


### PR DESCRIPTION
## Summary

Cloudflare Tunnel → Traefik → Spring Boot 경로에서 발생하는 Swagger UI "CORS" 에러 해결 및 ArgoCD Image Updater 미동작 수정.

  실제 원인은 CORS가 아니라 Traefik이 X-Forwarded-Proto/X-Forwarded-Port를 덮어쓰면서 발생한 mixed content 문제였다.
  브라우저가 HTTPS 페이지에서 HTTP 요청을 차단하면서 "CORS error"로 표시되는 오인 케이스.

  리뷰어는 Traefik middleware 설정의 적절성과 ArgoCD Application spec 변경의 부작용 여부를 중점적으로 봐주시면 감사하겠습니다.

  ---
## What's Changed

  1. Traefik Headers Middleware 추가 (forwarded-proto.yaml)

  - X-Forwarded-Proto: "https" / X-Forwarded-Port: "443" 강제 설정
  - Cloudflare Tunnel 뒤에서 Traefik web entrypoint(HTTP 80)가 원본 proto/port를 덮어쓰는 문제 해결
  - api-server IngressRoute에 미들웨어 참조 추가

  2. ArgoCD Application source type 명시 (application.yaml)

  - kustomize: {} 추가
  - Image Updater가 source type을 ''(빈 문자열)로 인식하여 skipping app 경고와 함께 0개 앱을 처리하던 문제 수정

  3. (develop 직접 반영) forward-headers-strategy 변경

  - application.yml의 server.forward-headers-strategy를 native → framework로 변경
  - Tomcat RemoteIpValve 대신 Spring ForwardedHeaderFilter 사용
  - ForwardedHeaderFilter가 X-Forwarded-* 헤더를 올바르게 처리하는 것을 port-forward 테스트로 검증 완료

  ---
## Decisions & Trade-offs

### Traefik middleware vs SpringDoc 서버 URL 명시

  - SpringDoc에 servers URL을 하드코딩하는 방식은 Swagger에만 적용되는 workaround
  - Traefik middleware는 모든 요청에 대해 scheme/port를 올바르게 전달하므로 근본적 해결
  - Cloudflare Tunnel 뒤에서는 외부 직접 접근이 불가하므로 헤더 강제 설정의 보안 위험 없음

### native vs framework

  - native(Tomcat RemoteIpValve)는 프록시 IP 신뢰 목록 + X-Forwarded-For 헤더 조합 조건이 까다로움
  - framework(Spring ForwardedHeaderFilter)는 헤더를 무조건 수용하되, 처리 후 헤더를 제거하여 스푸핑 방지
  - 다단 프록시(Cloudflare → Traefik → Spring Boot) 환경에서는 framework가 더 적합

### develop 직접 반영 건

  - forward-headers-strategy 변경과 Image Updater/미들웨어 수정이 동일 브랜치에서 작업되었으나, tracking 설정 실수로 develop에 직접
   push됨
  - 이미 운영 반영 및 검증 완료 상태이므로 revert 없이 진행

  ---
## Future Improvements

  - Traefik websecure entrypoint 도입: 현재 web(HTTP) entrypoint만 사용 중. Traefik에서 TLS를 직접 처리하면 middleware 없이도
  proto/port가 올바르게 설정됨
  - GitHub Webhook → ArgoCD 연동: 현재 3분 polling 방식. Webhook 설정 시 push 즉시 감지 가능
  - ArgoCD Application targetRevision 정리: 클러스터에서는 main을 바라보고 있었으나 실제 production 브랜치는 develop. Git의
  application.yaml과 클러스터 상태 일치 필요
