### PR TITLE
 진행 중인 펀딩 존재 시 상품 판매 중지(INACTIVE) 차단 로직 추가

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/FundingApiClient.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/FundingApiClient.java
@@ -1,0 +1,12 @@
+package app.giftify.product.adapter.outbound.client;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+
+@HttpExchange(url = "/api/internal/funding")
+public interface FundingApiClient {
+
+    @GetExchange("/{productId}/exists")
+    boolean checkFundingExistsByProductId(@PathVariable Long productId);
+}

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/FundingClientAdapter.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/FundingClientAdapter.java
@@ -1,0 +1,27 @@
+package app.giftify.product.adapter.outbound.client;
+
+import app.giftify.product.application.port.out.FundingClientPort;
+import app.giftify.product.domain.exception.ProductErrorCode;
+import app.giftify.product.domain.exception.ProductException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+@RequiredArgsConstructor
+public class FundingClientAdapter implements FundingClientPort {
+
+    private final FundingApiClient apiClient;
+
+    @Override
+    public boolean checkFundingExistsByProductId(Long productId) {
+        try {
+            return apiClient.checkFundingExistsByProductId(productId);
+        } catch (RestClientResponseException e) { // 4xx, 5xx
+            throw new ProductException(ProductErrorCode.EXTERNAL_API_ERROR);
+        } catch (ResourceAccessException e) { // 응답 못 받음
+            throw new ProductException(ProductErrorCode.EXTERNAL_API_CONNECTION_FAILURE);
+        }
+    }
+}

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/ProductApiClientConfig.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/client/ProductApiClientConfig.java
@@ -1,0 +1,27 @@
+package app.giftify.product.adapter.outbound.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.support.RestClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+@Configuration
+public class ProductApiClientConfig {
+
+    @Bean
+    public FundingApiClient fundingApiClient(
+            RestClient.Builder builder,
+            @Value("${app.service.funding.url:http://localhost:8080}") String baseUrl
+    ) {
+        RestClient restClient = builder
+                .baseUrl(baseUrl)
+                .build();
+
+        return HttpServiceProxyFactory
+                .builderFor(RestClientAdapter.create(restClient))
+                .build()
+                .createClient(FundingApiClient.class);
+    }
+}

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/out/FundingClientPort.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/out/FundingClientPort.java
@@ -1,0 +1,5 @@
+package app.giftify.product.application.port.out;
+
+public interface FundingClientPort {
+    boolean checkFundingExistsByProductId(Long productId);
+}

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -193,8 +193,21 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
                         product.active();
                 }
                 case INACTIVE -> {
-                    if (product.getStatus() != INACTIVE)
+                    if (product.getStatus() != INACTIVE) {
+                        log.info("진행 중인 펀딩 확인 중 ...");
+                        // todo 펀딩 api call try-catch
+                        // todo 펀딩 api call return false
                         product.inActive();
+                        log.info("[판매 중지 변경 성공] 변경 완료");
+
+                        // todo 펀딩 api call return true
+                        log.info("[판매 중지 변경 실패] 진행 중인 펀딩이 있습니다.");
+                        /**
+                         * throw Exception
+                         * "펀딩이 진행 중인 상품이 있습니다.
+                         * 판매를 원하지 않으실 경우, 재고를 0으로 변경하세요."
+                         */
+                    }
                 }
             }
         }
@@ -206,6 +219,7 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
                 product.getName(),
                 product.getImageKey()
         ));
+        log.info("상품 정보가 업데이트 되었습니다.");
 
         return ProductUpdateResult.from(product);
     }

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -4,6 +4,7 @@ import app.giftify.product.adapter.inbound.web.requestDto.MyProductSearchDto;
 import app.giftify.product.adapter.inbound.web.requestDto.ProductSearchDto;
 import app.giftify.product.adapter.inbound.web.requestDto.ProductUpdateRequestDto;
 import app.giftify.product.application.port.in.*;
+import app.giftify.product.application.port.out.FundingClientPort;
 import app.giftify.product.application.port.out.MyProductSearchCommand;
 import app.giftify.product.application.port.out.ProductRepositoryPort;
 import app.giftify.product.application.port.out.ProductSearchCommand;
@@ -18,6 +19,7 @@ import app.giftify.shared.api.paging.PageResponse;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.product.ProductUpdatedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -29,9 +31,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static app.giftify.product.domain.ProductStatus.ACTIVE;
-import static app.giftify.product.domain.ProductStatus.INACTIVE;
 import static app.giftify.product.domain.exception.ProductErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductService implements ProductCreateUseCase, ProductGetUseCase, ProductSearchUseCase, ProductApproveUseCase, ProductRejectUseCase, ProductUpdateUseCase, DecreaseProductStockUseCase {
@@ -39,6 +41,7 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
     private final MemberRepository memberRepository;
     private final EventPublisher eventPublisher;
     private final ProductSupport productSupport;
+    private final FundingClientPort fundingClientPort;
 
     // 상품 생성 (판매자)
     @Override
@@ -172,7 +175,7 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
 
             validateProductOwner(product, sellerId);
             if (product.getStock() != requestDto.expectedStock()) { // CAS 검증 (판매자가 재고 수정하려는 사이에 재고 변동이 일어남)
-                throw new ProductException(PRODUCT_STOCK_CHANGED);
+                throw new ProductException(PRODUCT_STOCK_CHANGED); // TODO 재시도 or 재고수정 분리
             }
             product.updateStock(requestDto.stock());
         } else {
@@ -188,26 +191,19 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
         var status = requestDto.status();
         if (status != null) {
             switch (status) {
-                case ACTIVE -> {
-                    if (product.getStatus() != ACTIVE)
-                        product.active();
+                case ACTIVE -> { // 도메인에서 상태 검증
+                    product.active();
                 }
-                case INACTIVE -> {
-                    if (product.getStatus() != INACTIVE) {
-                        log.info("진행 중인 펀딩 확인 중 ...");
-                        // todo 펀딩 api call try-catch
-                        // todo 펀딩 api call return false
-                        product.inActive();
-                        log.info("[판매 중지 변경 성공] 변경 완료");
+                case INACTIVE -> { // 펀딩 체크
+                    log.info("진행 중인 펀딩 확인 중 ...");
+                    boolean isFundingOngoing = fundingClientPort.checkFundingExistsByProductId(productId);
 
-                        // todo 펀딩 api call return true
+                    if (isFundingOngoing) {
                         log.info("[판매 중지 변경 실패] 진행 중인 펀딩이 있습니다.");
-                        /**
-                         * throw Exception
-                         * "펀딩이 진행 중인 상품이 있습니다.
-                         * 판매를 원하지 않으실 경우, 재고를 0으로 변경하세요."
-                         */
+                        throw new ProductException(CANNOT_STOP_SALE_DUE_TO_ACTIVE_FUNDING);
                     }
+                    product.inActive();
+                    log.info("[판매 중지 변경 성공] 변경 완료");
                 }
             }
         }

--- a/bc/catalog/src/main/java/app/giftify/product/domain/Product.java
+++ b/bc/catalog/src/main/java/app/giftify/product/domain/Product.java
@@ -59,7 +59,6 @@ public class Product extends BaseDomainModel {
 
     /**
      * 상품 상태 변경
-     * todo 상품 상태 변경 이력 컬렉션
      */
     // 상품 등록 승인
     public void approve() {
@@ -85,6 +84,9 @@ public class Product extends BaseDomainModel {
 
     // 상품 상태 검증 todo Map<from,to> 상태 머신
     private void validateTransition(ProductStatus toStatus) {
+        if (this.status == toStatus)
+            throw new ProductException(PRODUCT_CANNOT_CHANGE_TO_SAME_STATUS);
+        
         if (toStatus == DRAFT) {
             throw new ProductException(PRODUCT_CANNOT_CHANGE_STATUS_TO_DRAFT);
         }

--- a/bc/catalog/src/main/java/app/giftify/product/domain/exception/ProductErrorCode.java
+++ b/bc/catalog/src/main/java/app/giftify/product/domain/exception/ProductErrorCode.java
@@ -23,6 +23,8 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_NOT_ACTIVE(HttpStatus.BAD_REQUEST.value(), "P207", "판매 중인 상품이 아닙니다."),
     PRODUCT_NOT_IN_INACTIVE_STATUS(HttpStatus.BAD_REQUEST.value(), "P208", "'INACTIVE' 상태의 상품이 아닙니다."),
     INVALID_APPROVAL_ACTION(HttpStatus.BAD_REQUEST.value(), "P209", "올바르지 않은 액션값입니다."),
+    CANNOT_STOP_SALE_DUE_TO_ACTIVE_FUNDING(HttpStatus.BAD_REQUEST.value(), "P210", "진행 중이거나 수령자 수락 대기 중인 펀딩이 있습니다."),
+    PRODUCT_CANNOT_CHANGE_STATUS_TO_REJECTED(HttpStatus.BAD_REQUEST.value(), "P211", "'REJECTED'로 상태를 변경할 수 없습니다."),
 
     // P3xx: 도메인 생성/입력 검증
     PRODUCT_SELLER_REQUIRED(HttpStatus.BAD_REQUEST.value(), "P301", "판매자 정보는 필수입니다."),
@@ -40,7 +42,9 @@ public enum ProductErrorCode implements ErrorCode {
 
     // P5xx: 인프라/동시성 관련
     PRODUCT_STOCK_LOCK_TIMEOUT(HttpStatus.CONFLICT.value(), "P501", "일시적인 문제가 발생했습니다. 다시 시도하세요."),
-    PRODUCT_STOCK_CHANGED(HttpStatus.CONFLICT.value(), "P502", "재고가 변경되었습니다. 다시 시도하세요.");
+    PRODUCT_STOCK_CHANGED(HttpStatus.CONFLICT.value(), "P502", "재고가 변경되었습니다. 다시 시도하세요."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "P503", "외부 API 호출 중 오류가 발생했습니다."),
+    EXTERNAL_API_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE.value(), "P504", "외부 서비스에 연결할 수 없습니다.");
 
     private final int statusCode;
     private final String code;

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
@@ -1,14 +1,20 @@
 package app.giftify.product.application.service;
 
+import app.giftify.product.adapter.inbound.web.requestDto.ProductUpdateRequestDto;
+import app.giftify.product.application.port.in.ProductUpdateResult;
+import app.giftify.product.application.port.out.FundingClientPort;
 import app.giftify.product.application.port.out.ProductRepositoryPort;
 import app.giftify.product.application.support.ProductSupport;
 import app.giftify.product.domain.Product;
 import app.giftify.product.domain.ProductStatus;
 import app.giftify.product.domain.event.ProductStockUpdatedEvent;
+import app.giftify.product.domain.exception.ProductErrorCode;
 import app.giftify.product.domain.exception.ProductException;
+import app.giftify.replica.member.MemberRepository;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.product.ProductSaleDisabledEvent;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,94 +38,194 @@ class ProductServiceTest {
     private ProductRepositoryPort productRepositoryPort;
 
     @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FundingClientPort fundingClientPort;
+
+    @Mock
     private EventPublisher eventPublisher;
 
     @InjectMocks
     private ProductService productService;
 
-    @Test
-    @DisplayName("펀딩에 의한 재고 감소 성공 - 재고 5에서 4로 감소하고 재고 변경 이벤트가 발행된다")
-    void decreaseStockByFunding_Success() {
-        // given
-        Long productId = 1L;
-        Product product = Product.builder()
-                .id(productId)
-                .sellerId(10L)
+    @Nested
+    @DisplayName("재고 관리 기능 테스트 (decreaseStockByFunding)")
+    class StockManagementTests {
+        @Test
+        @DisplayName("성공: 재고 5에서 4로 감소하고 재고 변경 이벤트가 발행된다")
+        void decreaseStockByFunding_Success() {
+            // given
+            Long productId = 1L;
+            Product product = createProduct(productId, 5);
+            given(productSupport.findByIdForUpdate(productId)).willReturn(product);
+
+            // when
+            productService.decreaseStockByFunding(productId);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(4);
+            verify(productRepositoryPort).save(product);
+            verify(eventPublisher).publish(any(ProductStockUpdatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("성공: 재고가 0이 되면 판매 중지 이벤트가 발행된다")
+        void decreaseStockByFunding_StockBecomesZero() {
+            // given
+            Long productId = 1L;
+            Product product = createProduct(productId, 1);
+            given(productSupport.findByIdForUpdate(productId)).willReturn(product);
+
+            // when
+            productService.decreaseStockByFunding(productId);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(0);
+            verify(productRepositoryPort).save(product);
+            verify(eventPublisher).publish(any(ProductSaleDisabledEvent.class));
+        }
+
+        @Test
+        @DisplayName("실패: 재고가 0이면 PRODUCT_OUT_OF_STOCK 예외가 발생한다")
+        void decreaseStockByFunding_OutOfStock() {
+            // given
+            Long productId = 1L;
+            Product product = createProduct(productId, 0);
+            given(productSupport.findByIdForUpdate(productId)).willReturn(product);
+
+            // when & then
+            assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
+                    .isInstanceOf(ProductException.class);
+            assertThat(product.getStock()).isEqualTo(0);
+            verify(productRepositoryPort, never()).save(product);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 상품이면 예외가 발생한다")
+        void decreaseStockByFunding_ProductNotFound() {
+            // given
+            Long productId = 999L;
+            given(productSupport.findByIdForUpdate(productId))
+                    .willThrow(new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+            // when & then
+            assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
+                    .isInstanceOf(ProductException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("상품 수정 기능 테스트 (updateProduct)")
+    class UpdateProductTests {
+        private final Long PRODUCT_ID = 1L;
+        private final Long SELLER_ID = 100L;
+
+        @Test
+        @DisplayName("상품 수정 성공: 상품의 기본 정보(이름, 설명, 가격)를 수정할 수 있다.")
+        void updateProductInfo_Success() {
+            // given
+            Product product = createProduct(PRODUCT_ID, 10);
+            ProductUpdateRequestDto requestDto = new ProductUpdateRequestDto(
+                    "수정된 이름", "수정된 설명", 15000, null, null, null, "new-image-key"
+            );
+
+            given(productSupport.findById(PRODUCT_ID)).willReturn(product);
+
+            // when
+            ProductUpdateResult result = productService.updateProduct(PRODUCT_ID, SELLER_ID, requestDto);
+
+            // then
+            assertThat(product.getName()).isEqualTo("수정된 이름");
+            assertThat(product.getDescription()).isEqualTo("수정된 설명");
+            assertThat(product.getPrice()).isEqualTo(15000);
+            verify(productRepositoryPort).save(product);
+        }
+
+        @Test
+        @DisplayName("재고 수정 성공: CAS 검증을 통과하면 재고를 수정할 수 있다.")
+        void updateStock_Success() {
+            // given
+            Product product = createProduct(PRODUCT_ID, 10);
+            ProductUpdateRequestDto requestDto = new ProductUpdateRequestDto(
+                    null, null, null, 50, 10, null, null
+            );
+
+            given(productSupport.findByIdForUpdate(PRODUCT_ID)).willReturn(product);
+
+            // when
+            productService.updateProduct(PRODUCT_ID, SELLER_ID, requestDto);
+
+            // then
+            assertThat(product.getStock()).isEqualTo(50);
+            verify(productRepositoryPort).save(product);
+        }
+
+        @Test
+        @DisplayName("재고 수정 실패: 예상 재고가 실제와 다르면 PRODUCT_STOCK_CHANGED 예외가 발생한다.")
+        void updateStock_Fail_CasMismatch() {
+            // given
+            Product product = createProduct(PRODUCT_ID, 10);
+            ProductUpdateRequestDto requestDto = new ProductUpdateRequestDto(
+                    null, null, null, 50, 5, null, null
+            );
+
+            given(productSupport.findByIdForUpdate(PRODUCT_ID)).willReturn(product);
+
+            // when & then
+            assertThatThrownBy(() -> productService.updateProduct(PRODUCT_ID, SELLER_ID, requestDto))
+                    .isInstanceOf(ProductException.class)
+                    .hasMessageContaining(ProductErrorCode.PRODUCT_STOCK_CHANGED.getMessage());
+        }
+
+        @Test
+        @DisplayName("상태 변경 성공: 진행 중인 펀딩이 없으면 INACTIVE로 변경할 수 있다.")
+        void updateStatusToInactive_Success() {
+            // given
+            Product product = createProduct(PRODUCT_ID, 10);
+            ProductUpdateRequestDto requestDto = new ProductUpdateRequestDto(
+                    null, null, null, null, null, ProductStatus.INACTIVE, null
+            );
+
+            given(productSupport.findById(PRODUCT_ID)).willReturn(product);
+            given(fundingClientPort.checkFundingExistsByProductId(PRODUCT_ID)).willReturn(false);
+
+            // when
+            productService.updateProduct(PRODUCT_ID, SELLER_ID, requestDto);
+
+            // then
+            assertThat(product.getStatus()).isEqualTo(ProductStatus.INACTIVE);
+            verify(productRepositoryPort).save(product);
+        }
+
+        @Test
+        @DisplayName("상태 변경 실패: 진행 중인 펀딩이 있으면 INACTIVE로 변경 시 예외가 발생한다.")
+        void updateStatusToInactive_Fail_DueToFunding() {
+            // given
+            Product product = createProduct(PRODUCT_ID, 10);
+            ProductUpdateRequestDto requestDto = new ProductUpdateRequestDto(
+                    null, null, null, null, null, ProductStatus.INACTIVE, null
+            );
+
+            given(productSupport.findById(PRODUCT_ID)).willReturn(product);
+            given(fundingClientPort.checkFundingExistsByProductId(PRODUCT_ID)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> productService.updateProduct(PRODUCT_ID, SELLER_ID, requestDto))
+                    .isInstanceOf(ProductException.class)
+                    .hasMessageContaining(ProductErrorCode.CANNOT_STOP_SALE_DUE_TO_ACTIVE_FUNDING.getMessage());
+        }
+    }
+
+    private Product createProduct(Long id, int stock) {
+        return Product.builder()
+                .id(id)
+                .sellerId(100L)
                 .name("테스트 상품")
                 .description("테스트 설명")
                 .price(10000)
-                .stock(5)
+                .stock(stock)
                 .status(ProductStatus.ACTIVE)
                 .build();
-        given(productSupport.findByIdForUpdate(productId)).willReturn(product);
-
-        // when
-        productService.decreaseStockByFunding(productId);
-
-        // then
-        assertThat(product.getStock()).isEqualTo(4);
-        verify(productRepositoryPort).save(product);
-        verify(eventPublisher).publish(any(ProductStockUpdatedEvent.class));
-    }
-
-    @Test
-    @DisplayName("펀딩에 의한 재고 감소 - 재고가 0이 되면 판매 중지 이벤트가 발행된다")
-    void decreaseStockByFunding_StockBecomesZero() {
-        // given
-        Long productId = 1L;
-        Product product = Product.builder()
-                .id(productId)
-                .sellerId(10L)
-                .name("테스트 상품")
-                .description("테스트 설명")
-                .price(10000)
-                .stock(1)
-                .status(ProductStatus.ACTIVE)
-                .build();
-        given(productSupport.findByIdForUpdate(productId)).willReturn(product);
-
-        // when
-        productService.decreaseStockByFunding(productId);
-
-        // then
-        assertThat(product.getStock()).isEqualTo(0);
-        verify(productRepositoryPort).save(product);
-        verify(eventPublisher).publish(any(ProductSaleDisabledEvent.class));
-    }
-
-    @Test
-    @DisplayName("펀딩에 의한 재고 감소 실패 - 재고가 0이면 PRODUCT_OUT_OF_STOCK 예외가 발생한다")
-    void decreaseStockByFunding_OutOfStock() {
-        // given
-        Long productId = 1L;
-        Product product = Product.builder()
-                .id(productId)
-                .sellerId(10L)
-                .name("테스트 상품")
-                .description("테스트 설명")
-                .price(10000)
-                .stock(0)
-                .status(ProductStatus.ACTIVE)
-                .build();
-        given(productSupport.findByIdForUpdate(productId)).willReturn(product);
-
-        // when & then
-        assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
-                .isInstanceOf(ProductException.class);
-        assertThat(product.getStock()).isEqualTo(0);
-        verify(productRepositoryPort, never()).save(product);
-    }
-
-    @Test
-    @DisplayName("펀딩에 의한 재고 감소 실패 - 존재하지 않는 상품이면 예외가 발생한다")
-    void decreaseStockByFunding_ProductNotFound() {
-        // given
-        Long productId = 999L;
-        given(productSupport.findByIdForUpdate(productId))
-                .willThrow(new ProductException(app.giftify.product.domain.exception.ProductErrorCode.PRODUCT_NOT_FOUND));
-
-        // when & then
-        assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
-                .isInstanceOf(ProductException.class);
     }
 }


### PR DESCRIPTION
## Summary

"진행 중인 펀딩이 있는 상품은 판매 중지(`INACTIVE`)를 할 수 없다"는 핵심 정책을 구현하였습니다. 이를 위해 외부 모듈(펀딩)과의 통신 구조를 정의하고, 도메인 내부의 상태 전이 규칙을 체계화했습니다.

---

## What's Changed

### 상품 상태 변경 제약 조건 추가
- 상품 상태를 INACTIVE(판매 중지)로 변경 시, `FundingClientPort`를 호출하여 해당 상품에 대해 '진행 중인 펀딩'이 존재하는지 확인하는 검증 로직 도입.
- 진행 중이거나 달성되어 수령자 수락 전 상태인 펀딩이 존재할 경우 예외를 발생시켜 정책 위반 차단. -> 판매자가 품절 상태로 변경하기
```json
{
  "status": 400,
  "message": "진행 중이거나 수령자 수락 대기 중인 펀딩이 있습니다.",
  "code": "P210"
}
```

### 모듈 간 통신 구조 설계 (Ports & Adapters)
- 펀딩 모듈의 상태를 조회하기 위한 FundingClientPort 인터페이스와 이를 구현한 어댑터 구조 적용.
- 외부 모듈의 응답 결과에 따라 비즈니스 로직이 결정되도록 서비스 레이어에서 흐름 제어.
---

## Future Improvements

- 상태 머신 고도화: 현재 엔티티 내부에 구현된 상태 전이 맵을 별도의 컴포넌트로 분리하거나, Enum 내부의 로직으로 더 깊게 캡슐화하여 확장성을 높일 계획입니다.
---

### Linked Issues

- closes #279 
