### PR TITLE
OrderEventListener 재시도 조건 및 recover 메서드 수정 

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
@@ -27,9 +27,9 @@ public class OrderEventListener {
     private final FundingOrderService fundingOrderService;
 
 	@Retryable(
-		retryFor = InfraException.class,
-		exceptionExpression = "@retryService.isRetryable(#root)",
-		backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
+			retryFor = InfraException.class,
+			exceptionExpression = "#root.errorCode.isRetryable",
+			backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
 	)
 	@ApplicationModuleListener
 	public void on(PaymentCanceledEvent event) {
@@ -38,9 +38,9 @@ public class OrderEventListener {
 	}
 
 	@Retryable(
-		retryFor = InfraException.class,
-		exceptionExpression = "@retryService.isRetryable(#root)",
-		backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
+			retryFor = InfraException.class,
+			exceptionExpression = "#root.errorCode.isRetryable",
+			backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
 	)
 
 	@ApplicationModuleListener
@@ -51,7 +51,7 @@ public class OrderEventListener {
 
     @Retryable(
             retryFor = InfraException.class,
-            exceptionExpression = "@retryService.isRetryable(#root)",
+			exceptionExpression = "#root.errorCode.isRetryable",
             backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
     )
     @ApplicationModuleListener
@@ -76,17 +76,40 @@ public class OrderEventListener {
 	 * 모든 재시도 실패 시 실행되는 공통 복구 로직
 	 */
 	@Recover
-	public void recover(InfraException e, PaymentEvent event) {
-		Long orderId = event.data().orderId();
+	public void recover(InfraException e, PaymentCanceledEvent event) {
+		log(e, event);
+		throw e;
+	}
+
+	@Recover
+	public void recover(InfraException e, PaymentCancelFailedEvent event) {
+		log(e, event);
+		throw e;
+	}
+
+	@Recover
+	public void recover(InfraException e, FundingAcceptedEvent event) {
 		log.error("================================================================");
 		log.error("[최종 장애] 주문 취소 처리 최종 실패 (시스템 자동 복구 불가)");
-		log.error("OrderId: {}", orderId);
+		log.error("Funding ID: {}", event.getFundingId());
+		log.error("Event ID: {}", event.getEventId());
 		log.error("Event Type: {}", event.getClass().getSimpleName());
 		log.error("Reason: {}", e.getMessage());
 		log.error("조치 사항: DB 상태 확인 후 수동 정정 필요");
 		log.error("================================================================");
-
 		throw e;
 	}
 
+	private static void log(InfraException e, PaymentEvent event) {
+		Long orderId = event.data().orderId();
+
+		log.error("================================================================");
+		log.error("[최종 장애] 주문 취소 처리 최종 실패 (시스템 자동 복구 불가)");
+		log.error("Order ID: {}", orderId);
+		log.error("Event ID: {}", event.id());
+		log.error("Event Type: {}", event.getClass().getSimpleName());
+		log.error("Reason: {}", e.getMessage());
+		log.error("조치 사항: DB 상태 확인 후 수동 정정 필요");
+		log.error("================================================================");
+	}
 }

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -1,0 +1,70 @@
+package app.giftify.order.adapter.inbound.event;
+
+import app.giftify.order.application.FundingOrderService;
+import app.giftify.order.application.OrderService;
+import app.giftify.shared.api.exception.InfraErrorCode;
+import app.giftify.shared.api.exception.InfraException;
+import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
+import app.giftify.shared.domain.event.payment.PaymentEventData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        OrderEventListener.class,           // 1. 테스트 대상
+        OrderEventListenerTest.TestConfig.class // 2. 테스트 설정 (Retry 활성화)
+})
+class OrderEventListenerTest {
+
+    @TestConfiguration
+    @EnableRetry
+    @Import(OrderEventListener.class)
+    static class TestConfig {
+        // 테스트에 필요한 공통 설정이 있다면 여기에 작성
+    }
+
+    @Autowired
+    private OrderEventListener orderEventListener;
+
+    @MockitoBean
+    private OrderService orderService; // 의존성 모킹
+
+    @MockitoBean
+    private FundingOrderService fundingOrderService;
+
+    @Test
+    @DisplayName("재시도 가능한 에러코드의 InfraException 발생 시 recover가 호출되어야 한다")
+    void recover_test_with_enum_retryable() {
+        // given
+        PaymentCanceledEvent event = PaymentCanceledEvent.create(
+                mock(PaymentEventData.class)
+        );
+
+        // 1. 재시도가 가능한 Enum 값을 가진 실제 Exception 생성
+        // 예: ErrorCode.NETWORK_TIMEOUT.isRetryable() == true 라고 가정
+        InfraException retryableException = new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT);
+
+        // 2. 서비스 호출 시 해당 예외를 던지도록 설정
+        willThrow(retryableException)
+                .given(orderService).completeCancel(any());
+
+        // when & then
+        assertThatThrownBy(() -> orderEventListener.on(event))
+                .isInstanceOf(InfraException.class);
+
+        // then: 실제로 재시도가 발생했는지 횟수 확인
+        verify(orderService, atLeast(2)).completeCancel(any());
+    }
+}


### PR DESCRIPTION
## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

  `@Retryable`의 `exceptionExpression`에서 Bean을 직접 호출하는 방식
  (`@retryService.isRetryable(#root)`)이 정상적으로 동작하지 않는 문제가 있었습니다.
  또한 단일 `recover` 메서드가 `PaymentEvent` 상위 타입을 파라미터로 받아
  Spring-Retry의 타입 매칭에 실패하는 버그가 있었습니다.


---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

  - `exceptionExpression`을 Bean 호출 방식에서 `InfraErrorCode` enum 속성 직접
    참조 방식으로 변경
    - `"@retryService.isRetryable(#root)"` → `"#root.errorCode.isRetryable"`
  - 단일 `recover(InfraException, PaymentEvent)` 메서드를 이벤트 타입별로 분리
    - `recover(InfraException, PaymentCanceledEvent)`
    - `recover(InfraException, PaymentCancelFailedEvent)`
    - `recover(InfraException, FundingAcceptedEvent)`
  - 공통 에러 로그 출력 로직을 `private log()` 헬퍼 메서드로 추출
  - `OrderEventListenerTest` 신규 작성
    - `@EnableRetry` 통합 환경에서 재시도 횟수 및 recover 동작 검증


---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
