### PR TITLE
Jackson 3.x Record non-component 메서드 직렬화 핫픽스

### DIFF
--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsApi.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsApi.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -70,6 +71,7 @@ public interface TossPaymentsApi {
 		String code,
 		String message
 	) {
+		@JsonIgnore
 		public boolean isSuccess() {
 			return code == null;
 		}

--- a/bc/core/src/main/java/app/giftify/payment/application/inbound/CreateFundingPaymentCommand.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/inbound/CreateFundingPaymentCommand.java
@@ -2,6 +2,8 @@ package app.giftify.payment.application.inbound;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import app.giftify.payment.domain.OrderItemSnapshot;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
@@ -54,6 +56,7 @@ public record CreateFundingPaymentCommand(
 	/**
 	 * 펀딩 결제의 PaymentType은 항상 FUNDING
 	 */
+	@JsonIgnore
 	public PaymentType getType() {
 		return PaymentType.FUNDING;
 	}

--- a/bc/shared/src/main/java/app/giftify/shared/api/paging/PageRequest.java
+++ b/bc/shared/src/main/java/app/giftify/shared/api/paging/PageRequest.java
@@ -1,5 +1,7 @@
 package app.giftify.shared.api.paging;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public record PageRequest(int page, int size) {
 
     public PageRequest {
@@ -22,6 +24,7 @@ public record PageRequest(int page, int size) {
         return new PageRequest(0, 10);
     }
 
+    @JsonIgnore
     public long getOffset() {
         return (long) page * size;
     }

--- a/bc/shared/src/main/java/app/giftify/shared/domain/vo/MemberInfo.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/vo/MemberInfo.java
@@ -1,5 +1,7 @@
 package app.giftify.shared.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import app.giftify.shared.domain.type.MemberRole;
 
 /**
@@ -45,6 +47,7 @@ public record MemberInfo(
 	 *
 	 * @return memberId가 존재하면 true
 	 */
+	@JsonIgnore
 	public boolean isRegistered() {
 		return memberId != null;
 	}


### PR DESCRIPTION
 ## Summary      

  Spring Boot 4.0.3 업그레이드 후 Jackson 3.x가 Record의 non-component `is*()`/`get*()` 메서드를 property getter로 인식하여 RestClient 역직렬화 시 `Unrecognized property` 에러가 발생합니다.       
   
  **증상**: `MemberPrincipalFilter`에서 내부 API 호출 시 `Unrecognized property "registered" (class MemberInfo)` — 회원 닉네임 수정, 로그인 등 전체 인증 플로우가 동작하지 않는 상태.               
                  
  **원인**: Jackson 3.x는 Record의 `isRegistered()` 같은 helper 메서드를 boolean property getter로 감지하여 `"registered": true`를 JSON에 추가. 역직렬화 시 Record component에 `registered`가       
  없으므로 실패.  
                                                                                                                                                                                                    
###   **리뷰 포인트**: Domain VO(`MemberInfo`)에 Jackson 어노테이션이 침투하는 점을 임시 수용한 판단이 적절한지.                                                                                        
   
  ---                                                                                                                                                                                               
                  
  ## What's Changed

  영향받는 Record의 non-component 메서드에 `@JsonIgnore` 적용 (4건):                                                                                                                                
   
  | Record | 메서드 | 위험도 |                                                                                                                                                                      
  |--------|--------|--------|
  | `MemberInfo` | `isRegistered()` | **실제 에러 발생** |
  | `TossPaymentResponse` | `isSuccess()` | PG 연동 잠재적 |                                                                                                                                        
  | `PageRequest` | `getOffset()` | 방어적 |
  | `CreateFundingPaymentCommand` | `getType()` | 방어적 |                                                                                                                                          
                                                                                                                                                                                                    
  영향받지 않는 것:
  - Enum `is*()` — name 문자열 직렬화라 안전 (PaymentMethod, TargetType)                                                                                                                            
  - Money `is*()` — `@JsonValue`가 우선하므로 안전                                                                                                                                                  
  - `has*()` 메서드 — Jackson이 getter로 인식하지 않음
                                                                                                                                                                                                    
  ---             
                                                                                                                                                                                                    
  ## Decisions & Trade-offs                                                                                                                                                                         
   
  ### `@JsonIgnore` 개별 적용 vs 전역 설정                                                                                                                                                          
                  
  전역으로 IS_GETTER visibility를 끄는 `JsonMapperBuilderCustomizer` 방안도 검토했으나, Jackson 3.x 본격 마이그레이션과 함께 진행하는 것이 안전하다고 판단했습니다. 핫픽스 범위를 최소한으로        
  유지하기 위해 개별 `@JsonIgnore`를 선택했습니다.
                                                                                                                                                                                                    
  ### `spring.jackson.use-jackson2-defaults=true`로 해결 안 되는 이유                                                                                                                               
   
  이 설정은 날짜 포맷, Locale 등 Jackson 3에서 변경된 기본값을 Jackson 2 스타일로 되돌리는 것이지, `is*()` auto-detection 동작을 변경하지 않습니다. Jackson 2에서도 `isRegistered()`는 getter로     
  인식했고, 당시엔 `FAIL_ON_UNKNOWN_PROPERTIES=false`가 Spring Boot에 의해 RestClient에 적용되어 조용히 무시되었을 뿐입니다.
                                                                                                                                                                                                    
  ---             

  ## Future Improvements

  - [ ] `JsonMapperBuilderCustomizer`로 IS_GETTER visibility 전역 비활성화 (또는 Jackson 3.1 `INFER_RECORD_GETTERS_FROM_COMPONENTS_ONLY`)                                                           
  - [ ] `Jackson2ObjectMapperBuilderCustomizer` → `JsonMapperBuilderCustomizer` 전환 (Spring Boot 4.2에서 제거 예정)
  - [ ] `com.fasterxml.jackson` → `tools.jackson` 패키지 마이그레이션 (OpenRewrite `UpgradeJackson_2_3` 레시피 활용)                                                                                
  - [ ] `spring.jackson.use-jackson2-defaults: true` 제거 후 Jackson 3 네이티브 기본값 전환                                                                                                         
                                                                                                                                                                                                    
  ---                                                                                                                                                                                               
                                                                                                                                                                                                    
  ### Linked Issues                                                                                                                                                                                 
   
  - closes #  