### PR TITLE
fix: Elasticsearch 보안 인증 활성화

### DIFF
--- a/infra/k3s/base/apps/elasticsearch/statefulset.yaml
+++ b/infra/k3s/base/apps/elasticsearch/statefulset.yaml
@@ -26,9 +26,12 @@ spec:
             - name: discovery.type
               value: "single-node"
             - name: xpack.security.enabled
-              value: "false"
+              value: "true"
             - name: ES_JAVA_OPTS
               value: "-Xms512m -Xmx512m"
+          envFrom:
+            - secretRef:
+                name: es-secrets
           resources:
             requests:
               memory: "1Gi"
@@ -41,17 +44,17 @@ spec:
               mountPath: /usr/share/elasticsearch/data
           startupProbe:
             exec:
-              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -u elastic:$ES_PASSWORD -sfk https://127.0.0.1:9200/_cluster/health || exit 1"]
             initialDelaySeconds: 30
             periodSeconds: 10
             failureThreshold: 60
           readinessProbe:
             exec:
-              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -u elastic:$ES_PASSWORD -sfk https://127.0.0.1:9200/_cluster/health || exit 1"]
             periodSeconds: 10
           livenessProbe:
             exec:
-              command: ["sh", "-c", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+              command: ["sh", "-c", "curl -u elastic:$ES_PASSWORD -sfk https://127.0.0.1:9200/_cluster/health || exit 1"]
             periodSeconds: 30
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
- xpack.security.enabled를 false에서 true로 변경
- es-secrets SecretRef를 통해 인증 환경변수(ES_PASSWORD) 주입
- startupProbe/readinessProbe/livenessProbe의 health check 엔드포인트를 HTTP에서 HTTPS로 변경하고 elastic 사용자 인증(-u elastic:$ES_PASSWORD) 추가

## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.


---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.


---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
