### PR TITLE
판매자 닉네임 변경 시 ES 상품 도큐먼트 동기화

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEsEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEsEventListener.java
@@ -4,6 +4,7 @@ import app.giftify.product.application.port.out.ProductEsPort;
 import app.giftify.product.application.support.ProductSupport;
 import app.giftify.product.domain.Product;
 import app.giftify.product.domain.event.ProductAcceptedEvent;
+import app.giftify.shared.domain.event.member.SellerNicknameChangedEvent;
 import app.giftify.shared.domain.event.product.ProductDeletedEvent;
 import app.giftify.shared.domain.event.product.ProductSaleDisabledEvent;
 import app.giftify.shared.domain.event.product.ProductSaleEnabledEvent;
@@ -54,6 +55,12 @@ public class ProductEsEventListener {
     public void handleDeleted(ProductDeletedEvent event) {
         productEsPort.deleteById(event.getProductId());
         log.info("ES 도큐먼트 삭제 완료: {}", event.getProductId());
+    }
+
+    // 판매자 닉네임 변경 시 ES 도큐먼트 일괄 업데이트
+    @ApplicationModuleListener
+    public void handleSellerNicknameChanged(SellerNicknameChangedEvent event) {
+        productEsPort.updateSellerNickname(event.getSellerId(), event.getNickname());
     }
 
     private void syncToEs(Long productId) {

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/elasticsearch/ProductEsAdapter.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/elasticsearch/ProductEsAdapter.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.BulkFailureException;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -141,18 +142,23 @@ public class ProductEsAdapter implements ProductEsPort {
             return;
         }
 
-        try {
-            List<UpdateQuery> updateQueries = productIds.stream()
-                    .map(id -> UpdateQuery.builder(String.valueOf(id))
-                            // sellerNickname 필드만 새 값으로 변경 (나머지 필드는 그대로 유지)
-                            .withDocument(Document.create().append("sellerNickname", nickname))
-                            .build())
-                    .toList();
+        List<UpdateQuery> updateQueries = productIds.stream()
+                .map(id -> UpdateQuery.builder(String.valueOf(id))
+                        // sellerNickname 필드만 새 값으로 변경 (나머지 필드는 그대로 유지)
+                        .withDocument(Document.create().append("sellerNickname", nickname))
+                        .build())
+                .toList();
 
+        try {
             elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("products"));
             log.info("판매자 닉네임 ES 일괄 업데이트 완료: sellerId={}, nickname={}, updated={}",
                     sellerId, nickname, productIds.size());
-        } catch (Exception e) {
+        } catch (BulkFailureException e) { // 일부 도큐먼트 누락 시, 예외를 던지지 않고 로그 기록
+            int failed = e.getFailedDocuments().size();
+            int succeeded = productIds.size() - failed;
+            log.warn("판매자 닉네임 ES 일괄 업데이트 부분 성공: sellerId={}, nickname={}, succeeded={}, failed={}, failedIds={}",
+                    sellerId, nickname, succeeded, failed, e.getFailedDocuments().keySet());
+        } catch (Exception e) { // ES 연결 실패 등 전체 장애
             log.error("판매자 닉네임 ES 업데이트 실패: sellerId={}, nickname={}", sellerId, nickname, e);
             throw new ProductException(ProductErrorCode.ES_NICKNAME_UPDATE_FAILED);
         }

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/elasticsearch/ProductEsAdapter.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/elasticsearch/ProductEsAdapter.java
@@ -10,16 +10,22 @@ import app.giftify.product.application.port.out.ProductEsSearchCommand;
 import app.giftify.product.domain.Product;
 import app.giftify.product.domain.ProductSearchSortType;
 import app.giftify.product.domain.ProductStatus;
+import app.giftify.product.domain.exception.ProductErrorCode;
+import app.giftify.product.domain.exception.ProductException;
 import app.giftify.replica.member.Member;
 import app.giftify.replica.member.MemberRepository;
 import app.giftify.shared.api.paging.PageResponse;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -27,6 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class ProductEsAdapter implements ProductEsPort {
 
@@ -124,6 +131,31 @@ public class ProductEsAdapter implements ProductEsPort {
     @Override
     public void deleteById(Long productId) {
         productEsRepository.deleteById(String.valueOf(productId));
+    }
+
+    @Override
+    public void updateSellerNickname(Long sellerId, String nickname) {
+        List<Long> productIds = productRepository.findActiveProductIdsBySellerId(sellerId);
+        if (productIds.isEmpty()) {
+            log.info("판매자 닉네임 ES 업데이트 대상 없음: sellerId={}", sellerId);
+            return;
+        }
+
+        try {
+            List<UpdateQuery> updateQueries = productIds.stream()
+                    .map(id -> UpdateQuery.builder(String.valueOf(id))
+                            // sellerNickname 필드만 새 값으로 변경 (나머지 필드는 그대로 유지)
+                            .withDocument(Document.create().append("sellerNickname", nickname))
+                            .build())
+                    .toList();
+
+            elasticsearchOperations.bulkUpdate(updateQueries, IndexCoordinates.of("products"));
+            log.info("판매자 닉네임 ES 일괄 업데이트 완료: sellerId={}, nickname={}, updated={}",
+                    sellerId, nickname, productIds.size());
+        } catch (Exception e) {
+            log.error("판매자 닉네임 ES 업데이트 실패: sellerId={}, nickname={}", sellerId, nickname, e);
+            throw new ProductException(ProductErrorCode.ES_NICKNAME_UPDATE_FAILED);
+        }
     }
 
     private Sort buildSort(ProductSearchSortType sortType) {

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/repository/ProductRepository.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/repository/ProductRepository.java
@@ -22,6 +22,9 @@ public interface ProductRepository extends JpaRepository<ProductJpa, Long>, Prod
     @Query("SELECT p FROM ProductJpa p WHERE p.id = :id")
     Optional<ProductJpa> findByIdForUpdate(@Param("id") Long id);
 
+    @Query("SELECT p.id FROM ProductJpa p WHERE p.sellerId = :sellerId AND p.deletedAt IS NULL")
+    List<Long> findActiveProductIdsBySellerId(@Param("sellerId") Long sellerId);
+
     @Query("SELECT p.id FROM ProductJpa p WHERE p.deletedAt IS NOT NULL AND p.deletedAt < :cutoff")
     List<Long> findExpiredDeletedProductIds(@Param("cutoff") LocalDateTime cutoff);
 

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/repository/ProductRepository.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/repository/ProductRepository.java
@@ -22,7 +22,7 @@ public interface ProductRepository extends JpaRepository<ProductJpa, Long>, Prod
     @Query("SELECT p FROM ProductJpa p WHERE p.id = :id")
     Optional<ProductJpa> findByIdForUpdate(@Param("id") Long id);
 
-    @Query("SELECT p.id FROM ProductJpa p WHERE p.sellerId = :sellerId AND p.deletedAt IS NULL")
+    @Query("SELECT p.id FROM ProductJpa p WHERE p.sellerId = :sellerId AND p.status NOT IN ('DRAFT', 'REJECTED') AND p.deletedAt IS NULL")
     List<Long> findActiveProductIdsBySellerId(@Param("sellerId") Long sellerId);
 
     @Query("SELECT p.id FROM ProductJpa p WHERE p.deletedAt IS NOT NULL AND p.deletedAt < :cutoff")

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/out/ProductEsPort.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/out/ProductEsPort.java
@@ -12,4 +12,6 @@ public interface ProductEsPort {
     PageResponse<ProductResult> searchProducts(ProductEsSearchCommand command);
 
     void deleteById(Long productId);
+
+    void updateSellerNickname(Long sellerId, String nickname);
 }

--- a/bc/catalog/src/main/java/app/giftify/product/domain/exception/ProductErrorCode.java
+++ b/bc/catalog/src/main/java/app/giftify/product/domain/exception/ProductErrorCode.java
@@ -45,7 +45,8 @@ public enum ProductErrorCode implements ErrorCode {
     PRODUCT_STOCK_LOCK_TIMEOUT(HttpStatus.CONFLICT.value(), "P501", "일시적인 문제가 발생했습니다. 다시 시도하세요."),
     PRODUCT_STOCK_CHANGED(HttpStatus.CONFLICT.value(), "P502", "재고가 변경되었습니다. 다시 시도하세요."),
     EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "P503", "외부 API 호출 중 오류가 발생했습니다."),
-    EXTERNAL_API_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE.value(), "P504", "외부 서비스에 연결할 수 없습니다.");
+    EXTERNAL_API_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE.value(), "P504", "외부 서비스에 연결할 수 없습니다."),
+    ES_NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "P505", "ES 닉네임 업데이트에 실패했습니다.");
 
     private final int statusCode;
     private final String code;

--- a/bc/catalog/src/main/java/app/giftify/replica/member/MemberEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/replica/member/MemberEventListener.java
@@ -4,6 +4,7 @@ import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.member.MemberSignedEvent;
 import app.giftify.shared.domain.event.member.MemberUpdatedEvent;
 import app.giftify.shared.domain.event.member.SellerNicknameChangedEvent;
+import app.giftify.shared.domain.type.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
@@ -24,7 +25,8 @@ public class MemberEventListener {
     @ApplicationModuleListener
     public void handle(MemberUpdatedEvent event) {
         syncMember(event.getMemberId(), event.getNickname());
-        eventPublisher.publish(new SellerNicknameChangedEvent(event.getMemberId(), event.getNickname()));
+        if (event.getRole() == MemberRole.SELLER)
+            eventPublisher.publish(new SellerNicknameChangedEvent(event.getMemberId(), event.getNickname()));
     }
 
     private void syncMember(Long memberId, String nickname) {

--- a/bc/catalog/src/main/java/app/giftify/replica/member/MemberEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/replica/member/MemberEventListener.java
@@ -1,7 +1,9 @@
 package app.giftify.replica.member;
 
+import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.member.MemberSignedEvent;
 import app.giftify.shared.domain.event.member.MemberUpdatedEvent;
+import app.giftify.shared.domain.event.member.SellerNicknameChangedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MemberEventListener {
     private final MemberSyncUseCase memberSyncUseCase;
+    private final EventPublisher eventPublisher;
 
     // 회원가입 시 멤버 레플리카 동기화
     @ApplicationModuleListener
@@ -17,10 +20,11 @@ public class MemberEventListener {
         syncMember(event.getMemberId(), event.getNickname());
     }
 
-    // 닉네임 수정 시 멤버 레플리카 동기화
+    // 닉네임 수정 시 멤버 레플리카 동기화 및 ES 닉네임 업데이트 이벤트 발행 (이벤트 체이닝)
     @ApplicationModuleListener
     public void handle(MemberUpdatedEvent event) {
         syncMember(event.getMemberId(), event.getNickname());
+        eventPublisher.publish(new SellerNicknameChangedEvent(event.getMemberId(), event.getNickname()));
     }
 
     private void syncMember(Long memberId, String nickname) {

--- a/bc/catalog/src/test/java/app/giftify/product/ProductJpaTestApplication.java
+++ b/bc/catalog/src/test/java/app/giftify/product/ProductJpaTestApplication.java
@@ -80,6 +80,10 @@ public class ProductJpaTestApplication {
             @Override
             public void deleteById(Long productId) {
             }
+
+            @Override
+            public void updateSellerNickname(Long sellerId, String nickname) {
+            }
         };
     }
 

--- a/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEsEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEsEventListenerTest.java
@@ -4,6 +4,7 @@ import app.giftify.product.application.port.out.ProductEsPort;
 import app.giftify.product.application.support.ProductSupport;
 import app.giftify.product.domain.Product;
 import app.giftify.product.domain.event.ProductAcceptedEvent;
+import app.giftify.shared.domain.event.member.SellerNicknameChangedEvent;
 import app.giftify.shared.domain.event.product.ProductDeletedEvent;
 import app.giftify.shared.domain.event.product.ProductSaleDisabledEvent;
 import app.giftify.shared.domain.event.product.ProductSaleEnabledEvent;
@@ -105,6 +106,21 @@ class ProductEsEventListenerTest {
 
         // then
         verify(productEsPort).deleteById(productId);
+    }
+
+    @Test
+    @DisplayName("SellerNicknameChangedEvent가 발행되면 해당 판매자의 ES 도큐먼트 닉네임을 일괄 업데이트한다.")
+    void handleSellerNicknameChanged() {
+        // given
+        Long sellerId = 1L;
+        String newNickname = "새닉네임";
+        SellerNicknameChangedEvent event = new SellerNicknameChangedEvent(sellerId, newNickname);
+
+        // when
+        listener.handleSellerNicknameChanged(event);
+
+        // then
+        verify(productEsPort).updateSellerNickname(sellerId, newNickname);
     }
 
     private Product createProduct(Long productId) {

--- a/bc/catalog/src/test/java/app/giftify/replica/member/MemberEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/replica/member/MemberEventListenerTest.java
@@ -1,0 +1,57 @@
+package app.giftify.replica.member;
+
+import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.event.member.MemberUpdatedEvent;
+import app.giftify.shared.domain.event.member.SellerNicknameChangedEvent;
+import app.giftify.shared.domain.type.MemberRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class MemberEventListenerTest {
+
+    private final MemberSyncUseCase memberSyncUseCase = Mockito.mock(MemberSyncUseCase.class);
+    private final EventPublisher eventPublisher = Mockito.mock(EventPublisher.class);
+    private final MemberEventListener listener = new MemberEventListener(memberSyncUseCase, eventPublisher);
+
+    @Test
+    @DisplayName("SELLER 닉네임 변경 시 레플리카 동기화 후 SellerNicknameChangedEvent를 발행한다")
+    void sellerUpdated_publishesSellerNicknameChangedEvent() {
+        // given
+        Long memberId = 1L;
+        String nickname = "새닉네임";
+        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, "auth0|test", nickname, MemberRole.SELLER);
+
+        // when
+        listener.handle(event);
+
+        // then
+        verify(memberSyncUseCase).syncMember(memberId, nickname);
+        ArgumentCaptor<SellerNicknameChangedEvent> captor = ArgumentCaptor.forClass(SellerNicknameChangedEvent.class);
+        verify(eventPublisher).publish(captor.capture());
+        assertThat(captor.getValue().getSellerId()).isEqualTo(memberId);
+        assertThat(captor.getValue().getNickname()).isEqualTo(nickname);
+    }
+
+    @Test
+    @DisplayName("BUYER 닉네임 변경 시 레플리카 동기화만 하고 SellerNicknameChangedEvent는 발행하지 않는다")
+    void buyerUpdated_doesNotPublishSellerNicknameChangedEvent() {
+        // given
+        Long memberId = 2L;
+        String nickname = "바이어닉네임";
+        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, "auth0|test2", nickname, MemberRole.BUYER);
+
+        // when
+        listener.handle(event);
+
+        // then
+        verify(memberSyncUseCase).syncMember(memberId, nickname);
+        verify(eventPublisher, never()).publish(any(SellerNicknameChangedEvent.class));
+    }
+}

--- a/bc/core/src/test/java/app/giftify/replica/MemberReplicaEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/replica/MemberReplicaEventListenerTest.java
@@ -2,6 +2,7 @@ package app.giftify.replica;
 
 import app.giftify.shared.domain.event.member.MemberSignedEvent;
 import app.giftify.shared.domain.event.member.MemberUpdatedEvent;
+import app.giftify.shared.domain.type.MemberRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,7 @@ class MemberReplicaEventListenerTest {
     void handleMemberUpdatedEvent() {
         Long memberId = 1L;
         String nickname = "수정된닉네임";
-        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, "auth0|user1", nickname);
+        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, "auth0|user1", nickname, MemberRole.BUYER);
 
         listener.handle(event);
 

--- a/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
+++ b/bc/member/src/main/java/app/giftify/member/application/service/MemberService.java
@@ -1,10 +1,5 @@
 package app.giftify.member.application.service;
 
-import java.util.Optional;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import app.giftify.auth.application.TokenBlacklistService;
 import app.giftify.member.adapter.in.web.dto.SignupRequest;
 import app.giftify.member.application.port.in.GetMemberUseCase;
@@ -21,140 +16,145 @@ import app.giftify.shared.domain.event.member.MemberSignedEvent;
 import app.giftify.shared.domain.event.member.MemberUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MemberService
-	implements GetMemberUseCase, RegisterMemberUseCase, UpdateMemberUseCase, WithdrawMemberUseCase {
+        implements GetMemberUseCase, RegisterMemberUseCase, UpdateMemberUseCase, WithdrawMemberUseCase {
 
-	private final MemberRepositoryPort memberRepositoryPort;
-	private final EventPublisher eventPublisher;
-	private final NicknameGenerator nicknameGenerator;
-	private final TokenBlacklistService tokenBlacklistService;
+    private final MemberRepositoryPort memberRepositoryPort;
+    private final EventPublisher eventPublisher;
+    private final NicknameGenerator nicknameGenerator;
+    private final TokenBlacklistService tokenBlacklistService;
 
-	@Override
-	public Optional<Member> getMemberByAuthSub(String authSub) {
-		return memberRepositoryPort.findByAuthSub(authSub);
-	}
+    @Override
+    public Optional<Member> getMemberByAuthSub(String authSub) {
+        return memberRepositoryPort.findByAuthSub(authSub);
+    }
 
-	@Override
-	public Optional<Member> getMemberById(Long id) {
-		return memberRepositoryPort.findById(id);
-	}
+    @Override
+    public Optional<Member> getMemberById(Long id) {
+        return memberRepositoryPort.findById(id);
+    }
 
-	@Override
-	public Member registerMember(RegisterCommand command) {
-		Optional<Member> existingMember = memberRepositoryPort.findByAuthSub(command.authSub());
-		if (existingMember.isPresent()) {
-			Member member = existingMember.get();
-			if (member.isWithdrawn()) {
-				member.reactivate();
-				Member reactivated = memberRepositoryPort.save(member);
-				log.info("[MemberService] 탈퇴 회원 재활성화: memberId={}", reactivated.getId());
-				return reactivated;
-			}
-			throw new DuplicateMemberException(command.authSub());
-		}
+    @Override
+    public Member registerMember(RegisterCommand command) {
+        Optional<Member> existingMember = memberRepositoryPort.findByAuthSub(command.authSub());
+        if (existingMember.isPresent()) {
+            Member member = existingMember.get();
+            if (member.isWithdrawn()) {
+                member.reactivate();
+                Member reactivated = memberRepositoryPort.save(member);
+                log.info("[MemberService] 탈퇴 회원 재활성화: memberId={}", reactivated.getId());
+                return reactivated;
+            }
+            throw new DuplicateMemberException(command.authSub());
+        }
 
-		// 닉네임이 없으면 자동 생성
-		String nickname = command.nickname();
-		if (nickname == null || nickname.isBlank()) {
-			nickname = nicknameGenerator.generate();
-			log.info("[MemberService] 닉네임 자동 생성: {}", nickname);
-		}
+        // 닉네임이 없으면 자동 생성
+        String nickname = command.nickname();
+        if (nickname == null || nickname.isBlank()) {
+            nickname = nicknameGenerator.generate();
+            log.info("[MemberService] 닉네임 자동 생성: {}", nickname);
+        }
 
-		Member member = Member.builder()
-			.authSub(command.authSub())
-			.email(command.email())
-			.nickname(nickname)
-			.birthday(command.birthday())
-			.address(command.address())
-			.phoneNum(command.phoneNum())
-			.name(command.name())
-			.build();
+        Member member = Member.builder()
+                .authSub(command.authSub())
+                .email(command.email())
+                .nickname(nickname)
+                .birthday(command.birthday())
+                .address(command.address())
+                .phoneNum(command.phoneNum())
+                .name(command.name())
+                .build();
 
-		Member savedMember = memberRepositoryPort.save(member);
+        Member savedMember = memberRepositoryPort.save(member);
 
-		eventPublisher.publish(
-			new MemberSignedEvent(
-				savedMember.getId(),
-				savedMember.getAuthSub(),
-				savedMember.getNickname()
-			)
-		);
+        eventPublisher.publish(
+                new MemberSignedEvent(
+                        savedMember.getId(),
+                        savedMember.getAuthSub(),
+                        savedMember.getNickname()
+                )
+        );
 
-		return savedMember;
-	}
+        return savedMember;
+    }
 
-	@Override
-	public Member signup(String authSub, SignupRequest request) {
-		Member member = memberRepositoryPort.findByAuthSub(authSub)
-			.orElseThrow(() -> new MemberNotFoundException(authSub));
+    @Override
+    public Member signup(String authSub, SignupRequest request) {
+        Member member = memberRepositoryPort.findByAuthSub(authSub)
+                .orElseThrow(() -> new MemberNotFoundException(authSub));
 
-		member.updateProfile(request.birthday(), request.address(), request.phoneNum());
+        member.updateProfile(request.birthday(), request.address(), request.phoneNum());
 
-		if (request.nickname() != null && !request.nickname().isBlank()) {
-			member.updateInfo(request.nickname(), null, null, null);
-		}
+        if (request.nickname() != null && !request.nickname().isBlank()) {
+            member.updateInfo(request.nickname(), null, null, null);
+        }
 
-		Member updatedMember = memberRepositoryPort.save(member);
+        Member updatedMember = memberRepositoryPort.save(member);
 
-		log.info("[MemberService] 프로필 정보 업데이트 완료: memberId={}", updatedMember.getId());
+        log.info("[MemberService] 프로필 정보 업데이트 완료: memberId={}", updatedMember.getId());
 
-		return updatedMember;
-	}
+        return updatedMember;
+    }
 
-	@Override
-	public Member updateMember(UpdateCommand command) {
-		Member member = memberRepositoryPort.findByAuthSub(command.authSub())
-			.orElseThrow(() -> new MemberNotFoundException(command.authSub()));
+    @Override
+    public Member updateMember(UpdateCommand command) {
+        Member member = memberRepositoryPort.findByAuthSub(command.authSub())
+                .orElseThrow(() -> new MemberNotFoundException(command.authSub()));
 
-		member.validateActiveStatus();
+        member.validateActiveStatus();
 
-		member.updateInfo(command.nickname(), command.address(), command.phoneNum(),
-			command.name());
+        member.updateInfo(command.nickname(), command.address(), command.phoneNum(),
+                command.name());
 
-		Member updatedMember = memberRepositoryPort.save(member);
+        Member updatedMember = memberRepositoryPort.save(member);
 
-		eventPublisher.publish(
-			new MemberUpdatedEvent(
-				updatedMember.getId(),
-				updatedMember.getAuthSub(),
-				updatedMember.getNickname()
-			)
-		);
+        eventPublisher.publish(
+                new MemberUpdatedEvent(
+                        updatedMember.getId(),
+                        updatedMember.getAuthSub(),
+                        updatedMember.getNickname(),
+                        updatedMember.getRole()
+                )
+        );
 
-		log.info("[MemberService] 회원 정보 업데이트 완료: memberId={}", updatedMember.getId());
+        log.info("[MemberService] 회원 정보 업데이트 완료: memberId={}", updatedMember.getId());
 
-		return updatedMember;
-	}
+        return updatedMember;
+    }
 
-	@Override
-	public void withdrawMember(String authSub) {
-		Member member = memberRepositoryPort.findByAuthSub(authSub)
-			.orElseThrow(() -> new MemberNotFoundException(authSub));
+    @Override
+    public void withdrawMember(String authSub) {
+        Member member = memberRepositoryPort.findByAuthSub(authSub)
+                .orElseThrow(() -> new MemberNotFoundException(authSub));
 
-		member.validateActiveStatus();
+        member.validateActiveStatus();
 
-		member.withdraw();
+        member.withdraw();
 
-		memberRepositoryPort.save(member);
+        memberRepositoryPort.save(member);
 
-		// 토큰 무효화 - 탈퇴 후 기존 토큰으로 API 호출 방지
-		tokenBlacklistService.revokeAllUserTokens(authSub);
+        // 토큰 무효화 - 탈퇴 후 기존 토큰으로 API 호출 방지
+        tokenBlacklistService.revokeAllUserTokens(authSub);
 
-		log.info("[MemberService] 회원 탈퇴 및 토큰 무효화: authSub={}", authSub);
-	}
+        log.info("[MemberService] 회원 탈퇴 및 토큰 무효화: authSub={}", authSub);
+    }
 
-	@Override
-	public boolean existsByEmail(String email) {
-		return memberRepositoryPort.findByEmail(email).isPresent();
-	}
+    @Override
+    public boolean existsByEmail(String email) {
+        return memberRepositoryPort.findByEmail(email).isPresent();
+    }
 
-	@Override
-	public boolean isNicknameDuplicated(String nickname) {
-		return memberRepositoryPort.findByNickname(nickname).isPresent();
-	}
+    @Override
+    public boolean isNicknameDuplicated(String nickname) {
+        return memberRepositoryPort.findByNickname(nickname).isPresent();
+    }
 }

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/member/MemberUpdatedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/member/MemberUpdatedEvent.java
@@ -1,17 +1,20 @@
 package app.giftify.shared.domain.event.member;
 
 import app.giftify.shared.domain.event.BaseDomainEvent;
+import app.giftify.shared.domain.type.MemberRole;
 
 public class MemberUpdatedEvent extends BaseDomainEvent {
     private final Long memberId;
     private final String authSub;
     private final String nickname;
+    private final MemberRole role;
 
-    public MemberUpdatedEvent(Long memberId, String authSub, String nickname) {
+    public MemberUpdatedEvent(Long memberId, String authSub, String nickname, MemberRole role) {
         super();
         this.memberId = memberId;
         this.authSub = authSub;
         this.nickname = nickname;
+        this.role = role;
     }
 
     public Long getMemberId() {
@@ -26,12 +29,17 @@ public class MemberUpdatedEvent extends BaseDomainEvent {
         return nickname;
     }
 
+    public MemberRole getRole() {
+        return role;
+    }
+
     @Override
     public String toString() {
         return "MemberSignedEvent{" +
                 "memberId=" + memberId +
                 ", authSub='" + authSub + '\'' +
                 ", nickname='" + nickname + '\'' +
+                ", role='" + role + '\'' +
                 '}';
     }
 }

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/member/SellerNicknameChangedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/member/SellerNicknameChangedEvent.java
@@ -1,0 +1,30 @@
+package app.giftify.shared.domain.event.member;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+
+public class SellerNicknameChangedEvent extends BaseDomainEvent {
+    private final Long sellerId;
+    private final String nickname;
+
+    public SellerNicknameChangedEvent(Long sellerId, String nickname) {
+        super();
+        this.sellerId = sellerId;
+        this.nickname = nickname;
+    }
+
+    public Long getSellerId() {
+        return sellerId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    @Override
+    public String toString() {
+        return "SellerNicknameChangedEvent{" +
+                "sellerId=" + sellerId +
+                ", nickname='" + nickname + '\'' +
+                '}';
+    }
+}

--- a/bc/shared/src/test/java/app/giftify/shared/domain/event/member/MemberEventTest.java
+++ b/bc/shared/src/test/java/app/giftify/shared/domain/event/member/MemberEventTest.java
@@ -1,5 +1,6 @@
 package app.giftify.shared.domain.event.member;
 
+import app.giftify.shared.domain.type.MemberRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -32,14 +33,16 @@ class MemberEventTest {
         Long memberId = 1L;
         String authSub = "auth0|123";
         String nickname = "newTester";
+        MemberRole role = MemberRole.BUYER;
 
         // when
-        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, authSub, nickname);
+        MemberUpdatedEvent event = new MemberUpdatedEvent(memberId, authSub, nickname, role);
 
         // then
         assertThat(event.getMemberId()).isEqualTo(memberId);
         assertThat(event.getAuthSub()).isEqualTo(authSub);
         assertThat(event.getNickname()).isEqualTo(nickname);
+        assertThat(event.getRole()).isEqualTo(role);
         assertThat(event.toString()).contains("memberId=1", "authSub='auth0|123'", "nickname='newTester'");
     }
 }


### PR DESCRIPTION
## Summary

판매자(멤버)가 닉네임을 변경하면 상품 검색 결과에 이전 닉네임이 그대로 노출되는 문제를 해결합니다.                                             
   
상품 검색 API는 Elasticsearch의 ProductDocument.sellerNickname을 기반으로 응답하는데, 닉네임 변경 시 ES 도큐먼트를 갱신하는 로직이 누락되어 있었습니다. 
이를 이벤트 체이닝 패턴을 통해 멤버 레플리카 동기화와 ES 도큐먼트 업데이트를 순차적으로, 그러나 트랜잭션은 분리하여 처리하도록 구현했습니다. 

---

## What's Changed

### 이벤트 흐름
```
  MemberUpdatedEvent
    → MemberEventListener: 멤버 레플리카 동기화 (트랜잭션 커밋)
    → event.getRole == "SELLER" 이면, SellerNicknameChangedEvent 발행
      → ProductEsEventListener: RDB에서 삭제, DRAFT, REJECTED 제외한 상품 ID 조회 → ES bulkUpdate
```

### 추가 개선 사항

  - **SELLER role 조건 추가**: BUYER/ADMIN 닉네임 변경 시 불필요한 SellerNicknameChangedEvent 발행 방지
  - **ES 업데이트 대상 필터링**: DRAFT, REJECTED 상품은 ES에 인덱싱되지 않으므로 bulkUpdate 대상에서 제외 (`NOT IN ('DRAFT', 'REJECTED')`)
  - **부분 실패 허용**: RDB-ES 간 동기화 차이로 일부 도큐먼트가 누락된 경우, 전체 실패 대신 성공 건은 반영하고 실패 건만 warn 로그 기록
---

## Decisions & Trade-offs

### ES update-by-query 대신 RDB 조회 + bulkUpdate 선택


구분 | ES update-by-query | RDB 조회 + bulkUpdate (채택)
-- | -- | --
추가 의존성 | ElasticsearchClient (저수준 클라이언트) 필요 | 기존 ElasticsearchOperations로 충분
스키마 변경 | ProductDocument에 sellerId 필드 추가 필요 → 재인덱싱 필요 | 변경 없음
RDB 조회 | 불필요 | 필요

  저수준 클라이언트 혼용을 피하고, 스키마 변경 없이 기존 인프라만으로 해결할 수 있는 방식을 선택했습니다.

### 단일 핸들러 직접 호출 대신 이벤트 체이닝 선택

MemberEventListener에서 레플리카 동기화 + ES 업데이트를 한 번에 처리하면 간단하지만, 
@ApplicationModuleListener가 @Transactional이므로, ES  업데이트 실패 시 레플리카 동기화까지 롤백되는 문제가 있었습니다. 
이벤트 체이닝으로 트랜잭션을 분리하여 실패를 격리했습니다.

### SellerNicknameChangedEvent를 shared 모듈에 배치

발행자(replica.member)와 소비자(product)가 서로 다른 패키지에 있어, product.domain.event에 두면 replica → product 방향의 의존성이 생깁니다.
shared 모듈에 배치하여 의존 방향을 깔끔하게 유지했습니다.

---

## Future Improvements

  - 대량 상품 판매자 대응: 현재 bulkUpdate는 한 번에 모든 상품 ID를 처리합니다. 판매자의 상품 수가 매우 많아지면 chunk 단위 분할 처리를 고려할 수 있습니다.
  - ES update-by-query 재검토: 향후 ProductDocument에 sellerId 필드가 검색 등 다른 용도로 필요해지면, 그 시점에 update-by-query 방식으로 전환하여 RDB 조회를 제거할 수 있습니다.
