### PR TITLE
feat: 펀딩 수령 확정 이벤트 기반 주문 확정 구현 (#417)

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
@@ -73,13 +73,6 @@ public class OrderEventListener {
     }
 
 	@ApplicationModuleListener
-	public void on (FundingAcceptedEvent event) {
-		log.info("[이벤트 수신] 펀딩 수령 확정 -> 주문 확정 시작. FundingId: {}", event.getFundingId());
-
-		fundingOrderService.confirmOrderItemsByFunding(event.getFundingId());
-	}
-
-	@ApplicationModuleListener
 	public void on(FundingConfirmPendingEvent event) {
 		log.info("[이벤트 수신] 펀딩 수령 확정 대기 -> 주문 확정 시작. FundingId: {}", event.getFundingId());
 
@@ -93,10 +86,12 @@ public class OrderEventListener {
 			log.error("[주문 확정 실패] 정의된 예외 발생. ErrorCode: {}, FundingId: {}, productId: {}", e.getErrorCode().getCode(), event.getFundingId(), event.getProductId(), e);
 
 			eventPublisher.publish(new OrderConfirmFailedEvent(event.getFundingId(), e.getMessage()));
+			throw e;
 		} catch (Exception e) {
 			log.error("[주문 확정 실패] 알 수 없는 예외 발생. FundingId: {}, productId: {}", event.getFundingId(), event.getProductId(), e);
 
 			eventPublisher.publish(new OrderConfirmFailedEvent(event.getFundingId(), "예기치 못한 오류 발생"));
+			throw e;
 		}
 	}
 

--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
@@ -3,9 +3,15 @@ package app.giftify.order.adapter.inbound.event;
 import app.giftify.order.application.FundingOrderService;
 import app.giftify.order.application.OrderService;
 import app.giftify.order.application.inbound.command.CancelFundingOrderCommand;
+import app.giftify.order.application.inbound.command.ConfirmFundingOrderCommand;
+import app.giftify.shared.api.exception.BusinessException;
 import app.giftify.shared.api.exception.InfraException;
+import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.funding.FundingAcceptedEvent;
+import app.giftify.shared.domain.event.funding.FundingConfirmPendingEvent;
 import app.giftify.shared.domain.event.funding.FundingExpiredEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmFailedEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.shared.domain.event.payment.PaymentEvent;
@@ -25,6 +31,7 @@ public class OrderEventListener {
 
     private final OrderService orderService;
     private final FundingOrderService fundingOrderService;
+	private final EventPublisher eventPublisher;
 
 	@Retryable(
 			retryFor = InfraException.class,
@@ -70,6 +77,27 @@ public class OrderEventListener {
 		log.info("[이벤트 수신] 펀딩 수령 확정 -> 주문 확정 시작. FundingId: {}", event.getFundingId());
 
 		fundingOrderService.confirmOrderItemsByFunding(event.getFundingId());
+	}
+
+	@ApplicationModuleListener
+	public void on(FundingConfirmPendingEvent event) {
+		log.info("[이벤트 수신] 펀딩 수령 확정 대기 -> 주문 확정 시작. FundingId: {}", event.getFundingId());
+
+		ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(event.getFundingId(), event.getProductId());
+
+		try {
+			fundingOrderService.confirmOrderItemsByFunding(command);
+
+			eventPublisher.publish(new OrderConfirmedEvent(event.getFundingId()));
+		} catch (BusinessException | InfraException e) {
+			log.error("[주문 확정 실패] 정의된 예외 발생. ErrorCode: {}, FundingId: {}, productId: {}", e.getErrorCode().getCode(), event.getFundingId(), event.getProductId(), e);
+
+			eventPublisher.publish(new OrderConfirmFailedEvent(event.getFundingId(), e.getMessage()));
+		} catch (Exception e) {
+			log.error("[주문 확정 실패] 알 수 없는 예외 발생. FundingId: {}, productId: {}", event.getFundingId(), event.getProductId(), e);
+
+			eventPublisher.publish(new OrderConfirmFailedEvent(event.getFundingId(), "예기치 못한 오류 발생"));
+		}
 	}
 
 	/**

--- a/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/OrderItemAdapter.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/OrderItemAdapter.java
@@ -39,5 +39,10 @@ public class OrderItemAdapter implements OrderItemRepository {
         return jpaOrderItemRepository.findItemIdMapByFundingId(fundingId, TargetType.FUNDING);
     }
 
+    @Override
+    public int confirmOrderItems(List<Long> ids) {
+        return jpaOrderItemRepository.confirmOrderItems(ids);
+    }
+
 
 }

--- a/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/jpa/JpaOrderItemRepository.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/jpa/JpaOrderItemRepository.java
@@ -3,6 +3,7 @@ package app.giftify.order.adapter.outbound.persistence.jpa;
 import app.giftify.order.domain.OrderItem;
 import app.giftify.shared.domain.type.TargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +39,9 @@ public interface JpaOrderItemRepository extends JpaRepository<OrderItem, Long> {
         Long getOrderId();
         Long getItemId();
     }
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE OrderItem oi SET oi.status = 'CONFIRMED' " +
+            "WHERE oi.id IN :ids AND oi.status = 'PENDING'")
+    int confirmOrderItems(@Param("ids") List<Long> ids);
 }

--- a/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
+++ b/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
@@ -62,25 +62,6 @@ public class FundingOrderService {
         });
     }
 
-    @Transactional(readOnly = true)
-    public void confirmOrderItemsByFunding(Long fundingId) {
-        Map<Long, List<Long>> orderIdMap = orderItemRepository.getItemIdMapByFundingId(fundingId);
-
-        Set<Long> orderIds = orderIdMap.keySet();
-
-        orderIds.forEach(orderId -> {
-            List<Long> targetItemIds = orderIdMap.get(orderId);
-            try {
-                orderService.confirmOrderItems(orderId, new HashSet<>(targetItemIds));
-            } catch (BusinessException | InfraException e) {
-                ErrorCode errorCode = e.getErrorCode();
-                log.error("[주문 확정 실패] orderId: {}, errorCode: {}, message = {}", orderId, errorCode.getCode(), errorCode.getMessage(), e);
-            } catch (Exception e) {
-                log.error("[주문 확정 실패] orderId: {}, message = {}", orderId, e.getMessage(), e);
-            }
-        });
-    }
-
     @Transactional
     public void confirmOrderItemsByFunding(ConfirmFundingOrderCommand command) {
         eventPublisher.publish(

--- a/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
+++ b/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
@@ -2,11 +2,16 @@ package app.giftify.order.application;
 
 import app.giftify.order.application.inbound.command.CancelFundingOrderCommand;
 import app.giftify.order.application.inbound.command.CancelOrderItemsCommand;
+import app.giftify.order.application.inbound.command.ConfirmFundingOrderCommand;
 import app.giftify.order.application.outbound.port.OrderItemRepository;
+import app.giftify.order.application.outbound.port.OrderRepository;
 import app.giftify.order.domain.Order;
 import app.giftify.order.domain.OrderItem;
 import app.giftify.order.domain.errorCode.OrderErrorCode;
 import app.giftify.shared.api.exception.*;
+import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
+import app.giftify.shared.domain.vo.ConfirmItem;
 import app.giftify.shared.domain.vo.Money;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +29,8 @@ import java.util.stream.Collectors;
 public class FundingOrderService {
     private final OrderItemRepository orderItemRepository;
     private final OrderService orderService;
+    private final EventPublisher eventPublisher;
+    private final OrderRepository orderRepository;
 
     @Transactional(readOnly = true)
     public void requestCancelFundingOrder(CancelFundingOrderCommand command) {
@@ -72,6 +79,33 @@ public class FundingOrderService {
                 log.error("[주문 확정 실패] orderId: {}, message = {}", orderId, e.getMessage(), e);
             }
         });
+    }
+
+    @Transactional
+    public void confirmOrderItemsByFunding(ConfirmFundingOrderCommand command) {
+        eventPublisher.publish(
+                new OrderConfirmPendingEvent(
+                        List.of(ConfirmItem.ofFunding(command.productId()))
+                )
+        );
+
+        Map<Long, List<Long>> orderIdMap = orderItemRepository.getItemIdMapByFundingId(command.fundingId());
+
+        List<Long> orderItemIds = orderIdMap.values().stream()
+                .flatMap(List::stream)
+                .toList();
+
+        int updatedItems = orderItemRepository.confirmOrderItems(orderItemIds);
+
+        if (updatedItems != orderItemIds.size()) {
+            log.error("[주문 확정 실패] 주문 아이템 중 확정할 수 없는 상태의 아이템이 포함되어 있습니다. Expected Count: {}, Updated Count: {}, OrderItem IDs : {}",
+                    orderItemIds.size(), updatedItems, orderItemIds);
+
+            throw new DomainException(OrderErrorCode.INVALID_STATUS_TRANSITION);
+        }
+
+        List<Order> orders = orderRepository.getAllByIdInWithItems(new ArrayList<>(orderIdMap.keySet()));
+        orders.forEach(Order::synchronizeStatus);
     }
 
     private static void validateItemsNotEmpty(Long fundingId, List<OrderItem> orderItems) {

--- a/bc/core/src/main/java/app/giftify/order/application/OrderService.java
+++ b/bc/core/src/main/java/app/giftify/order/application/OrderService.java
@@ -217,13 +217,6 @@ public class OrderService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void confirmOrderItems(Long orderId, Set<Long> itemIds) {
-        Order targetOrder = orderRepository.getByIdWithItemsAndLock(orderId);
-
-        targetOrder.confirmed(itemIds);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void expire(Long orderId) {
         Order order = orderRepository.getByIdWithItems(orderId);
 

--- a/bc/core/src/main/java/app/giftify/order/application/inbound/command/ConfirmFundingOrderCommand.java
+++ b/bc/core/src/main/java/app/giftify/order/application/inbound/command/ConfirmFundingOrderCommand.java
@@ -1,0 +1,7 @@
+package app.giftify.order.application.inbound.command;
+
+public record ConfirmFundingOrderCommand(
+        Long fundingId,
+        Long productId
+) {
+}

--- a/bc/core/src/main/java/app/giftify/order/application/outbound/port/OrderItemRepository.java
+++ b/bc/core/src/main/java/app/giftify/order/application/outbound/port/OrderItemRepository.java
@@ -14,4 +14,6 @@ public interface OrderItemRepository {
     List<OrderItem> getOrderItemsWithOrderAndFindingId(Long findingId);
 
     Map<Long, List<Long>> getItemIdMapByFundingId(Long fundingId);
+
+    int confirmOrderItems(List<Long> ids);
 }

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -2,13 +2,21 @@ package app.giftify.order.adapter.inbound.event;
 
 import app.giftify.order.application.FundingOrderService;
 import app.giftify.order.application.OrderService;
+import app.giftify.order.application.inbound.command.ConfirmFundingOrderCommand;
+import app.giftify.order.domain.errorCode.OrderErrorCode;
+import app.giftify.shared.api.exception.DomainException;
 import app.giftify.shared.api.exception.InfraErrorCode;
 import app.giftify.shared.api.exception.InfraException;
 import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.event.funding.FundingConfirmPendingEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmFailedEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.shared.domain.event.payment.PaymentEventData;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -17,6 +25,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
@@ -70,5 +79,97 @@ class OrderEventListenerTest {
 
         // then: 실제로 재시도가 발생했는지 횟수 확인
         verify(orderService, atLeast(2)).completeCancel(any());
+    }
+
+    @Nested
+    @DisplayName("FundingConfirmPendingEvent 처리 (on(FundingConfirmPendingEvent))")
+    class OnFundingConfirmPendingEvent {
+
+        private static final Long FUNDING_ID = 1L;
+        private static final Long PRODUCT_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 정상 처리 후 fundingId를 담은 OrderConfirmedEvent가 발행된다")
+        void given_success_when_onFundingConfirmPendingEvent_then_publishOrderConfirmedEvent() {
+            // given
+            FundingConfirmPendingEvent event = new FundingConfirmPendingEvent(FUNDING_ID, PRODUCT_ID);
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            verify(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
+            ArgumentCaptor<OrderConfirmedEvent> captor = ArgumentCaptor.forClass(OrderConfirmedEvent.class);
+            verify(eventPublisher).publish(captor.capture());
+            assertThat(captor.getValue().getFundingId()).isEqualTo(FUNDING_ID);
+        }
+
+        @Test
+        @DisplayName("성공: 커맨드에 이벤트의 fundingId와 productId가 올바르게 전달된다")
+        void given_event_when_onFundingConfirmPendingEvent_then_commandHasCorrectIds() {
+            // given
+            FundingConfirmPendingEvent event = new FundingConfirmPendingEvent(FUNDING_ID, PRODUCT_ID);
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<ConfirmFundingOrderCommand> captor = ArgumentCaptor.forClass(ConfirmFundingOrderCommand.class);
+            verify(fundingOrderService).confirmOrderItemsByFunding(captor.capture());
+            assertThat(captor.getValue().fundingId()).isEqualTo(FUNDING_ID);
+            assertThat(captor.getValue().productId()).isEqualTo(PRODUCT_ID);
+        }
+
+        @Test
+        @DisplayName("실패: BusinessException 발생 시 fundingId를 담은 OrderConfirmFailedEvent가 발행된다")
+        void given_businessException_when_onFundingConfirmPendingEvent_then_publishOrderConfirmFailedEvent() {
+            // given
+            FundingConfirmPendingEvent event = new FundingConfirmPendingEvent(FUNDING_ID, PRODUCT_ID);
+            doThrow(new DomainException(OrderErrorCode.INVALID_STATUS_TRANSITION))
+                    .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);
+            verify(eventPublisher).publish(captor.capture());
+            assertThat(captor.getValue().getFundingId()).isEqualTo(FUNDING_ID);
+        }
+
+        @Test
+        @DisplayName("실패: InfraException 발생 시 fundingId를 담은 OrderConfirmFailedEvent가 발행된다")
+        void given_infraException_when_onFundingConfirmPendingEvent_then_publishOrderConfirmFailedEvent() {
+            // given
+            FundingConfirmPendingEvent event = new FundingConfirmPendingEvent(FUNDING_ID, PRODUCT_ID);
+            doThrow(new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT))
+                    .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);
+            verify(eventPublisher).publish(captor.capture());
+            assertThat(captor.getValue().getFundingId()).isEqualTo(FUNDING_ID);
+        }
+
+        @Test
+        @DisplayName("실패: 예상치 못한 예외 발생 시 '예기치 못한 오류 발생' 메시지로 OrderConfirmFailedEvent가 발행된다")
+        void given_unexpectedException_when_onFundingConfirmPendingEvent_then_publishFailedEventWithDefaultMessage() {
+            // given
+            FundingConfirmPendingEvent event = new FundingConfirmPendingEvent(FUNDING_ID, PRODUCT_ID);
+            doThrow(new RuntimeException("DB connection lost"))
+                    .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);
+            verify(eventPublisher).publish(captor.capture());
+            assertThat(captor.getValue().getFundingId()).isEqualTo(FUNDING_ID);
+            assertThat(captor.getValue().getReason()).isEqualTo("예기치 못한 오류 발생");
+        }
     }
 }

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -4,6 +4,7 @@ import app.giftify.order.application.FundingOrderService;
 import app.giftify.order.application.OrderService;
 import app.giftify.order.application.inbound.command.ConfirmFundingOrderCommand;
 import app.giftify.order.domain.errorCode.OrderErrorCode;
+import app.giftify.shared.api.exception.BusinessException;
 import app.giftify.shared.api.exception.DomainException;
 import app.giftify.shared.api.exception.InfraErrorCode;
 import app.giftify.shared.api.exception.InfraException;
@@ -128,8 +129,8 @@ class OrderEventListenerTest {
             doThrow(new DomainException(OrderErrorCode.INVALID_STATUS_TRANSITION))
                     .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
 
-            // when
-            orderEventListener.on(event);
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event)).isInstanceOf(BusinessException.class);
 
             // then
             ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);
@@ -145,10 +146,9 @@ class OrderEventListenerTest {
             doThrow(new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT))
                     .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
 
-            // when
-            orderEventListener.on(event);
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event)).isInstanceOf(InfraException.class);
 
-            // then
             ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);
             verify(eventPublisher).publish(captor.capture());
             assertThat(captor.getValue().getFundingId()).isEqualTo(FUNDING_ID);
@@ -162,8 +162,8 @@ class OrderEventListenerTest {
             doThrow(new RuntimeException("DB connection lost"))
                     .when(fundingOrderService).confirmOrderItemsByFunding(any(ConfirmFundingOrderCommand.class));
 
-            // when
-            orderEventListener.on(event);
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event)).isInstanceOf(Exception.class);
 
             // then
             ArgumentCaptor<OrderConfirmFailedEvent> captor = ArgumentCaptor.forClass(OrderConfirmFailedEvent.class);

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -4,6 +4,7 @@ import app.giftify.order.application.FundingOrderService;
 import app.giftify.order.application.OrderService;
 import app.giftify.shared.api.exception.InfraErrorCode;
 import app.giftify.shared.api.exception.InfraException;
+import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.shared.domain.event.payment.PaymentEventData;
 import org.junit.jupiter.api.DisplayName;
@@ -43,6 +44,9 @@ class OrderEventListenerTest {
 
     @MockitoBean
     private FundingOrderService fundingOrderService;
+
+    @MockitoBean
+    private EventPublisher eventPublisher;
 
     @Test
     @DisplayName("재시도 가능한 에러코드의 InfraException 발생 시 recover가 호출되어야 한다")

--- a/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
@@ -29,11 +29,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -249,127 +247,7 @@ class FundingOrderServiceTest {
     }
 
     @Nested
-    @DisplayName("펀딩 수령 확정 주문 처리 (confirmOrderItemsByFunding)")
-    class ConfirmOrderItemsByFunding {
-
-        @Test
-        @DisplayName("성공: 단일 주문에 속한 아이템을 확정할 때 confirmOrderItems를 정확한 인자로 1회 호출한다")
-        void given_singleOrder_when_confirmOrderItemsByFunding_then_confirmOrderItemsCalledOnce() {
-            // given
-            Long orderId = 10L;
-            Long itemId1 = 1L;
-            Long itemId2 = 2L;
-
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(orderId, List.of(itemId1, itemId2)));
-
-            // when
-            fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID);
-
-            // then
-            ArgumentCaptor<Set<Long>> captor = ArgumentCaptor.forClass(Set.class);
-            verify(orderService, times(1)).confirmOrderItems(eq(orderId), captor.capture());
-            assertThat(captor.getValue()).containsExactlyInAnyOrder(itemId1, itemId2);
-        }
-
-        @Test
-        @DisplayName("성공: 여러 주문에 걸쳐 있을 때 주문별로 각각 confirmOrderItems를 호출한다")
-        void given_multipleOrders_when_confirmOrderItemsByFunding_then_confirmOrderItemsCalledForEachOrder() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(
-                            10L, List.of(1L),
-                            20L, List.of(2L)
-                    ));
-
-            // when
-            fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID);
-
-            // then
-            verify(orderService, times(2)).confirmOrderItems(any(), any());
-        }
-
-        @Test
-        @DisplayName("성공: 매핑 결과가 비어있으면 confirmOrderItems를 호출하지 않는다")
-        void given_emptyMap_when_confirmOrderItemsByFunding_then_confirmOrderItemsNeverCalled() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of());
-
-            // when
-            fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID);
-
-            // then
-            verify(orderService, never()).confirmOrderItems(any(), any());
-        }
-
-        @Test
-        @DisplayName("성공: confirmOrderItems에서 BusinessException이 발생해도 예외가 삼켜지고 정상 종료된다")
-        void given_businessException_when_confirmOrderItemsByFunding_then_exceptionSwallowed() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(10L, List.of(1L)));
-            doThrow(new PolicyException(OrderErrorCode.INVALID_STATUS_TRANSITION))
-                    .when(orderService).confirmOrderItems(any(), any());
-
-            // when & then
-            assertThatCode(() -> fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("성공: confirmOrderItems에서 InfraException이 발생해도 예외가 삼켜지고 정상 종료된다")
-        void given_infraException_when_confirmOrderItemsByFunding_then_exceptionSwallowed() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(10L, List.of(1L)));
-            doThrow(new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT))
-                    .when(orderService).confirmOrderItems(any(), any());
-
-            // when & then
-            assertThatCode(() -> fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("성공: confirmOrderItems에서 RuntimeException이 발생해도 예외가 삼켜지고 정상 종료된다")
-        void given_runtimeException_when_confirmOrderItemsByFunding_then_exceptionSwallowed() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(10L, List.of(1L)));
-            doThrow(new RuntimeException("예상치 못한 오류"))
-                    .when(orderService).confirmOrderItems(any(), any());
-
-            // when & then
-            assertThatCode(() -> fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("성공: 여러 주문 중 하나에서 예외가 발생해도 나머지 주문 확정 처리가 계속된다")
-        void given_exceptionOnOneOrder_when_confirmOrderItemsByFunding_then_otherOrdersStillProcessed() {
-            // given
-            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
-                    .willReturn(Map.of(
-                            10L, List.of(1L),
-                            20L, List.of(2L)
-                    ));
-            // 첫 번째 호출 실패, 두 번째 호출 정상
-            doThrow(new PolicyException(OrderErrorCode.INVALID_STATUS_TRANSITION))
-                    .doNothing()
-                    .when(orderService).confirmOrderItems(any(), any());
-
-            // when & then
-            assertThatCode(() -> fundingOrderService.confirmOrderItemsByFunding(FUNDING_ID))
-                    .doesNotThrowAnyException();
-
-            // 예외와 무관하게 두 주문 모두에 대해 확정 요청이 시도됨
-            verify(orderService, times(2)).confirmOrderItems(any(), any());
-        }
-    }
-
-    @Nested
-    @DisplayName("펀딩 확정 주문 처리 - 커맨드 기반 (confirmOrderItemsByFunding(ConfirmFundingOrderCommand))")
+    @DisplayName("펀딩 확정 주문 처리")
     class ConfirmOrderItemsByFundingWithCommand {
 
         private static final Long PRODUCT_ID = 100L;

--- a/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
@@ -2,7 +2,9 @@ package app.giftify.order.application;
 
 import app.giftify.order.application.inbound.command.CancelFundingOrderCommand;
 import app.giftify.order.application.inbound.command.CancelOrderItemsCommand;
+import app.giftify.order.application.inbound.command.ConfirmFundingOrderCommand;
 import app.giftify.order.application.outbound.port.OrderItemRepository;
+import app.giftify.order.application.outbound.port.OrderRepository;
 import app.giftify.order.domain.Order;
 import app.giftify.order.domain.OrderItem;
 import app.giftify.order.domain.errorCode.OrderErrorCode;
@@ -11,6 +13,8 @@ import app.giftify.shared.api.exception.DomainException;
 import app.giftify.shared.api.exception.InfraErrorCode;
 import app.giftify.shared.api.exception.InfraException;
 import app.giftify.shared.api.exception.PolicyException;
+import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
 import app.giftify.shared.domain.vo.Money;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -41,6 +45,12 @@ class FundingOrderServiceTest {
 
     @Mock
     private OrderService orderService;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @Mock
+    private OrderRepository orderRepository;
 
     @InjectMocks
     private FundingOrderService fundingOrderService;
@@ -355,6 +365,113 @@ class FundingOrderServiceTest {
 
             // 예외와 무관하게 두 주문 모두에 대해 확정 요청이 시도됨
             verify(orderService, times(2)).confirmOrderItems(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("펀딩 확정 주문 처리 - 커맨드 기반 (confirmOrderItemsByFunding(ConfirmFundingOrderCommand))")
+    class ConfirmOrderItemsByFundingWithCommand {
+
+        private static final Long PRODUCT_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 모든 아이템이 정상 확정되면 OrderConfirmPendingEvent가 발행되고 주문 상태가 동기화된다")
+        void given_allItemsConfirmed_when_confirmOrderItemsByFundingWithCommand_then_eventPublishedAndOrdersSynchronized() {
+            // given
+            ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(FUNDING_ID, PRODUCT_ID);
+            Map<Long, List<Long>> orderIdMap = Map.of(ORDER_ID, List.of(1L, 2L));
+            Order order = OrderFixture.createOrderWithItems(BUYER_ID, 2);
+            ReflectionTestUtils.setField(order, "id", ORDER_ID);
+
+            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID)).willReturn(orderIdMap);
+            given(orderItemRepository.confirmOrderItems(any())).willReturn(2);
+            given(orderRepository.getAllByIdInWithItems(any())).willReturn(List.of(order));
+
+            // when
+            assertThatCode(() -> fundingOrderService.confirmOrderItemsByFunding(command))
+                    .doesNotThrowAnyException();
+
+            // then
+            verify(eventPublisher).publish(any(OrderConfirmPendingEvent.class));
+            verify(orderItemRepository).confirmOrderItems(any());
+            verify(orderRepository).getAllByIdInWithItems(any());
+        }
+
+        @Test
+        @DisplayName("성공: OrderConfirmPendingEvent에 올바른 productId가 담겨 발행된다")
+        void given_command_when_confirmOrderItemsByFundingWithCommand_then_publishesEventWithCorrectProductId() {
+            // given
+            ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(FUNDING_ID, PRODUCT_ID);
+            Order order = OrderFixture.createOrderWithItems(BUYER_ID, 1);
+
+            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
+                    .willReturn(Map.of(ORDER_ID, List.of(1L)));
+            given(orderItemRepository.confirmOrderItems(any())).willReturn(1);
+            given(orderRepository.getAllByIdInWithItems(any())).willReturn(List.of(order));
+
+            // when
+            fundingOrderService.confirmOrderItemsByFunding(command);
+
+            // then
+            ArgumentCaptor<OrderConfirmPendingEvent> captor = ArgumentCaptor.forClass(OrderConfirmPendingEvent.class);
+            verify(eventPublisher).publish(captor.capture());
+            assertThat(captor.getValue().getItems()).hasSize(1);
+            assertThat(captor.getValue().getItems().get(0).productId()).isEqualTo(PRODUCT_ID);
+        }
+
+        @Test
+        @DisplayName("성공: 확정 대상 아이템 ID 목록이 confirmOrderItems에 올바르게 전달된다")
+        void given_multipleItems_when_confirmOrderItemsByFundingWithCommand_then_allItemIdsPassedToRepository() {
+            // given
+            ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(FUNDING_ID, PRODUCT_ID);
+            Map<Long, List<Long>> orderIdMap = Map.of(ORDER_ID, List.of(1L, 2L, 3L));
+            Order order = OrderFixture.createOrderWithItems(BUYER_ID, 3);
+
+            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID)).willReturn(orderIdMap);
+            given(orderItemRepository.confirmOrderItems(any())).willReturn(3);
+            given(orderRepository.getAllByIdInWithItems(any())).willReturn(List.of(order));
+
+            // when
+            fundingOrderService.confirmOrderItemsByFunding(command);
+
+            // then
+            ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
+            verify(orderItemRepository).confirmOrderItems(captor.capture());
+            assertThat(captor.getValue()).containsExactlyInAnyOrder(1L, 2L, 3L);
+        }
+
+        @Test
+        @DisplayName("실패: 업데이트된 아이템 수가 기대치보다 적으면 DomainException(INVALID_STATUS_TRANSITION)이 발생한다")
+        void given_mismatchUpdatedCount_when_confirmOrderItemsByFundingWithCommand_then_throwDomainException() {
+            // given
+            ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(FUNDING_ID, PRODUCT_ID);
+            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
+                    .willReturn(Map.of(ORDER_ID, List.of(1L, 2L)));
+            given(orderItemRepository.confirmOrderItems(any())).willReturn(1); // 2개 중 1개만 업데이트됨
+
+            // when & then
+            assertThatThrownBy(() -> fundingOrderService.confirmOrderItemsByFunding(command))
+                    .isInstanceOf(DomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(OrderErrorCode.INVALID_STATUS_TRANSITION);
+
+            verify(orderRepository, never()).getAllByIdInWithItems(any());
+        }
+
+        @Test
+        @DisplayName("실패: 업데이트된 아이템 수가 0이면 DomainException(INVALID_STATUS_TRANSITION)이 발생한다")
+        void given_zeroUpdatedCount_when_confirmOrderItemsByFundingWithCommand_then_throwDomainException() {
+            // given
+            ConfirmFundingOrderCommand command = new ConfirmFundingOrderCommand(FUNDING_ID, PRODUCT_ID);
+            given(orderItemRepository.getItemIdMapByFundingId(FUNDING_ID))
+                    .willReturn(Map.of(ORDER_ID, List.of(1L)));
+            given(orderItemRepository.confirmOrderItems(any())).willReturn(0);
+
+            // when & then
+            assertThatThrownBy(() -> fundingOrderService.confirmOrderItemsByFunding(command))
+                    .isInstanceOf(DomainException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(OrderErrorCode.INVALID_STATUS_TRANSITION);
         }
     }
 }

--- a/bc/core/src/test/java/app/giftify/order/application/OrderServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/order/application/OrderServiceTest.java
@@ -38,7 +38,6 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -749,94 +748,6 @@ class OrderServiceTest {
             assertThat(result).hasSize(1);
             assertThat(result).containsKey(orderId2);
             assertThat(result).doesNotContainKey(orderId1);
-        }
-    }
-
-    @Nested
-    @DisplayName("주문 아이템 확정 (confirmOrderItems)")
-    class ConfirmOrderItems {
-
-        @Test
-        @DisplayName("성공: PAID 아이템을 확정하면 CONFIRMED 상태로 변경된다")
-        void given_paidItems_when_confirmOrderItems_then_statusChangedToConfirmed() {
-            // given
-            Long orderId = 1L;
-            Long itemId1 = 10L;
-            Long itemId2 = 20L;
-
-            Order order = OrderFixture.createOrderWithItems(1L, 2);
-            ReflectionTestUtils.setField(order, "id", orderId);
-            ReflectionTestUtils.setField(order.getItems().get(0), "id", itemId1);
-            ReflectionTestUtils.setField(order.getItems().get(1), "id", itemId2);
-            order.getItems().forEach(item -> ReflectionTestUtils.setField(item, "status", OrderItemStatus.PAID));
-
-            given(orderRepository.getByIdWithItemsAndLock(orderId)).willReturn(order);
-
-            // when
-            orderService.confirmOrderItems(orderId, Set.of(itemId1, itemId2));
-
-            // then
-            assertThat(order.getItems())
-                    .allMatch(item -> item.getStatus() == OrderItemStatus.CONFIRMED);
-        }
-
-        @Test
-        @DisplayName("성공: itemIds에 포함된 아이템만 CONFIRMED로 변경되고 나머지는 그대로다")
-        void given_partialItemIds_when_confirmOrderItems_then_onlyTargetItemsConfirmed() {
-            // given
-            Long orderId = 1L;
-            Long itemId1 = 10L;
-            Long itemId2 = 20L;
-
-            Order order = OrderFixture.createOrderWithItems(1L, 2);
-            ReflectionTestUtils.setField(order, "id", orderId);
-            ReflectionTestUtils.setField(order.getItems().get(0), "id", itemId1);
-            ReflectionTestUtils.setField(order.getItems().get(1), "id", itemId2);
-            order.getItems().forEach(item -> ReflectionTestUtils.setField(item, "status", OrderItemStatus.PAID));
-
-            given(orderRepository.getByIdWithItemsAndLock(orderId)).willReturn(order);
-
-            // when - itemId1 만 확정
-            orderService.confirmOrderItems(orderId, Set.of(itemId1));
-
-            // then
-            assertThat(order.getItems().get(0).getStatus()).isEqualTo(OrderItemStatus.CONFIRMED);
-            assertThat(order.getItems().get(1).getStatus()).isEqualTo(OrderItemStatus.PAID);
-        }
-
-        @Test
-        @DisplayName("실패: 존재하지 않는 주문이면 예외가 전파된다")
-        void given_nonExistentOrder_when_confirmOrderItems_then_throwException() {
-            // given
-            Long orderId = 999L;
-            given(orderRepository.getByIdWithItemsAndLock(orderId))
-                    .willThrow(new PolicyException(OrderErrorCode.ORDER_NOT_FOUND));
-
-            // when & then
-            assertThatThrownBy(() -> orderService.confirmOrderItems(orderId, Set.of(1L)))
-                    .isInstanceOf(PolicyException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(OrderErrorCode.ORDER_NOT_FOUND);
-        }
-
-        @Test
-        @DisplayName("실패: PAID 상태가 아닌 아이템 확정 시도 시 PolicyException이 발생한다")
-        void given_nonPaidItem_when_confirmOrderItems_then_throwPolicyException() {
-            // given
-            Long orderId = 1L;
-            Long itemId = 10L;
-
-            Order order = OrderFixture.createOrderWithItems(1L, 1); // CREATED 상태 (기본값)
-            ReflectionTestUtils.setField(order, "id", orderId);
-            ReflectionTestUtils.setField(order.getItems().get(0), "id", itemId);
-
-            given(orderRepository.getByIdWithItemsAndLock(orderId)).willReturn(order);
-
-            // when & then
-            assertThatThrownBy(() -> orderService.confirmOrderItems(orderId, Set.of(itemId)))
-                    .isInstanceOf(PolicyException.class)
-                    .extracting("errorCode")
-                    .isEqualTo(OrderErrorCode.INVALID_STATUS_TRANSITION);
         }
     }
 

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/funding/FundingConfirmPendingEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/funding/FundingConfirmPendingEvent.java
@@ -1,0 +1,22 @@
+package app.giftify.shared.domain.event.funding;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+
+public class FundingConfirmPendingEvent extends BaseDomainEvent {
+    private final Long fundingId;
+    private final Long productId;
+
+    public FundingConfirmPendingEvent(Long fundingId, Long productId) {
+        super();
+        this.fundingId = fundingId;
+        this.productId = productId;
+    }
+
+    public Long getFundingId() {
+        return fundingId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmFailedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmFailedEvent.java
@@ -1,0 +1,22 @@
+package app.giftify.shared.domain.event.order;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+
+public class OrderConfirmFailedEvent extends BaseDomainEvent {
+    private final Long fundingId;
+    private final String reason;
+
+    public OrderConfirmFailedEvent(Long fundingId, String reason) {
+        super();
+        this.fundingId = fundingId;
+        this.reason = reason;
+    }
+
+    public Long getFundingId() {
+        return fundingId;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmPendingEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmPendingEvent.java
@@ -1,0 +1,18 @@
+package app.giftify.shared.domain.event.order;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+import app.giftify.shared.domain.vo.ConfirmItem;
+
+import java.util.List;
+
+public class OrderConfirmPendingEvent extends BaseDomainEvent {
+    private final List<ConfirmItem> items;
+
+    public OrderConfirmPendingEvent(List<ConfirmItem> items) {
+        this.items = items;
+    }
+
+    public List<ConfirmItem> getItems() {
+        return items;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/order/OrderConfirmedEvent.java
@@ -1,0 +1,16 @@
+package app.giftify.shared.domain.event.order;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+
+public class OrderConfirmedEvent extends BaseDomainEvent {
+    private final Long fundingId;
+
+    public OrderConfirmedEvent(Long fundingId) {
+        super();
+        this.fundingId = fundingId;
+    }
+
+    public Long getFundingId() {
+        return fundingId;
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/domain/vo/ConfirmItem.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/vo/ConfirmItem.java
@@ -1,0 +1,14 @@
+package app.giftify.shared.domain.vo;
+
+public record ConfirmItem(
+        Long productId,
+        Long quantity
+) {
+    public static ConfirmItem ofFunding(Long productId) {
+        return new ConfirmItem(productId, 1L);
+    }
+
+    public static ConfirmItem of(Long productId, Long quantity) {
+        return new ConfirmItem(productId, quantity);
+    }
+}


### PR DESCRIPTION
## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

펀딩 수령 확정(FundingConfirmPendingEvent) 시 주문 아이템을 CONFIRMED 상태로
  일괄 업데이트하고 주문 전체 상태를 동기화하는 이벤트 기반 흐름을 구현합니다.


---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

### 도메인 이벤트 / VO 추가 (bc:shared)
  - `FundingConfirmPendingEvent` - 펀딩 수령 확정 대기 이벤트 ( **펀딩 도메인 발행** )
  - `OrderConfirmPendingEvent` - 주문 확정(재고 차감) 요청 이벤트 ( **상품 도메인 수신** )
  - `OrderConfirmedEvent` - 주문 확정 완료 이벤트 ( **펀딩 도메인 수신** )
  - `OrderConfirmFailedEvent` - 주문 확정 실패 이벤트 ( **펀딩 도메인 수신** )
  - `ConfirmItem` - 확정 요청 상품 정보 VO

### 주문 확정 처리 구현 (bc:core)
  - `ConfirmFundingOrderCommand` 추가
  - `FundingOrderService.confirmOrderItemsByFunding(ConfirmFundingOrderCommand)` 구현
    - `OrderConfirmPendingEvent` 발행 (재고 차감 트리거)
    - 주문 아이템 벌크 UPDATE (`status = 'CONFIRMED'`)
    - 업데이트 수 불일치 시 `DomainException(INVALID_STATUS_TRANSITION)` 발생
    - `Order.synchronizeStatus()` 로 주문 전체 상태 동기화
  - `OrderItemRepository` 포트 및 JPA 구현에 `confirmOrderItems(List<Long>)` 추가
  - `OrderEventListener.on(FundingConfirmPendingEvent)` 핸들러 추가
    - 성공 시 `OrderConfirmedEvent` 발행
    - `BusinessException` / `InfraException` / 그 외 예외 발생 시 `OrderConfirmFailedEvent` 발행



---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.



  ### 1. 벌크 UPDATE 방식 채택
  개별 엔티티 로딩 후 상태 변경(더티 체킹) 대신 JPQL 벌크 UPDATE를 사용합니다.
  펀딩 참여자가 많을수록 주문 아이템 수도 비례해 증가하므로, N번의 SELECT + UPDATE
  대신 단일 쿼리로 처리해 DB 부하를 줄였습니다.
  단, 벌크 UPDATE는 영속성 컨텍스트를 우회하므로 `@Modifying(clearAutomatically = true)`
  로 1차 캐시를 초기화하고, 이후 `Order::synchronizeStatus` 호출을 위해 주문을
  다시 조회합니다.

### 2. WHERE 조건에 `status = 'PENDING'` 추가 (조건부 업데이트)

1. 데이터 정합성 (Race Condition 방지)

    조회와 수정 사이에 상태가 변하는 문제를 방지합니다. WHERE status = 'PENDING' 조건을 통해, 그사이 사용자가 취소한 건은 업데이트 대상에서 제외되므로 잘못된 상태 전이를 DB 레벨에서 완벽히 차단합니다.
    

2. 고성능 유지 (Lock 최소화)

    비관적 락(Select for Update)처럼 DB 커넥션을 붙잡고 대기하지 않습니다. 락 점유 시간을 최소화하는 낙관적 접근 방식을 취해, 트래픽이 몰리는 펀딩 시스템에서도 높은 처리량을 유지합니다.
    

3. 벌크 연산의 효율성

    여러 아이템을 루프로 돌며 개별 쿼리를 날리지 않고, 단 한 번의 UPDATE 쿼리로 처리합니다. 네트워크 왕복 비용을 줄여 시스템 자원을 효율적으로 사용합니다.
    

4. 명확한 결과 검증

    업데이트된 행 수(updatedCount)와 요청 수(ids.size())를 비교하여, "일부 실패" 상황을 즉시 감지하고 비즈니스 예외를 던질 수 있는 명확한 근거를 제공합니다.

  ### 3. FundingAcceptedEvent와 FundingConfirmPendingEvent 분리
  기존 `FundingAcceptedEvent` → `confirmOrderItemsByFunding(Long)` 흐름은
  productId 정보가 없어 재고 차감 이벤트를 발행할 수 없었습니다.
  기존 핸들러를 수정하는 대신 새 이벤트(`FundingConfirmPendingEvent`)와 새 커맨드
  (`ConfirmFundingOrderCommand`)를 추가해 하위 호환성을 유지했습니다.

  ### 4. 실패 시 예외 전파 대신 실패 이벤트 발행
  `OrderEventListener.on(FundingConfirmPendingEvent)`에서 예외를 외부로 전파하지
  않고 `OrderConfirmFailedEvent`로 변환해 발행합니다. 주문 확정 실패를 소비하는
  다른 바운디드 컨텍스트(예: 펀딩, 정산)가 독립적으로 보상 처리를 수행할 수 있도록
  이벤트 기반 에러 핸들링 패턴을 적용했습니다.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.

- `order.synchronizeStatus()` 벌크 처리 고려

---

### Linked Issues

- closes #417