### PR TITLE
fix: Elasticsearch Service를 ClusterIP와 Headless로 분리

### DIFF
--- a/infra/k3s/base/apps/elasticsearch/service.yaml
+++ b/infra/k3s/base/apps/elasticsearch/service.yaml
@@ -1,11 +1,30 @@
+# 1. API 접속용 (Spring Boot용)
 apiVersion: v1
 kind: Service
 metadata:
-  name: elasticsearch
+  name: elasticsearch # 앱에서 사용하는 이름
+  namespace: giftify
 spec:
+  selector:
+    app: elasticsearch # StatefulSet의 포드 라벨과 일치해야 함
+  ports:
+    - port: 9200
+      targetPort: 9200
+  type: ClusterIP # 가상 IP 부여 (기본값)
+
+---
+# 2. 클러스터 내부 통신용 (기존 설정)
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-headless # 이름을 살짝 바꿔주는 게 관례입니다.
+  namespace: giftify
+spec:
+  clusterIP: None
   selector:
     app: elasticsearch
   ports:
     - port: 9200
-      targetPort: 9200
-  clusterIP: None
+      name: http
+    - port: 9300
+      name: transport


### PR DESCRIPTION
## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

  Spring Boot 애플리케이션이 `elasticsearch` 호스트명으로 DNS 조회 시,
  기존 Headless Service(`clusterIP: None`)가 Pod IP를 직접 반환하여
  단일 노드 장애나 Pod 재시작 시 연결이 불안정한 문제가 있었습니다.


---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

  - 기존 단일 Service를 역할에 따라 두 개로 분리
    - `elasticsearch` (ClusterIP): Spring Boot 앱에서 사용하는 안정적인 가상 IP 제공 (9200)
    - `elasticsearch-headless` (Headless): 클러스터 내부 노드 간 통신용 (9200 http, 9300 transport)
  - 두 Service 모두 `namespace: giftify` 명시


---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
