### PR TITLE
암시적으로 누락되어 있던 PG 결제 취소 통합 및 부분 취소 지원

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,6 +29,8 @@ DB_PASSWORD=your-secure-password
 TOSSPAYMENTS_SECRET_KEY=test_sk_xxxxxxxx
 #TOSSPAYMENTS_WEBHOOK_SECRET_KEY=whsk_xxxxxxxx
 # TOSSPAYMENTS_API_BASE_URL=https://api.tosspayments.com  # 기본값 사용 시 생략 가능
+# TOSSPAYMENTS_TIMEOUT_CONNECT=5s   # 기본값 5초
+# TOSSPAYMENTS_TIMEOUT_READ=30s     # 기본값 30초
 
 # -------- Grafana 설정 (docker-compose 모니터링용) --------
 GF_SECURITY_ADMIN_USER=admin

--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/event/OrderCancelEventHandler.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/event/OrderCancelEventHandler.java
@@ -1,21 +1,13 @@
 package app.giftify.payment.adapter.inbound.event;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
+import static app.giftify.payment.domain.SystemConstants.*;
 
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import app.giftify.payment.application.outbound.CancelRepository;
-import app.giftify.payment.application.outbound.PaymentRepository;
-import app.giftify.payment.domain.Cancel;
-import app.giftify.payment.domain.Payment;
-import app.giftify.payment.domain.PaymentErrorCode;
-import app.giftify.payment.domain.PaymentException;
-import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.payment.application.inbound.CancelPaymentCommand;
+import app.giftify.payment.application.inbound.CancelPaymentUseCase;
 import app.giftify.shared.domain.event.order.OrderCancelRequestedEvent;
-import app.giftify.shared.domain.type.CancelType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,47 +16,22 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class OrderCancelEventHandler {
 
-	private final PaymentRepository paymentRepository;
-	private final CancelRepository cancelRepository;
-	private final EventPublisher eventPublisher;
+	private final CancelPaymentUseCase cancelPaymentUseCase;
 
 	@ApplicationModuleListener
 	public void handle(OrderCancelRequestedEvent event) {
-		log.info("[OrderCancelEventHandler] 주문 취소 요청 이벤트 수신. orderId={}, paymentId={}, cancelAmount={}",
+		log.info("[OrderCancelEventHandler] 주문 취소 요청 수신. orderId={}, paymentId={}, cancelAmount={}",
 			event.getOrderId(), event.getPaymentId(), event.getCancelAmount());
 
-		Payment payment = paymentRepository.findById(event.getPaymentId())
-			.orElseThrow(() -> new PaymentException(
-				PaymentErrorCode.PAYMENT_NOT_FOUND,
-				"[OrderCancelEventHandler] Payment를 찾을 수 없습니다. paymentId=" + event.getPaymentId()
-			));
-
-		String transactionKey = resolveTransactionKey(payment);
-
-		payment.markAsPartiallyCanceled(transactionKey, event.getCancelAmount(), CancelType.REFUND, "주문 취소");
-
-		Cancel cancel = Cancel.create(
-			payment.getId(),
-			transactionKey,
-			event.getCancelAmount(),
+		CancelPaymentCommand command = CancelPaymentCommand.withAmount(
+			event.getPaymentId(),
+			SYSTEM_REQUESTER_ID,
 			"주문 취소",
-			LocalDateTime.now()
+			event.getCancelAmount()
 		);
-		cancelRepository.save(cancel);
 
-		paymentRepository.save(payment);
-		var domainEvents = payment.pullEvents();
-		domainEvents.forEach(eventPublisher::publish);
+		cancelPaymentUseCase.cancel(command);
 
-		log.info("[OrderCancelEventHandler] 주문 취소 처리 완료. paymentId={}, status={}, refundedAmount={}",
-			payment.getId(), payment.getStatus(), payment.getRefundedAmount());
-	}
-
-	private String resolveTransactionKey(Payment payment) {
-		if (!payment.getMethod().requiresPg()) {
-			return "internal-" + UUID.randomUUID();
-		}
-		throw new UnsupportedOperationException(
-			"PG cancel not yet supported for method: " + payment.getMethod());
+		log.info("[OrderCancelEventHandler] 주문 취소 처리 위임 완료. paymentId={}", event.getPaymentId());
 	}
 }

--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
@@ -1,11 +1,12 @@
 package app.giftify.payment.adapter.inbound.scheduler;
 
-import static app.giftify.payment.domain.SystemConstants.SYSTEM_REQUESTER_ID;
+import static app.giftify.payment.domain.SystemConstants.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PaymentTimeoutScheduler {
 
 	private static final String TIMEOUT_REASON = "TIMEOUT";
+	private static final int BATCH_SIZE = 100;
 
 	private final CancelPaymentUseCase cancelPaymentUseCase;
 	private final PaymentRepository paymentRepository;
@@ -29,30 +31,35 @@ public class PaymentTimeoutScheduler {
 	@Value("${payment.timeout.minutes:30}")
 	private int timeoutMinutes;
 
-	@Scheduled(fixedDelayString = "${payment.timeout.check-interval:60000}")
+	@Scheduled(fixedDelayString = "${payment.timeout.check-interval:600000}")
 	public void cancelExpiredPayments() {
 		LocalDateTime threshold = LocalDateTime.now().minusMinutes(timeoutMinutes);
-		List<Payment> expiredPayments = paymentRepository.findPendingPaymentsBefore(threshold);
+		int totalCanceled = 0;
 
-		if (expiredPayments.isEmpty()) {
-			log.debug("[Payment] 만료된 결제가 없습니다. threshold={}", threshold);
-			return;
-		}
+		Slice<Payment> slice;
+		do {
+			slice = paymentRepository.findPendingPaymentsBefore(threshold, PageRequest.of(0,
+				BATCH_SIZE));
 
-		log.info("[Payment] 만료된 결제 {}건 자동 취소 시작. threshold={}", expiredPayments.size(), threshold);
-
-		for (Payment payment : expiredPayments) {
-			try {
-				CancelPaymentCommand command = new CancelPaymentCommand(
-					payment.getId(),
-					SYSTEM_REQUESTER_ID,
-					TIMEOUT_REASON
-				);
-				cancelPaymentUseCase.cancel(command);
-				log.info("[Payment] 결제 타임아웃 처리 완료. paymentId={}", payment.getId());
-			} catch (Exception e) {
-				log.error("[Payment] 결제 자동 취소 실패. paymentId={}", payment.getId(), e);
+			for (Payment payment : slice.getContent()) {
+				try {
+					CancelPaymentCommand command = new CancelPaymentCommand(
+						payment.getId(),
+						SYSTEM_REQUESTER_ID,
+						TIMEOUT_REASON
+					);
+					cancelPaymentUseCase.cancel(command);
+					totalCanceled++;
+				} catch (Exception e) {
+					log.error("[Payment] 결제 자동 취소 실패. paymentId={}", payment.getId(), e);
+				}
 			}
+		} while (slice.hasNext());
+
+		if (totalCanceled > 0) {
+			log.info("[Payment] 만료된 결제 {}건 자동 취소 완료. threshold={}", totalCanceled,
+				threshold);
 		}
 	}
+
 }

--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
@@ -43,7 +43,7 @@ public class PaymentTimeoutScheduler {
 
 			for (Payment payment : slice.getContent()) {
 				try {
-					CancelPaymentCommand command = new CancelPaymentCommand(
+					CancelPaymentCommand command = CancelPaymentCommand.full( // 스케쥴러에 의한 취소는 완료되지 못한 결제에 대한 전액 취소이므로
 						payment.getId(),
 						SYSTEM_REQUESTER_ID,
 						TIMEOUT_REASON

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/JpaPaymentRepository.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/JpaPaymentRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,7 +16,9 @@ import app.giftify.payment.domain.PaymentStatus;
 @Repository("paymentBcJpaPaymentRepository")
 public interface JpaPaymentRepository extends JpaRepository<JpaPayment, Long> {
 
-	List<JpaPayment> findByStatusAndCreatedAtBefore(PaymentStatus status, LocalDateTime threshold);
+	Slice<JpaPayment> findByStatusAndCreatedAtBefore(
+		PaymentStatus status, LocalDateTime threshold, Pageable pageable
+	);
 
 	Optional<JpaPayment> findByPaymentKey(String paymentKey);
 

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentRepositoryAdapter.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentRepositoryAdapter.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,13 +58,16 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
 	}
 
 	@Override
-	@Transactional(readOnly = true)
-	public List<Payment> findPendingPaymentsBefore(LocalDateTime threshold) {
-		return jpaPaymentRepository.findByStatusAndCreatedAtBefore(PaymentStatus.PENDING, threshold)
-			.stream()
+	public Slice<Payment> findPendingPaymentsBefore(LocalDateTime threshold, Pageable pageable) {
+		Slice<JpaPayment> slice = jpaPaymentRepository.findByStatusAndCreatedAtBefore(
+			PaymentStatus.PENDING, threshold, pageable
+		);
+		List<Payment> payments = slice.getContent().stream()
 			.map(paymentMapper::toDomain)
 			.toList();
+		return new SliceImpl<>(payments, pageable, slice.hasNext());
 	}
+
 
 	@Override
 	@Transactional(readOnly = true)

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentRepositoryAdapter.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/PaymentRepositoryAdapter.java
@@ -58,6 +58,7 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Slice<Payment> findPendingPaymentsBefore(LocalDateTime threshold, Pageable pageable) {
 		Slice<JpaPayment> slice = jpaPaymentRepository.findByStatusAndCreatedAtBefore(
 			PaymentStatus.PENDING, threshold, pageable
@@ -67,7 +68,6 @@ public class PaymentRepositoryAdapter implements PaymentRepository {
 			.toList();
 		return new SliceImpl<>(payments, pageable, slice.hasNext());
 	}
-
 
 	@Override
 	@Transactional(readOnly = true)

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/config/TossPaymentsConfig.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/config/TossPaymentsConfig.java
@@ -1,7 +1,6 @@
 package app.giftify.payment.adapter.outbound.pg.config;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.Base64;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -43,15 +42,14 @@ public class TossPaymentsConfig {
 			.baseUrl(properties.getApi().getBaseUrl())
 			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 			.defaultHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedCredentials)
-			.requestFactory(clientHttpRequestFactory())
+			.requestFactory(clientHttpRequestFactory(properties))
 			.build();
 	}
 
-	private ClientHttpRequestFactory clientHttpRequestFactory() {
+	private ClientHttpRequestFactory clientHttpRequestFactory(TossPaymentsProperties properties) {
 		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-		factory.setConnectTimeout(Duration.ofSeconds(5));
-		factory.setReadTimeout(Duration.ofSeconds(30));
-
+		factory.setConnectTimeout(properties.getTimeout().getConnect());
+		factory.setReadTimeout(properties.getTimeout().getRead());
 		return factory;
 	}
 

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/config/TossPaymentsProperties.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/config/TossPaymentsProperties.java
@@ -1,5 +1,7 @@
 package app.giftify.payment.adapter.outbound.pg.config;
 
+import java.time.Duration;
+
 import lombok.Data;
 
 @Data
@@ -7,9 +9,16 @@ public class TossPaymentsProperties {
 
 	private Api api = new Api();
 	private String secretKey;
+	private Timeout timeout = new Timeout();
 
 	@Data
 	public static class Api {
 		private String baseUrl = "https://api.tosspayments.com";
+	}
+
+	@Data
+	public static class Timeout {
+		private Duration connect = Duration.ofSeconds(5);
+		private Duration read = Duration.ofSeconds(30);
 	}
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/CancelPaymentService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/CancelPaymentService.java
@@ -1,18 +1,23 @@
 package app.giftify.payment.application;
 
-import static app.giftify.payment.domain.SystemConstants.SYSTEM_REQUESTER_ID;
+import static app.giftify.payment.domain.SystemConstants.*;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import app.giftify.payment.adapter.outbound.pg.TossCancelResult;
 import app.giftify.payment.application.inbound.CancelPaymentCommand;
 import app.giftify.payment.application.inbound.CancelPaymentUseCase;
+import app.giftify.payment.application.outbound.PaymentFieldEncryptor;
+import app.giftify.payment.application.outbound.PaymentGateway;
 import app.giftify.payment.application.outbound.PaymentRepository;
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
+import app.giftify.payment.domain.PaymentStatus;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.type.CancelType;
 import lombok.extern.slf4j.Slf4j;
@@ -25,14 +30,18 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional
 public class CancelPaymentService implements CancelPaymentUseCase {
 	private final PaymentRepository paymentRepository;
+	private final PaymentGateway paymentGateway;
 	private final EventPublisher eventPublisher;
+	private final PaymentFieldEncryptor encryptor;
 
 	public CancelPaymentService(
-		PaymentRepository paymentRepository,
-		EventPublisher eventPublisher
+		PaymentRepository paymentRepository, PaymentGateway paymentGateway,
+		EventPublisher eventPublisher, PaymentFieldEncryptor encryptor
 	) {
 		this.paymentRepository = paymentRepository;
+		this.paymentGateway = paymentGateway;
 		this.eventPublisher = eventPublisher;
+		this.encryptor = encryptor;
 	}
 
 	@Override
@@ -44,21 +53,41 @@ public class CancelPaymentService implements CancelPaymentUseCase {
 				"[CancelPaymentService] 결제를 찾을 수 없습니다. paymentId=" + command.paymentId()
 			));
 
-		// 2. 권한 검증 (시스템 호출자는 스킵)
+		// 2. 권한 검증 (시스템 권한자는 검증 스킵)
 		if (!Objects.equals(command.requesterId(), SYSTEM_REQUESTER_ID)
 			&& !payment.isOwnedBy(command.requesterId())) {
 			throw new PaymentException(
 				PaymentErrorCode.UNAUTHORIZED_ACCESS,
-				"[CancelPaymentService] 결제 취소 권한이 없습니다. requesterId=" + command.requesterId()
+				"[CancelPaymentService] 결제 취소 권한이 없습니다. requesterId=" +
+					command.requesterId()
 			);
 		}
 
-		// 3. 상태 변경 (도메인 메서드 — 내부적으로 registerEvent 호출)
-		payment.markAsCanceled(CancelType.CANCEL, command.reason());
+		// 3. 상태에 따른 취소 처리
+		if (payment.getStatus() == PaymentStatus.PAID) {
+			String decryptedPaymentKey = encryptor.decrypt(payment.getPaymentKey());
 
-		// 4. 도메인 이벤트 확보 → 저장 → 발행
+			TossCancelResult pgResult = paymentGateway.cancel(
+				decryptedPaymentKey, command.reason(), null
+			);
+
+			if (!pgResult.success()) {
+				payment.recordCancelFailed(pgResult.errorMessage(), LocalDateTime.now());
+				var failEvents = payment.pullEvents();
+				paymentRepository.save(payment);
+				failEvents.forEach(eventPublisher::publish);
+				return;
+			}
+
+			payment.markAsCanceled(CancelType.REFUND, command.reason());
+		} else {
+			payment.markAsCanceled(CancelType.CANCEL, command.reason());
+		}
+
+		// 4. 성공 시 저장 + 이벤트 발행
 		var domainEvents = payment.pullEvents();
 		paymentRepository.save(payment);
 		domainEvents.forEach(eventPublisher::publish);
 	}
+
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/CancelPaymentService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/CancelPaymentService.java
@@ -11,34 +11,36 @@ import org.springframework.transaction.annotation.Transactional;
 import app.giftify.payment.adapter.outbound.pg.TossCancelResult;
 import app.giftify.payment.application.inbound.CancelPaymentCommand;
 import app.giftify.payment.application.inbound.CancelPaymentUseCase;
+import app.giftify.payment.application.outbound.CancelRepository;
 import app.giftify.payment.application.outbound.PaymentFieldEncryptor;
 import app.giftify.payment.application.outbound.PaymentGateway;
 import app.giftify.payment.application.outbound.PaymentRepository;
+import app.giftify.payment.domain.Cancel;
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
-import app.giftify.payment.domain.PaymentStatus;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.type.CancelType;
+import app.giftify.shared.domain.vo.Money;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * 결제 취소 UseCase 구현체.
- */
 @Slf4j
 @Service
 @Transactional
 public class CancelPaymentService implements CancelPaymentUseCase {
 	private final PaymentRepository paymentRepository;
+	private final CancelRepository cancelRepository;
 	private final PaymentGateway paymentGateway;
 	private final EventPublisher eventPublisher;
 	private final PaymentFieldEncryptor encryptor;
 
 	public CancelPaymentService(
-		PaymentRepository paymentRepository, PaymentGateway paymentGateway,
-		EventPublisher eventPublisher, PaymentFieldEncryptor encryptor
+		PaymentRepository paymentRepository, CancelRepository cancelRepository,
+		PaymentGateway paymentGateway, EventPublisher eventPublisher,
+		PaymentFieldEncryptor encryptor
 	) {
 		this.paymentRepository = paymentRepository;
+		this.cancelRepository = cancelRepository;
 		this.paymentGateway = paymentGateway;
 		this.eventPublisher = eventPublisher;
 		this.encryptor = encryptor;
@@ -46,48 +48,85 @@ public class CancelPaymentService implements CancelPaymentUseCase {
 
 	@Override
 	public void cancel(CancelPaymentCommand command) {
-		// 1. 결제 조회
 		Payment payment = paymentRepository.findById(command.paymentId())
 			.orElseThrow(() -> new PaymentException(
 				PaymentErrorCode.PAYMENT_NOT_FOUND,
 				"[CancelPaymentService] 결제를 찾을 수 없습니다. paymentId=" + command.paymentId()
 			));
 
-		// 2. 권한 검증 (시스템 권한자는 검증 스킵)
 		if (!Objects.equals(command.requesterId(), SYSTEM_REQUESTER_ID)
 			&& !payment.isOwnedBy(command.requesterId())) {
 			throw new PaymentException(
 				PaymentErrorCode.UNAUTHORIZED_ACCESS,
-				"[CancelPaymentService] 결제 취소 권한이 없습니다. requesterId=" +
-					command.requesterId()
+				"[CancelPaymentService] 결제 취소 권한이 없습니다. requesterId=" + command.requesterId()
 			);
 		}
 
-		// 3. 상태에 따른 취소 처리
-		if (payment.getStatus() == PaymentStatus.PAID) {
-			String decryptedPaymentKey = encryptor.decrypt(payment.getPaymentKey());
-
-			TossCancelResult pgResult = paymentGateway.cancel(
-				decryptedPaymentKey, command.reason(), null
-			);
-
-			if (!pgResult.success()) {
-				payment.recordCancelFailed(pgResult.errorMessage(), LocalDateTime.now());
-				var failEvents = payment.pullEvents();
-				paymentRepository.save(payment);
-				failEvents.forEach(eventPublisher::publish);
-				return;
-			}
-
-			payment.markAsCanceled(CancelType.REFUND, command.reason());
+		if (command.cancelAmount() != null) {
+			handlePartialCancel(payment, command);
 		} else {
-			payment.markAsCanceled(CancelType.CANCEL, command.reason());
+			handleFullCancel(payment, command);
+		}
+	}
+
+	private void handleFullCancel(Payment payment, CancelPaymentCommand command) {
+		CancelType cancelType = payment.resolveCancelType();
+
+		if (cancelType == CancelType.REFUND) {
+			TossCancelResult pgResult = callPgCancel(payment, command.reason(), null);
+			if (pgResult == null) return;
+
+			payment.markAsCanceled(cancelType, command.reason());
+			saveCancelRecord(payment, pgResult.lastTransactionKey(), payment.getPaidAmount(), command.reason());
+		} else {
+			payment.markAsCanceled(cancelType, command.reason());
 		}
 
-		// 4. 성공 시 저장 + 이벤트 발행
+		saveAndPublish(payment);
+	}
+
+	private void handlePartialCancel(Payment payment, CancelPaymentCommand command) {
+		if (payment.resolveCancelType() != CancelType.REFUND) {
+			throw new PaymentException(PaymentErrorCode.NOT_CANCELABLE,
+				"[CancelPaymentService] 부분 취소 불가능한 상태입니다: " + payment.getStatus());
+		}
+
+		Money cancelAmount = command.cancelAmount();
+		TossCancelResult pgResult = callPgCancel(payment, command.reason(), cancelAmount);
+		if (pgResult == null) return;
+
+		payment.markAsPartiallyCanceled(
+			pgResult.lastTransactionKey(), cancelAmount, CancelType.REFUND, command.reason()
+		);
+		saveCancelRecord(payment, pgResult.lastTransactionKey(), cancelAmount, command.reason());
+
+		saveAndPublish(payment);
+	}
+
+	private TossCancelResult callPgCancel(Payment payment, String reason, Money cancelAmount) {
+		String decryptedPaymentKey = encryptor.decrypt(payment.getPaymentKey());
+		TossCancelResult pgResult = paymentGateway.cancel(decryptedPaymentKey, reason, cancelAmount);
+
+		if (!pgResult.success()) {
+			payment.recordCancelFailed(pgResult.errorMessage(), LocalDateTime.now());
+			var failEvents = payment.pullEvents();
+			paymentRepository.save(payment);
+			failEvents.forEach(eventPublisher::publish);
+			return null;
+		}
+		return pgResult;
+	}
+
+	private void saveCancelRecord(Payment payment, String transactionKey, Money cancelAmount, String reason) {
+		Cancel cancel = Cancel.create(
+			payment.getId(), transactionKey, cancelAmount, reason, LocalDateTime.now()
+		);
+		cancelRepository.save(cancel);
+	}
+
+	private void saveAndPublish(Payment payment) {
 		var domainEvents = payment.pullEvents();
 		paymentRepository.save(payment);
 		domainEvents.forEach(eventPublisher::publish);
 	}
-
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/inbound/CancelPaymentCommand.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/inbound/CancelPaymentCommand.java
@@ -2,11 +2,13 @@ package app.giftify.payment.application.inbound;
 
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
+import app.giftify.shared.domain.vo.Money;
 
 public record CancelPaymentCommand(
 	Long paymentId,
 	Long requesterId,
-	String reason
+	String reason,
+	Money cancelAmount
 ) {
 	public CancelPaymentCommand {
 		if (paymentId == null) {
@@ -17,6 +19,20 @@ public record CancelPaymentCommand(
 			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
 				"[CancelPaymentCommand] requesterId는 필수입니다.");
 		}
-		// reason은 optional - 검증하지 않음
+	}
+
+	public static CancelPaymentCommand full(Long paymentId, Long requesterId, String reason) {
+		return new CancelPaymentCommand(paymentId, requesterId, reason, null);
+	}
+
+	public static CancelPaymentCommand partial(
+		Long paymentId, Long requesterId, String reason, Money cancelAmount
+	) {
+		if (cancelAmount == null || !cancelAmount.isPositive()) {
+			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+				"[CancelPaymentCommand] 취소 금액은 양수여야 합니다."
+			);
+		}
+		return new CancelPaymentCommand(paymentId, requesterId, reason, cancelAmount);
 	}
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/inbound/CancelPaymentCommand.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/inbound/CancelPaymentCommand.java
@@ -25,7 +25,7 @@ public record CancelPaymentCommand(
 		return new CancelPaymentCommand(paymentId, requesterId, reason, null);
 	}
 
-	public static CancelPaymentCommand partial(
+	public static CancelPaymentCommand withAmount(
 		Long paymentId, Long requesterId, String reason, Money cancelAmount
 	) {
 		if (cancelAmount == null || !cancelAmount.isPositive()) {

--- a/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentRepository.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/outbound/PaymentRepository.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentStatus;
 import app.giftify.shared.api.paging.Page;
@@ -14,7 +17,7 @@ public interface PaymentRepository {
 
 	Optional<Payment> findById(Long paymentId);
 
-	List<Payment> findPendingPaymentsBefore(LocalDateTime threshold);
+	Slice<Payment> findPendingPaymentsBefore(LocalDateTime threshold, Pageable pageable);
 
 	Optional<Payment> findByPaymentKey(String paymentKey);
 

--- a/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
+++ b/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
@@ -85,6 +85,13 @@ public class Payment extends BaseDomainModel {
 		));
 	}
 
+	// charged (PAID, PARTIALLY_CANCELED) -> REFUND, uncharged (PENDING) -> CANCEL
+	public CancelType resolveCancelType() {
+		return (this.status == PaymentStatus.PAID || this.status == PaymentStatus.PARTIALLY_CANCELED)
+			? CancelType.REFUND
+			: CancelType.CANCEL;
+	}
+
 	public void markAsCanceled(CancelType cancelType, String reason) {
 		PaymentEventType eventType = (cancelType == CancelType.REFUND)
 			? PaymentEventType.CANCEL_AFTER_PAID

--- a/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/OrderCancelEventHandlerTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/OrderCancelEventHandlerTest.java
@@ -1,11 +1,8 @@
 package app.giftify.payment.adapter.inbound.event;
 
+import static app.giftify.payment.domain.SystemConstants.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,17 +12,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import app.giftify.payment.application.outbound.CancelRepository;
-import app.giftify.payment.application.outbound.PaymentRepository;
-import app.giftify.payment.domain.Cancel;
-import app.giftify.payment.domain.OrderItemSnapshot;
-import app.giftify.payment.domain.Payment;
-import app.giftify.payment.domain.PaymentStatus;
-import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.payment.application.inbound.CancelPaymentCommand;
+import app.giftify.payment.application.inbound.CancelPaymentUseCase;
 import app.giftify.shared.domain.event.order.OrderCancelRequestedEvent;
-import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
-import app.giftify.shared.domain.type.PaymentMethod;
-import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,83 +22,30 @@ import app.giftify.shared.domain.vo.Money;
 class OrderCancelEventHandlerTest {
 
 	@Mock
-	PaymentRepository paymentRepository;
-
-	@Mock
-	CancelRepository cancelRepository;
-
-	@Mock
-	EventPublisher eventPublisher;
+	CancelPaymentUseCase cancelPaymentUseCase;
 
 	@InjectMocks
 	OrderCancelEventHandler handler;
 
-	private Payment createPaidFundingPayment(Money paidAmount) {
-		OrderItemSnapshot item = new OrderItemSnapshot(100L, paidAmount, 200L);
-		return Payment.builder()
-			.id(1L)
-			.orderId(100L)
-			.orderNumber("ORD-001")
-			.memberId(10L)
-			.type(PaymentType.FUNDING)
-			.method(PaymentMethod.DEPOSIT)
-			.originAmount(paidAmount)
-			.paidAmount(paidAmount)
-			.refundedAmount(Money.zero())
-			.orderItems(List.of(item))
-			.status(PaymentStatus.PAID)
-			.paymentKey("payment-key-123")
-			.lastTransactionKey("txn-001")
-			.approveCode("approve-001")
-			.paidAt(LocalDateTime.now())
-			.createdAt(LocalDateTime.now())
-			.build();
-	}
-
 	@Test
-	@DisplayName("FUNDING 부분 취소 → PARTIALLY_CANCELED, Cancel 저장, PaymentCanceledEvent 발행")
-	void handle_FundingPartialCancel_Success() {
-		Payment payment = createPaidFundingPayment(Money.of(10000));
+	@DisplayName("주문 취소 이벤트를 수신하면 CancelPaymentUseCase에 partial 커맨드로 위임한다")
+	void handle_DelegatesToUseCase() {
+		// given
 		OrderCancelRequestedEvent event = new OrderCancelRequestedEvent(
 			100L, "ORD-001", 1L, "txn-001", Money.of(3000)
 		);
 
-		when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
-
+		// when
 		handler.handle(event);
 
-		assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PARTIALLY_CANCELED);
-		assertThat(payment.getRefundedAmount()).isEqualTo(Money.of(3000));
+		// then
+		ArgumentCaptor<CancelPaymentCommand> captor = ArgumentCaptor.forClass(CancelPaymentCommand.class);
+		verify(cancelPaymentUseCase).cancel(captor.capture());
 
-		ArgumentCaptor<Cancel> cancelCaptor = ArgumentCaptor.forClass(Cancel.class);
-		verify(cancelRepository).save(cancelCaptor.capture());
-		Cancel savedCancel = cancelCaptor.getValue();
-		assertThat(savedCancel.getPaymentId()).isEqualTo(1L);
-		assertThat(savedCancel.getCancelAmount()).isEqualTo(Money.of(3000));
-		assertThat(savedCancel.getCancelReason()).isEqualTo("주문 취소");
-		assertThat(savedCancel.getTransactionKey()).startsWith("internal-");
-
-		verify(paymentRepository).save(payment);
-		verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
-	}
-
-	@Test
-	@DisplayName("FUNDING 전체 취소 → CANCELED")
-	void handle_FundingFullCancel_Success() {
-		Payment payment = createPaidFundingPayment(Money.of(10000));
-		OrderCancelRequestedEvent event = new OrderCancelRequestedEvent(
-			100L, "ORD-001", 1L, "txn-001", Money.of(10000)
-		);
-
-		when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
-
-		handler.handle(event);
-
-		assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
-		assertThat(payment.getRefundedAmount()).isEqualTo(Money.of(10000));
-
-		verify(cancelRepository).save(any(Cancel.class));
-		verify(paymentRepository).save(payment);
-		verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
+		CancelPaymentCommand command = captor.getValue();
+		assertThat(command.paymentId()).isEqualTo(1L);
+		assertThat(command.requesterId()).isEqualTo(SYSTEM_REQUESTER_ID);
+		assertThat(command.reason()).isEqualTo("주문 취소");
+		assertThat(command.cancelAmount()).isEqualTo(Money.of(3000));
 	}
 }

--- a/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
@@ -20,9 +20,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import app.giftify.payment.adapter.outbound.pg.TossCancelResult;
 import app.giftify.payment.application.inbound.CancelPaymentCommand;
+import app.giftify.payment.application.outbound.CancelRepository;
 import app.giftify.payment.application.outbound.PaymentFieldEncryptor;
 import app.giftify.payment.application.outbound.PaymentGateway;
 import app.giftify.payment.application.outbound.PaymentRepository;
+import app.giftify.payment.domain.Cancel;
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
@@ -41,6 +43,9 @@ class CancelPaymentServiceTest {
 
 	@Mock
 	private PaymentRepository paymentRepository;
+
+	@Mock
+	private CancelRepository cancelRepository;
 
 	@Mock
 	private EventPublisher eventPublisher;
@@ -146,8 +151,8 @@ class CancelPaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("PAID 상태 결제 취소 시 PG 취소 API를 호출한다")
-		void cancel_WhenPaid_CallsPgCancel() {
+		@DisplayName("PAID 상태 결제 전액 취소 시 PG 취소 + Cancel 이력을 생성한다")
+		void cancel_WhenPaid_CallsPgCancelAndCreatesCancelRecord() {
 			// given
 			Long paymentId = 1L;
 			Long memberId = 100L;
@@ -164,10 +169,17 @@ class CancelPaymentServiceTest {
 			cancelPaymentService.cancel(command);
 
 			// then
-			verify(encryptor).decrypt("encrypted-payment-key");
 			verify(paymentGateway).cancel("raw-payment-key", "고객 변심", null);
 			verify(paymentRepository).save(any(Payment.class));
 			verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
+
+			ArgumentCaptor<Cancel> cancelCaptor = ArgumentCaptor.forClass(Cancel.class);
+			verify(cancelRepository).save(cancelCaptor.capture());
+			Cancel savedCancel = cancelCaptor.getValue();
+			assertThat(savedCancel.getPaymentId()).isEqualTo(paymentId);
+			assertThat(savedCancel.getTransactionKey()).isEqualTo("txn-cancel-123");
+			assertThat(savedCancel.getCancelAmount()).isEqualTo(Money.of(10000));
+			assertThat(savedCancel.getCancelReason()).isEqualTo("고객 변심");
 		}
 
 		@Test
@@ -317,6 +329,112 @@ class CancelPaymentServiceTest {
 			assertThat(event.data().amount()).isEqualTo(Money.of(10000));
 			assertThat(event.data().reason()).isEqualTo(reason);
 			assertThat(event.time()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("PENDING 상태 전액 취소 시 Cancel 이력을 생성하지 않는다")
+		void cancel_WhenPending_DoesNotCreateCancelRecord() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, "고객 요청");
+
+			Payment payment = createPendingPayment(paymentId, memberId, "order-123");
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			cancelPaymentService.cancel(command);
+
+			// then
+			verify(cancelRepository, never()).save(any(Cancel.class));
+			verify(paymentRepository).save(any(Payment.class));
+			verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("부분 취소")
+	class PartialCancelTests {
+
+		@Test
+		@DisplayName("PAID 상태에서 부분 취소 시 PG 부분 환불 + Cancel 이력을 생성한다")
+		void partialCancel_WhenPaid_Success() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			Money cancelAmount = Money.of(3000);
+			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
+			CancelPaymentCommand command = CancelPaymentCommand.withAmount(paymentId, memberId, "부분 환불", cancelAmount);
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
+			given(paymentGateway.cancel(eq("raw-payment-key"), eq("부분 환불"), eq(cancelAmount)))
+				.willReturn(TossCancelResult.success("raw-payment-key", "txn-partial-123", List.of()));
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			cancelPaymentService.cancel(command);
+
+			// then
+			verify(paymentGateway).cancel("raw-payment-key", "부분 환불", cancelAmount);
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PARTIALLY_CANCELED);
+
+			ArgumentCaptor<Cancel> cancelCaptor = ArgumentCaptor.forClass(Cancel.class);
+			verify(cancelRepository).save(cancelCaptor.capture());
+			Cancel savedCancel = cancelCaptor.getValue();
+			assertThat(savedCancel.getCancelAmount()).isEqualTo(cancelAmount);
+			assertThat(savedCancel.getTransactionKey()).isEqualTo("txn-partial-123");
+
+			verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
+		}
+
+		@Test
+		@DisplayName("PENDING 상태에서 부분 취소를 요청하면 예외가 발생한다")
+		void partialCancel_WhenPending_ThrowsException() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			Payment payment = createPendingPayment(paymentId, memberId, "order-123");
+			CancelPaymentCommand command = CancelPaymentCommand.withAmount(paymentId, memberId, "부분 환불", Money.of(3000));
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+
+			// when & then
+			assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+				.isInstanceOf(PaymentException.class)
+				.extracting("errorCode")
+				.isEqualTo(PaymentErrorCode.NOT_CANCELABLE);
+		}
+
+		@Test
+		@DisplayName("부분 취소 PG 실패 시 상태를 유지하고 실패 이벤트를 발행한다")
+		void partialCancel_WhenPgFails_RecordsCancelFailed() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			Money cancelAmount = Money.of(3000);
+			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
+			CancelPaymentCommand command = CancelPaymentCommand.withAmount(paymentId, memberId, "부분 환불", cancelAmount);
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
+			given(paymentGateway.cancel(eq("raw-payment-key"), eq("부분 환불"), eq(cancelAmount)))
+				.willReturn(TossCancelResult.failure("CANCEL_AMOUNT_EXCEEDED", "취소 금액 초과"));
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			cancelPaymentService.cancel(command);
+
+			// then
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
+			verify(cancelRepository, never()).save(any(Cancel.class));
+
+			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+			verify(eventPublisher).publish(eventCaptor.capture());
+			assertThat(eventCaptor.getValue()).isInstanceOf(PaymentCancelFailedEvent.class);
 		}
 
 	}

--- a/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
@@ -18,14 +18,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import app.giftify.payment.adapter.outbound.pg.TossCancelResult;
 import app.giftify.payment.application.inbound.CancelPaymentCommand;
+import app.giftify.payment.application.outbound.PaymentFieldEncryptor;
+import app.giftify.payment.application.outbound.PaymentGateway;
 import app.giftify.payment.application.outbound.PaymentRepository;
 import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
 import app.giftify.payment.domain.PaymentStatus;
 import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
+import app.giftify.shared.domain.type.CancelType;
 import app.giftify.shared.domain.type.PaymentMethod;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
@@ -40,6 +45,12 @@ class CancelPaymentServiceTest {
 	@Mock
 	private EventPublisher eventPublisher;
 
+	@Mock
+	private PaymentGateway paymentGateway;
+
+	@Mock
+	private PaymentFieldEncryptor encryptor;
+
 	@InjectMocks
 	private CancelPaymentService cancelPaymentService;
 
@@ -50,6 +61,7 @@ class CancelPaymentServiceTest {
 			.orderId(123L)
 			.orderNumber(orderNumber)
 			.memberId(memberId)
+			.paymentKey("encrypted-payment-key")
 			.type(PaymentType.DEPOSIT_CHARGE)
 			.method(PaymentMethod.CARD)
 			.originAmount(Money.of(10000))
@@ -65,6 +77,7 @@ class CancelPaymentServiceTest {
 			.orderId(123L)
 			.orderNumber(orderNumber)
 			.memberId(memberId)
+			.paymentKey("encrypted-payment-key")
 			.type(PaymentType.DEPOSIT_CHARGE)
 			.method(PaymentMethod.CARD)
 			.originAmount(Money.of(10000))
@@ -73,6 +86,13 @@ class CancelPaymentServiceTest {
 			.status(PaymentStatus.PAID)
 			.paidAt(LocalDateTime.now())
 			.build();
+	}
+
+	private Payment createCanceledPayment(Long paymentId, Long memberId, String orderNumber) {
+		Payment payment = createPendingPayment(paymentId, memberId, orderNumber);
+		payment.markAsCanceled(CancelType.CANCEL, "이전 취소");
+		payment.pullEvents();  // 테스트에 불필요한 이벤트 비우기
+		return payment;
 	}
 
 	@Nested
@@ -126,6 +146,31 @@ class CancelPaymentServiceTest {
 		}
 
 		@Test
+		@DisplayName("PAID 상태 결제 취소 시 PG 취소 API를 호출한다")
+		void cancel_WhenPaid_CallsPgCancel() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
+			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 변심");
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
+			given(paymentGateway.cancel(eq("raw-payment-key"), eq("고객 변심"), isNull()))
+				.willReturn(TossCancelResult.success("raw-payment-key", "txn-cancel-123", List.of()));
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			cancelPaymentService.cancel(command);
+
+			// then
+			verify(encryptor).decrypt("encrypted-payment-key");
+			verify(paymentGateway).cancel("raw-payment-key", "고객 변심", null);
+			verify(paymentRepository).save(any(Payment.class));
+			verify(eventPublisher).publish(any(PaymentCanceledEvent.class));
+		}
+
+		@Test
 		@DisplayName("결제가 존재하지 않으면 예외가 발생한다")
 		void cancel_PaymentNotFound_ThrowsException() {
 			// given
@@ -167,14 +212,14 @@ class CancelPaymentServiceTest {
 		}
 
 		@Test
-		@DisplayName("취소 불가능한 상태(PAID)이면 예외가 발생한다")
+		@DisplayName("이미 취소된 결제를 다시 취소하면 예외가 발생한다")
 		void cancel_NotCancelableStatus_ThrowsException() {
 			// given
 			Long paymentId = 1L;
 			Long memberId = 100L;
 			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 요청");
 
-			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
+			Payment payment = createCanceledPayment(paymentId, memberId, "order-123");
 
 			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
 
@@ -185,6 +230,35 @@ class CancelPaymentServiceTest {
 				.isEqualTo(PaymentErrorCode.NOT_CANCELABLE);
 
 			verify(paymentRepository).findById(paymentId);
+		}
+
+		@Test
+		@DisplayName("PAID 상태에서 PG 취소가 실패하면 상태를 유지하고 실패 이벤트를 발행한다")
+		void cancel_WhenPgFails_RecordsCancelFailed() {
+			// given
+			Long paymentId = 1L;
+			Long memberId = 100L;
+			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
+			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 변심");
+
+			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
+			given(paymentGateway.cancel(eq("raw-payment-key"), eq("고객 변심"), isNull()))
+				.willReturn(TossCancelResult.failure("ALREADY_CANCELED", "이미 취소된 결제입니다"));
+			given(paymentRepository.save(any(Payment.class))).willAnswer(inv -> inv.getArgument(0));
+
+			// when
+			cancelPaymentService.cancel(command);
+
+			// then
+			verify(paymentGateway).cancel("raw-payment-key", "고객 변심", null);
+			verify(paymentRepository).save(any(Payment.class));
+
+			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+			verify(eventPublisher).publish(eventCaptor.capture());
+			assertThat(eventCaptor.getValue()).isInstanceOf(PaymentCancelFailedEvent.class);
+
+			assertThat(payment.getStatus()).isEqualTo(PaymentStatus.PAID);
 		}
 
 		@Test
@@ -208,7 +282,7 @@ class CancelPaymentServiceTest {
 
 			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
 			verify(eventPublisher).publish(eventCaptor.capture());
-			PaymentCanceledEvent event = (PaymentCanceledEvent) eventCaptor.getValue();
+			PaymentCanceledEvent event = (PaymentCanceledEvent)eventCaptor.getValue();
 
 			assertThat(event.data().reason()).isNull();
 		}
@@ -234,7 +308,7 @@ class CancelPaymentServiceTest {
 			// then
 			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
 			verify(eventPublisher).publish(eventCaptor.capture());
-			PaymentCanceledEvent event = (PaymentCanceledEvent) eventCaptor.getValue();
+			PaymentCanceledEvent event = (PaymentCanceledEvent)eventCaptor.getValue();
 
 			assertThat(event.data().paymentId()).isEqualTo(paymentId);
 			assertThat(event.data().memberId()).isEqualTo(memberId);

--- a/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/application/CancelPaymentServiceTest.java
@@ -106,7 +106,7 @@ class CancelPaymentServiceTest {
 			Long paymentId = 1L;
 			Long memberId = 100L;
 			String orderId = "order-123";
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 요청");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, "고객 요청");
 
 			Payment payment = createPendingPayment(paymentId, memberId, orderId);
 
@@ -129,7 +129,7 @@ class CancelPaymentServiceTest {
 			Long paymentId = 1L;
 			Long actualOwnerId = 100L;
 			String orderId = "order-123";
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, SYSTEM_REQUESTER_ID, "시스템 자동 취소");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, SYSTEM_REQUESTER_ID, "시스템 자동 취소");
 
 			Payment payment = createPendingPayment(paymentId, actualOwnerId, orderId);
 
@@ -152,7 +152,7 @@ class CancelPaymentServiceTest {
 			Long paymentId = 1L;
 			Long memberId = 100L;
 			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 변심");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, "고객 변심");
 
 			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
 			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
@@ -176,7 +176,7 @@ class CancelPaymentServiceTest {
 			// given
 			Long paymentId = 999L;
 			Long requesterId = 100L;
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, requesterId, "고객 요청");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, requesterId, "고객 요청");
 
 			given(paymentRepository.findById(paymentId)).willReturn(Optional.empty());
 
@@ -196,7 +196,7 @@ class CancelPaymentServiceTest {
 			Long paymentId = 1L;
 			Long actualOwnerId = 100L;
 			Long unauthorizedUserId = 200L;
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, unauthorizedUserId, "고객 요청");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, unauthorizedUserId, "고객 요청");
 
 			Payment payment = createPendingPayment(paymentId, actualOwnerId, "order-123");
 
@@ -217,7 +217,7 @@ class CancelPaymentServiceTest {
 			// given
 			Long paymentId = 1L;
 			Long memberId = 100L;
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 요청");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, "고객 요청");
 
 			Payment payment = createCanceledPayment(paymentId, memberId, "order-123");
 
@@ -239,7 +239,7 @@ class CancelPaymentServiceTest {
 			Long paymentId = 1L;
 			Long memberId = 100L;
 			Payment payment = createPaidPayment(paymentId, memberId, "order-123");
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, "고객 변심");
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, "고객 변심");
 
 			given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
 			given(encryptor.decrypt("encrypted-payment-key")).willReturn("raw-payment-key");
@@ -267,7 +267,7 @@ class CancelPaymentServiceTest {
 			// given
 			Long paymentId = 1L;
 			Long memberId = 100L;
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, null);
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, null);
 
 			Payment payment = createPendingPayment(paymentId, memberId, "order-123");
 
@@ -295,7 +295,7 @@ class CancelPaymentServiceTest {
 			Long memberId = 100L;
 			String orderNumber = "order-123";
 			String reason = "고객 변심";
-			CancelPaymentCommand command = new CancelPaymentCommand(paymentId, memberId, reason);
+			CancelPaymentCommand command = CancelPaymentCommand.full(paymentId, memberId, reason);
 
 			Payment payment = createPendingPayment(paymentId, memberId, orderNumber);
 


### PR DESCRIPTION
## Summary

  CancelPaymentService에 실제 PG(TossPayments) 취소 호출을 통합하고, 부분 취소를 지원합니다. 사실 MVP 스코프 내에서는안해도 되는거긴 한데, 안해 놓으면 로직 흐름이 헷갈려서 추가합니다. 
  기존에는 도메인 상태만 변경하고 PG 취소는 발생하지 않았던 구조를 개선하여, PAID/PARTIALLY_CANCELED 상태의 결제에 대해 PG 환불이 실행되도록 합니다.

  리뷰어는 **도메인 책임 분리**(Payment.resolveCancelType)와 **서비스 오케스트레이션 흐름**(PG 호출 → Cancel 엔티티 생성 → 이벤트 발행 순서)을 중점적으로 봐주시면 좋겠습니다.

  ---

  ## What's Changed

  - **CancelPaymentCommand**: cancelAmount 필드 추가, `full()` / `withAmount()` 팩토리 메서드 도입
  - **CancelPaymentService**: 전체취소/부분취소 분기, PG 취소 호출, Cancel 엔티티 생성, 실패 시 상태 기록
  - **Payment.resolveCancelType()**: 취소 유형(REFUND/CANCEL) 판단을 도메인으로 이동
  - **OrderCancelEventHandler**: 3개 의존성 → CancelPaymentUseCase 1개로 thin adapter 전환
  - **PaymentTimeoutScheduler**: 페이지네이션 적용 (Slice 기반)
  - **TossPaymentsConfig**: HTTP 타임아웃 외부화 (하드코딩 → properties)

  ---

  ## Decisions & Trade-offs

  - **`withAmount()` 네이밍**: 원래 `partial()`이었으나, OrderCancelEventHandler에서 전체 주문 취소 시에도 cancelAmount가 전달되므로 의미 중립적인 `withAmount()`로 변경. 도메인 내부에서 전체/부분을
  판단.
  - **SimpleClientHttpRequestFactory 유지**: 현재 트래픽 수준에서 커넥션 풀링 불필요. 타임아웃만 외부화하여 운영 대응력 확보. HttpComponents 전환은 TPS 증가 시 별도 작업으로.
  - **confirm/cancel 동일 RestClient**: cancel 전용 타임아웃 분리는 YAGNI. 운영 중 필요 시 `.env` 수정 + 재시작으로 대응 가능.

  ---

  ## Future Improvements

  - [ ] Phase 1B: 알림 핸들러 활성화 
  - [ ] Phase 1C: 암호화 테스트 보완
  - [ ] HttpComponentsClientHttpRequestFactory 전환 (트래픽 증가 시)
  - [ ] PG 취소 API 재시도 전략 (지수 백오프)
  - [ ] 모니터링 메트릭 추가 (cancel 성공/실패 비율, PG 응답 시간)
