### PR TITLE
모듈별로 하드코딩된 의존성을 Version Catalog로 통일 및 Modulith 1.3.12 패치

### DIFF
--- a/bc/catalog/build.gradle.kts
+++ b/bc/catalog/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 group = "app.giftify"
 version = "1.0.0-SNAPSHOT"
 
-val springModulithVersion = "1.3.1"
-
 repositories {
     mavenCentral()
 }
@@ -43,7 +41,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
 
     // Apache Commons
-    implementation("org.apache.commons:commons-lang3:3.17.0")
+    implementation(libs.commons.lang3)
 
     // Test
     testImplementation(libs.spring.boot.starter.test)
@@ -55,8 +53,9 @@ dependencies {
     testImplementation(libs.testcontainers.elasticsearch)
     testImplementation(libs.testcontainers.junit)
     testImplementation(libs.spring.boot.testcontainers)
+
     // Retry
-    implementation("org.springframework.retry:spring-retry")
+    implementation(libs.spring.retry)
     implementation(libs.spring.boot.starter.aop)
 }
 

--- a/bc/core/build.gradle.kts
+++ b/bc/core/build.gradle.kts
@@ -5,8 +5,6 @@ plugins {
 group = "app.giftify"
 version = "1.0.0-SNAPSHOT"
 
-val springModulithVersion = "1.3.1"
-
 repositories {
     mavenCentral()
 }
@@ -23,9 +21,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
-    // Spring Modulith (버전 명시)
-    implementation("org.springframework.modulith:spring-modulith-starter-core:$springModulithVersion")
-    implementation("org.springframework.modulith:spring-modulith-starter-jpa:$springModulithVersion")
+    // Spring Modulith
+    implementation(libs.spring.modulith.core)
+    implementation(libs.spring.modulith.jpa)
 
     // API Documentation
     implementation(libs.springdoc.openapi)
@@ -40,7 +38,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
 
     // Retry
-    implementation("org.springframework.retry:spring-retry")
+    implementation(libs.spring.retry)
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // Batch
@@ -48,9 +46,9 @@ dependencies {
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.springframework.modulith:spring-modulith-starter-test:$springModulithVersion")
+    testImplementation(libs.spring.modulith.test)
     testImplementation("org.springframework.security:spring-security-test")
-    testImplementation("com.tngtech.archunit:archunit-junit5:1.3.0")
+    testImplementation(libs.archunit)
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.batch:spring-batch-test")

--- a/bc/notification/build.gradle.kts
+++ b/bc/notification/build.gradle.kts
@@ -1,5 +1,3 @@
-val springModulithVersion = "1.3.1"
-
 dependencies {
     implementation(project(":bc:shared"))
     implementation(project(":support:common"))
@@ -9,14 +7,14 @@ dependencies {
 
     implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
-    implementation("org.springframework.modulith:spring-modulith-starter-core:$springModulithVersion")
-    implementation("org.springframework.modulith:spring-modulith-starter-jpa:$springModulithVersion")
+    implementation(libs.spring.modulith.core)
+    implementation(libs.spring.modulith.jpa)
 
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 
     testImplementation(libs.spring.boot.starter.test)
-    testImplementation("org.springframework.modulith:spring-modulith-starter-test:$springModulithVersion")
+    testImplementation(libs.spring.modulith.test)
     testCompileOnly(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 }

--- a/bc/settlement/build.gradle.kts
+++ b/bc/settlement/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     annotationProcessor(libs.lombok)
 
     // Retry
-    implementation("org.springframework.retry:spring-retry:2.0.2")
+    implementation(libs.spring.retry)
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // batch

--- a/bootstrap/api-server/build.gradle.kts
+++ b/bootstrap/api-server/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.spring.boot.starter.validation)
     implementation(libs.spring.boot.starter.actuator)
     implementation(libs.flyway.core)
-    implementation("org.springframework.retry:spring-retry")
+    implementation(libs.spring.retry)
     implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation(libs.spring.modulith.kafka)
     implementation(libs.spring.modulith.jpa)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,8 @@ lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 # =============================================================================
 java-jwt = { module = "com.auth0:java-jwt", version.ref = "jwt" }
 dotenv = { module = "io.github.cdimascio:dotenv-java", version.ref = "dotenv" }
+spring-retry = { module = "org.springframework.retry:spring-retry" }
+commons-lang3 = { module = "org.apache.commons:commons-lang3" }
 
 # =============================================================================
 # Testing

--- a/support/web/build.gradle.kts
+++ b/support/web/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation(libs.spring.boot.starter.web)
 
     // Retry
-    implementation("org.springframework.retry:spring-retry:2.0.2")
+    implementation(libs.spring.retry)
     implementation("org.springframework.boot:spring-boot-starter-aop")
 
     // Redis


### PR DESCRIPTION

## Summary

> flyway 마이그레이션 스크립트 정리에 앞서서, 각 프로젝트별로 개별 관리되던 종속성을 libs.versions.toml 을 참조하여 관리되도록 변경합니다.
-  각 모듈 build.gradle.kts에서 하드코딩되던 Spring Modulith, spring-retry, commons-lang3 의존성을 Version Catalog(libs.versions.toml)로 통일하고, Modulith를 1.3.1 → 1.3.12 패치 업그레이드합니다.

---

## What's Changed
  - `bc/core`, `bc/notification`, `bc/catalog`: 로컬 `springModulithVersion` 변수 삭제, Modulith 의존성을 `libs.spring.modulith.*`로 교체
  - `bc/catalog`: `commons-lang3:3.17.0` 하드코딩 → `libs.commons.lang3` (BOM 관리)
  - `support/web`, `bc/settlement`: `spring-retry:2.0.2` 하드코딩 → `libs.spring.retry` (BOM 관리)
  - `bc/core`, `bootstrap/api-server`: `spring-retry` 문자열 의존성 → `libs.spring.retry`
  - `bc/core`: `archunit-junit5:1.3.0` 하드코딩 → `libs.archunit`
  - `gradle/libs.versions.toml`: `springModulith` 1.3.1 → 1.3.12, `spring-retry`·`commons-lang3` 카탈로그 항목 추가



## Decisions & Trade-offs

 - spring-retry, commons-lang3를 카탈로그에 등록할 때 **버전을 명시하지 않음** — Boot BOM이 관리하는 라이브러리이므로 Boot 업그레이드 시 자동으로 호환 버전이 적용됩니다.
  - Modulith 1.3.1 → 1.3.12는 패치 업그레이드로 Breaking change 없이 버그픽스만 포함됩니다.


## Future Improvements
  - Flyway 시드 데이터 경량화
  - Java 25 + Boot 4.0.3 + Modulith 2.0.4 + module-aware Flyway 전환