### PR TITLE
Spring Modulith event_publication 테이블 JPA 매핑 실패 수정

### DIFF
--- a/bootstrap/api-server/build.gradle.kts
+++ b/bootstrap/api-server/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("org.springframework.retry:spring-retry")
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation(libs.spring.modulith.kafka)
+    implementation(libs.spring.modulith.jpa)
     implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
 
     runtimeOnly(libs.h2)
@@ -34,7 +35,6 @@ dependencies {
     runtimeOnly(libs.micrometer.prometheus)
 
     testImplementation(libs.spring.boot.starter.test)
-    testImplementation(libs.spring.modulith.jpa)
     testImplementation(libs.rest.assured)
     testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("org.awaitility:awaitility")

--- a/bootstrap/api-server/src/main/java/app/giftify/GiftifyApplication.java
+++ b/bootstrap/api-server/src/main/java/app/giftify/GiftifyApplication.java
@@ -2,6 +2,7 @@ package app.giftify;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
@@ -23,7 +24,12 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "walletHistory"
 })
 @EnableJpaRepositories(basePackages = {
-        "app.giftify"
+        "app.giftify",
+        "org.springframework.modulith.events.jpa"
+})
+@EntityScan(basePackages = {
+        "app.giftify",
+        "org.springframework.modulith.events.jpa"
 })
 @EnableElasticsearchRepositories(basePackages = "app.giftify")
 @EnableRetry


### PR DESCRIPTION
## Summary

프로덕션 환경에서 Spring Modulith의 `event_publication` 테이블 관련 JPA 엔티티(`DefaultJpaEventPublication`)가 인식되지 않는 문제를 수정합니다.

두 가지 원인이 있었습니다:
1. `spring-modulith-starter-jpa`가 `testImplementation`으로만 선언되어 런타임 클래스패스에서 누락
2. `@EnableJpaRepositories`의 스캔 범위가 `app.giftify`로 한정되어 `org.springframework.modulith.events.jpa` 패키지의 엔티티를 인식하지 못함

리뷰어 관점: 의존성 스코프 변경이 다른 모듈에 영향을 주는지, `@EntityScan` 추가가 기존 자동 설정과 충돌하지 않는지 확인 부탁드립니다.

---

## What's Changed

### 1. 의존성 스코프 수정 (`build.gradle.kts`)
- `testImplementation(libs.spring.modulith.jpa)` → `implementation(libs.spring.modulith.jpa)`
- 런타임에 `DefaultJpaEventPublication` 엔티티가 클래스패스에 포함되도록 변경

### 2. JPA 엔티티 스캔 범위 확장 (`GiftifyApplication.java`)
- `@EnableJpaRepositories`에 `org.springframework.modulith.events.jpa` 패키지 추가
- `@EntityScan` 어노테이션 신규 추가 (동일 패키지 범위)

---

## Decisions & Trade-offs

### 왜 `@EntityScan`도 함께 추가했는가?
- `@EnableJpaRepositories`만으로는 Repository만 스캔되고 엔티티 스캔은 보장되지 않음
- `@EntityScan`을 명시적으로 추가하여 Spring Boot 자동 설정이 비활성화된 환경에서도 엔티티 등록을 보장
- 현재 테스트 환경에서는 전이 의존성 + 자동 설정으로 동작했지만, 프로덕션 안정성을 위해 명시적 선언 채택

### 기존 전이 의존성으로 동작하던 이유
- `bc/core`, `bc/settlement`, `bc/notification`에 이미 `implementation` 스코프로 선언되어 있어 클래스 자체는 런타임에 존재
- 그러나 JPA 엔티티 스캔 범위(`app.giftify`)에 포함되지 않아 매핑 실패

---

## Future Improvements

- `bc/core`, `bc/notification`의 하드코딩된 버전(`spring-modulith-starter-jpa:1.3.1`)을 `libs.spring.modulith.jpa`로 통일하는 것을 검토

---

### Linked Issues

- Spring Modulith event_publication 테이블 런타임 매핑 실패 핫픽스