### PR TITLE
fix: Elasticsearch StatefulSet 설정 오류 수정

### DIFF
--- a/infra/k3s/base/apps/elasticsearch/statefulset.yaml
+++ b/infra/k3s/base/apps/elasticsearch/statefulset.yaml
@@ -2,10 +2,11 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch
+  namespace: giftify
   labels:
     app: elasticsearch
 spec:
-  serviceName: elasticsearch
+  serviceName: elasticsearch-headless
   replicas: 1
   selector:
     matchLabels:
@@ -25,7 +26,7 @@ spec:
             - name: discovery.type
               value: "single-node"
             - name: xpack.security.enabled
-              value: "true"
+              value: "false"
             - name: ES_JAVA_OPTS
               value: "-Xms512m -Xmx512m"
           resources:
@@ -40,17 +41,17 @@ spec:
               mountPath: /usr/share/elasticsearch/data
           startupProbe:
             exec:
-              command: ["sh", "-c", "curl -sfk https://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 60
           readinessProbe:
             exec:
-              command: ["sh", "-c", "curl -sfk https://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
             periodSeconds: 10
           livenessProbe:
             exec:
-              command: ["sh", "-c", "curl -sfk https://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
             periodSeconds: 30
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
- serviceName을 Headless Service 이름과 일치하도록 변경                 (elasticsearch → elasticsearch-headless)
- namespace: giftify 명시
- xpack.security.enabled를 false로 변경하여 보안 비활성화 상태와 일치
- Health probe URL을 https → http로 수정
    (xpack.security 비활성화로 TLS 미사용 환경에 맞춤)

## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

Elasticsearch 포드(Pod)가 Running 상태임에도 불구하고 Startup Probe가 계속 실패하여 컨테이너가 무한히 재시작됨에 따라 보안 설정 변경

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

#### 보안 설정 및 통신 프로토콜 조정 (임시)
- xpack.security.enabled: true -> false 로 변경.

사유: 인프라 구축 초기 단계에서 자동 생성되는 비밀번호로 인한 Startup Probe 실패(401 Unauthorized)를 방지하고, 앱 수준의 권한 에러(AuthorizationDeniedException) 디버깅에 집중하기 위함입니다.

#### 통신 프로토콜: https -> http 로 전환.

- 보안 해제에 따라 모든 내부 통신 및 헬스 체크 경로를 HTTP 평문 통신으로 조정했습니다.

3. Probe 설정 최적화
Startup Probe: 부팅 시간이 긴 Elasticsearch 특성을 고려하여 failureThreshold를 유지하고, curl 명령어를 인증 정보가 필요 없는 http 요청으로 수정했습니다.

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
