### PR TITLE
펀딩/일반 주문의 상품 재고 차감 프로세스 통합

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
@@ -24,7 +24,7 @@ public class ProductEventListener {
     // 주문의 이벤트를 받아 상품 재고 감소 (펀딩/일반 주문 통합)
     @EventListener
     public void handleOrderConfirmed(OrderConfirmPendingEvent event) {
-        Map<Long, Long> productQuantityMap = event.getItems().stream()
+        Map<Long, Integer> productQuantityMap = event.getItems().stream()
                 .collect(Collectors.toMap(ConfirmItem::productId, ConfirmItem::quantity));
         log.info("[product] 주문 확정 진행 이벤트를 받았습니다. | 상품 수: {}", productQuantityMap.size());
 

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
@@ -26,10 +26,10 @@ public class ProductEventListener {
     public void handleOrderConfirmed(OrderConfirmPendingEvent event) {
         Map<Long, Long> productQuantityMap = event.getItems().stream()
                 .collect(Collectors.toMap(ConfirmItem::productId, ConfirmItem::quantity));
-        log.info("[product] 주문 확정 이벤트를 받았습니다. | 상품 수: {}", productQuantityMap.size());
+        log.info("[product] 주문 확정 진행 이벤트를 받았습니다. | 상품 수: {}", productQuantityMap.size());
 
         decreaseProductStockUseCase.decreaseStockByOrder(productQuantityMap);
-        log.info("[product] 주문 재고 차감 완료 | 상품 수: {}", productQuantityMap.size());
+        log.info("[product] 주문 상품 재고 차감 완료 | 상품 수: {}", productQuantityMap.size());
     }
 
     // 재고 이력 생성

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
@@ -3,12 +3,16 @@ package app.giftify.product.adapter.inbound.event;
 import app.giftify.product.application.port.in.DecreaseProductStockUseCase;
 import app.giftify.product.application.port.in.StockHistoryCreateUseCase;
 import app.giftify.product.domain.event.ProductStockUpdatedEvent;
-import app.giftify.shared.domain.event.funding.FundingAcceptedEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
+import app.giftify.shared.domain.vo.ConfirmItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -17,14 +21,15 @@ public class ProductEventListener {
     private final DecreaseProductStockUseCase decreaseProductStockUseCase;
     private final StockHistoryCreateUseCase stockHistoryCreateUseCase;
 
-    // 펀딩 수락 시 재고 감소
+    // 주문의 이벤트를 받아 상품 재고 감소 (펀딩/일반 주문 통합)
     @EventListener
-    public void handleFundingAccepted(FundingAcceptedEvent event) {
-        Long productId = event.getProductId();
-        log.info("[product] 펀딩 수락 이벤트를 받았습니다.  | productId: {}", productId);
+    public void handleOrderConfirmed(OrderConfirmPendingEvent event) {
+        Map<Long, Long> productQuantityMap = event.getItems().stream()
+                .collect(Collectors.toMap(ConfirmItem::productId, ConfirmItem::quantity));
+        log.info("[product] 주문 확정 이벤트를 받았습니다. | 상품 수: {}", productQuantityMap.size());
 
-        decreaseProductStockUseCase.decreaseStockByFunding(productId);
-        log.info("[product] 상품 재고 차감 완료 | productId: {}", productId);
+        decreaseProductStockUseCase.decreaseStockByOrder(productQuantityMap);
+        log.info("[product] 주문 재고 차감 완료 | 상품 수: {}", productQuantityMap.size());
     }
 
     // 재고 이력 생성

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
@@ -3,9 +3,6 @@ package app.giftify.product.application.port.in;
 import java.util.Map;
 
 public interface DecreaseProductStockUseCase {
-    // 펀딩에 의한 재고 감소
-    // void decreaseStockByFunding(Long productId);
-
     // 주문에 의한 재고 감소 (펀딩/일반 주문 통합)
     void decreaseStockByOrder(Map<Long, Long> productQuantityMap);
 }

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
@@ -1,8 +1,11 @@
 package app.giftify.product.application.port.in;
 
+import java.util.Map;
+
 public interface DecreaseProductStockUseCase {
     // 펀딩에 의한 재고 감소
-    void decreaseStockByFunding(Long productId);
+    // void decreaseStockByFunding(Long productId);
 
-    // todo 일반 주문에 의한 재고 감소
+    // 주문에 의한 재고 감소 (펀딩/일반 주문 통합)
+    void decreaseStockByOrder(Map<Long, Long> productQuantityMap);
 }

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
@@ -4,5 +4,5 @@ import java.util.Map;
 
 public interface DecreaseProductStockUseCase {
     // 주문에 의한 재고 감소 (펀딩/일반 주문 통합)
-    void decreaseStockByOrder(Map<Long, Long> productQuantityMap);
+    void decreaseStockByOrder(Map<Long, Integer> productQuantityMap);
 }

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static app.giftify.product.domain.ProductStatus.ACTIVE;
@@ -225,23 +226,30 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
     }
 
     /**
-     * 펀딩에 의한 재고 감소
-     * 비관적 락 - 배타 잠금 적용
+     * 주문에 의한 재고 감소 (펀딩/일반 주문 통합)
+     * 데드락 방지를 위해 productId 오름차순으로 배타 잠금 획득
      */
     @Transactional
     @Override
-    public void decreaseStockByFunding(Long productId) {
-        Product product;
-        try {
-            product = productSupport.findByIdForUpdate(productId); // 배타 잠금
-        } catch (PessimisticLockingFailureException e) {
-            throw new InfraException(PRODUCT_STOCK_LOCK_TIMEOUT);
+    public void decreaseStockByOrder(Map<Long, Long> productQuantityMap) {
+        var sorted = new TreeMap<>(productQuantityMap); // ProductId를 오름차순으로 정렬
+
+        for (var entry : sorted.entrySet()) {
+            Long productId = entry.getKey();
+            Long quantity = entry.getValue();
+
+            Product product;
+            try {
+                product = productSupport.findByIdForUpdate(productId);
+            } catch (PessimisticLockingFailureException e) {
+                throw new InfraException(PRODUCT_STOCK_LOCK_TIMEOUT);
+            }
+
+            product.decreaseStock(quantity.intValue());
+            productRepositoryPort.save(product);
+
+            product.pullEvents().forEach(eventPublisher::publish);
         }
-
-        product.decreaseStockByFunding();
-        productRepositoryPort.save(product);
-
-        product.pullEvents().forEach(eventPublisher::publish);
     }
 
     // 도메인 -> ProductResult(애플리케이션 전용 dto/queryModel)

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -231,12 +231,12 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
      */
     @Transactional
     @Override
-    public void decreaseStockByOrder(Map<Long, Long> productQuantityMap) {
+    public void decreaseStockByOrder(Map<Long, Integer> productQuantityMap) {
         var sorted = new TreeMap<>(productQuantityMap); // ProductId를 오름차순으로 정렬
 
         for (var entry : sorted.entrySet()) {
             Long productId = entry.getKey();
-            Long quantity = entry.getValue();
+            int quantity = entry.getValue();
 
             Product product;
             try {
@@ -245,7 +245,7 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
                 throw new InfraException(PRODUCT_STOCK_LOCK_TIMEOUT);
             }
 
-            product.decreaseStock(quantity.intValue());
+            product.decreaseStock(quantity);
             productRepositoryPort.save(product);
 
             product.pullEvents().forEach(eventPublisher::publish);

--- a/bc/catalog/src/main/java/app/giftify/product/domain/Product.java
+++ b/bc/catalog/src/main/java/app/giftify/product/domain/Product.java
@@ -148,31 +148,7 @@ public class Product extends BaseDomainModel {
         registerStockUpdatedEvent(this.sellerId, this.getId(), beforeStock, this.stock, newStock - beforeStock, StockChangeType.MANUAL_SELLER);
     }
 
-    // 펀딩에 의한 상품 재고 감소
-    public void decreaseStockByFunding() {
-        validateStockForFunding();
-
-        int beforeStock = this.stock;
-        --this.stock;
-
-        if (this.stock == 0 && this.status == ACTIVE)
-            registerEvent(new ProductSaleDisabledEvent(this.getId()));
-
-        registerStockUpdatedEvent(this.sellerId, this.getId(), beforeStock, this.stock, this.stock - beforeStock, StockChangeType.ORDER_COMPLETED);
-    }
-
-    // 펀딩에 의한 상품 재고 추가 (반품 등등)
-    public void increaseStockByFunding() {
-        int beforeStock = this.stock;
-        ++this.stock;
-
-        if (beforeStock == 0 && this.status == ACTIVE)
-            registerEvent(new ProductSaleEnabledEvent(this.getId()));
-
-        registerStockUpdatedEvent(this.sellerId, this.getId(), beforeStock, this.stock, this.stock - beforeStock, StockChangeType.ORDER_REFUNDED);
-    }
-
-    // 일반 주문에 의한 상품 재고 감소
+    // 주문에 의한 상품 재고 감소
     public void decreaseStock(int quantity) {
         validateStockForOrder(quantity);
 
@@ -185,7 +161,7 @@ public class Product extends BaseDomainModel {
         registerStockUpdatedEvent(this.sellerId, this.getId(), beforeStock, this.stock, this.stock - beforeStock, StockChangeType.ORDER_COMPLETED);
     }
 
-    // 일반 주문에 의한 상품 재고 추가 (반품 등등)
+    // 주문에 의한 상품 재고 추가 (반품 등등)
     public void increaseStock(int quantity) {
         int beforeStock = this.stock;
         this.stock += quantity;
@@ -196,14 +172,7 @@ public class Product extends BaseDomainModel {
         registerStockUpdatedEvent(this.sellerId, this.getId(), beforeStock, this.stock, this.stock - beforeStock, StockChangeType.ORDER_REFUNDED);
     }
 
-    // 펀딩 재고 검증: 펀딩은 항상 1개 차감이므로 재고가 1 미만이면 불가
-    private void validateStockForFunding() {
-        if (this.stock < 1) {
-            throw new ProductException(PRODUCT_OUT_OF_STOCK);
-        }
-    }
-
-    // 일반 주문 재고 검증: 주문 수량만큼 재고가 있어야 함
+    // 주문 재고 검증: 주문 수량만큼 재고가 있어야 함
     private void validateStockForOrder(int quantity) {
         if (this.stock < quantity) {
             throw new ProductException(PRODUCT_OUT_OF_STOCK);

--- a/bc/catalog/src/main/java/app/giftify/product/domain/StockChangeType.java
+++ b/bc/catalog/src/main/java/app/giftify/product/domain/StockChangeType.java
@@ -3,6 +3,6 @@ package app.giftify.product.domain;
 public enum StockChangeType {
     MANUAL_SYSTEM, // 관리자 수동 조정 (시스템 장애, 운영 이슈 등)
     MANUAL_SELLER, // 판매자 수동 수정
-    ORDER_COMPLETED, // 펀딩 성공으로 차감
-    ORDER_REFUNDED // 펀딩 취소/환불 복구
+    ORDER_COMPLETED, // 주문 성공으로 차감
+    ORDER_REFUNDED // 주문 취소/환불 복구
 }

--- a/bc/catalog/src/main/java/app/giftify/wishlist/adapter/in/event/WishlistEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/wishlist/adapter/in/event/WishlistEventListener.java
@@ -57,6 +57,7 @@ public class WishlistEventListener {
                 "[Wishlist] 위시리스트상품의 펀딩이 달성되었습니다.");
     }
 
+    // 펀딩 수령자의 수락 요청 -> 펀딩 수락 진행 -> 주문 확정 -> 펀딩 수락 변경 완료 -> 위시리스트아이템 COMPLETED
     @ApplicationModuleListener
     public void handleFundingAccepted(FundingAcceptedEvent event) {
         updateStatus(event.getWishlistItemId(),

--- a/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
@@ -43,8 +43,8 @@ class ProductEventListenerTest {
     void handleOrderConfirmed_Success() {
         // given
         List<ConfirmItem> items = List.of(
-                ConfirmItem.of(1L, 2L),
-                ConfirmItem.of(2L, 3L)
+                ConfirmItem.of(1L, 2),
+                ConfirmItem.of(2L, 3)
         );
         OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
 
@@ -53,19 +53,19 @@ class ProductEventListenerTest {
 
         // then
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<Map<Long, Long>> captor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Map<Long, Integer>> captor = ArgumentCaptor.forClass(Map.class);
         verify(decreaseProductStockUseCase).decreaseStockByOrder(captor.capture());
 
-        Map<Long, Long> captured = captor.getValue();
-        assertThat(captured).containsEntry(1L, 2L);
-        assertThat(captured).containsEntry(2L, 3L);
+        Map<Long, Integer> captured = captor.getValue();
+        assertThat(captured).containsEntry(1L, 2);
+        assertThat(captured).containsEntry(2L, 3);
     }
 
     @Test
     @DisplayName("주문 확정 이벤트 처리 중 재고가 부족하면 예외가 전파된다")
     void handleOrderConfirmed_OutOfStock() {
         // given
-        List<ConfirmItem> items = List.of(ConfirmItem.of(1L, 5L));
+        List<ConfirmItem> items = List.of(ConfirmItem.of(1L, 5));
         OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
 
         doThrow(new ProductException(ProductErrorCode.PRODUCT_OUT_OF_STOCK))
@@ -80,7 +80,7 @@ class ProductEventListenerTest {
     @DisplayName("주문 확정 이벤트 처리 중 상품이 존재하지 않으면 예외가 전파된다")
     void handleOrderConfirmed_ProductNotFound() {
         // given
-        List<ConfirmItem> items = List.of(ConfirmItem.of(999L, 1L));
+        List<ConfirmItem> items = List.of(ConfirmItem.of(999L, 1));
         OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
 
         doThrow(new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND))

--- a/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
@@ -7,17 +7,22 @@ import app.giftify.product.domain.StockChangeType;
 import app.giftify.product.domain.event.ProductStockUpdatedEvent;
 import app.giftify.product.domain.exception.ProductErrorCode;
 import app.giftify.product.domain.exception.ProductException;
-import app.giftify.shared.domain.event.funding.FundingAcceptedEvent;
+import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
+import app.giftify.shared.domain.vo.ConfirmItem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.doThrow;
 
@@ -34,50 +39,55 @@ class ProductEventListenerTest {
     private ProductEventListener productEventListener;
 
     @Test
-    @DisplayName("펀딩 수락 이벤트를 받으면 해당 상품의 재고를 감소시킨다")
-    void handleFundingAccepted_Success() {
+    @DisplayName("주문 확정 이벤트를 받으면 상품별 재고를 감소시킨다")
+    void handleOrderConfirmed_Success() {
         // given
-        Long productId = 1L;
-        FundingAcceptedEvent event = new FundingAcceptedEvent(
-                100L, 200L, productId, 3L, LocalDateTime.now()
+        List<ConfirmItem> items = List.of(
+                ConfirmItem.of(1L, 2L),
+                ConfirmItem.of(2L, 3L)
         );
+        OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
 
         // when
-        productEventListener.handleFundingAccepted(event);
+        productEventListener.handleOrderConfirmed(event);
 
         // then
-        verify(decreaseProductStockUseCase).decreaseStockByFunding(productId);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Long, Long>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(decreaseProductStockUseCase).decreaseStockByOrder(captor.capture());
+
+        Map<Long, Long> captured = captor.getValue();
+        assertThat(captured).containsEntry(1L, 2L);
+        assertThat(captured).containsEntry(2L, 3L);
     }
 
     @Test
-    @DisplayName("펀딩 수락 이벤트 처리 중 재고가 부족하면 예외가 전파된다")
-    void handleFundingAccepted_OutOfStock() {
+    @DisplayName("주문 확정 이벤트 처리 중 재고가 부족하면 예외가 전파된다")
+    void handleOrderConfirmed_OutOfStock() {
         // given
-        Long productId = 1L;
-        FundingAcceptedEvent event = new FundingAcceptedEvent(
-                100L, 200L, productId, 3L, LocalDateTime.now()
-        );
+        List<ConfirmItem> items = List.of(ConfirmItem.of(1L, 5L));
+        OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
+
         doThrow(new ProductException(ProductErrorCode.PRODUCT_OUT_OF_STOCK))
-                .when(decreaseProductStockUseCase).decreaseStockByFunding(productId);
+                .when(decreaseProductStockUseCase).decreaseStockByOrder(anyMap());
 
         // when & then
-        assertThatThrownBy(() -> productEventListener.handleFundingAccepted(event))
+        assertThatThrownBy(() -> productEventListener.handleOrderConfirmed(event))
                 .isInstanceOf(ProductException.class);
     }
 
     @Test
-    @DisplayName("펀딩 수락 이벤트 처리 중 상품이 존재하지 않으면 예외가 전파된다")
-    void handleFundingAccepted_ProductNotFound() {
+    @DisplayName("주문 확정 이벤트 처리 중 상품이 존재하지 않으면 예외가 전파된다")
+    void handleOrderConfirmed_ProductNotFound() {
         // given
-        Long productId = 999L;
-        FundingAcceptedEvent event = new FundingAcceptedEvent(
-                100L, 200L, productId, 3L, LocalDateTime.now()
-        );
+        List<ConfirmItem> items = List.of(ConfirmItem.of(999L, 1L));
+        OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
+
         doThrow(new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND))
-                .when(decreaseProductStockUseCase).decreaseStockByFunding(productId);
+                .when(decreaseProductStockUseCase).decreaseStockByOrder(anyMap());
 
         // when & then
-        assertThatThrownBy(() -> productEventListener.handleFundingAccepted(event))
+        assertThatThrownBy(() -> productEventListener.handleOrderConfirmed(event))
                 .isInstanceOf(ProductException.class);
     }
 

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
@@ -77,7 +77,7 @@ class ProductServiceTest {
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when
-            productService.decreaseStockByOrder(Map.of(productId, 2L));
+            productService.decreaseStockByOrder(Map.of(productId, 2));
 
             // then
             assertThat(product.getStock()).isEqualTo(3);
@@ -94,7 +94,7 @@ class ProductServiceTest {
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when
-            productService.decreaseStockByOrder(Map.of(productId, 1L));
+            productService.decreaseStockByOrder(Map.of(productId, 1));
 
             // then
             assertThat(product.getStock()).isEqualTo(0);
@@ -111,7 +111,7 @@ class ProductServiceTest {
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when & then
-            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1L)))
+            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1)))
                     .isInstanceOf(ProductException.class);
             assertThat(product.getStock()).isEqualTo(0);
             verify(productRepositoryPort, never()).save(product);
@@ -126,7 +126,7 @@ class ProductServiceTest {
                     .willThrow(new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
             // when & then
-            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1L)))
+            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1)))
                     .isInstanceOf(ProductException.class);
         }
     }

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
@@ -31,6 +31,7 @@ import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -65,35 +66,35 @@ class ProductServiceTest {
     private ProductService productService;
 
     @Nested
-    @DisplayName("재고 관리 기능 테스트 (decreaseStockByFunding)")
+    @DisplayName("재고 관리 기능 테스트 (decreaseStockByOrder)")
     class StockManagementTests {
         @Test
-        @DisplayName("성공: 재고 5에서 4로 감소하고 재고 변경 이벤트가 발행된다")
-        void decreaseStockByFunding_Success() {
+        @DisplayName("성공: 재고 5에서 3으로 감소하고 재고 변경 이벤트가 발행된다")
+        void decreaseStockByOrder_Success() {
             // given
             Long productId = 1L;
             Product product = createProduct(productId, 5);
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when
-            productService.decreaseStockByFunding(productId);
+            productService.decreaseStockByOrder(Map.of(productId, 2L));
 
             // then
-            assertThat(product.getStock()).isEqualTo(4);
+            assertThat(product.getStock()).isEqualTo(3);
             verify(productRepositoryPort).save(product);
             verify(eventPublisher).publish(any(ProductStockUpdatedEvent.class));
         }
 
         @Test
         @DisplayName("성공: 재고가 0이 되면 판매 중지 이벤트가 발행된다")
-        void decreaseStockByFunding_StockBecomesZero() {
+        void decreaseStockByOrder_StockBecomesZero() {
             // given
             Long productId = 1L;
             Product product = createProduct(productId, 1);
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when
-            productService.decreaseStockByFunding(productId);
+            productService.decreaseStockByOrder(Map.of(productId, 1L));
 
             // then
             assertThat(product.getStock()).isEqualTo(0);
@@ -102,15 +103,15 @@ class ProductServiceTest {
         }
 
         @Test
-        @DisplayName("실패: 재고가 0이면 PRODUCT_OUT_OF_STOCK 예외가 발생한다")
-        void decreaseStockByFunding_OutOfStock() {
+        @DisplayName("실패: 재고가 부족하면 PRODUCT_OUT_OF_STOCK 예외가 발생한다")
+        void decreaseStockByOrder_OutOfStock() {
             // given
             Long productId = 1L;
             Product product = createProduct(productId, 0);
             given(productSupport.findByIdForUpdate(productId)).willReturn(product);
 
             // when & then
-            assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
+            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1L)))
                     .isInstanceOf(ProductException.class);
             assertThat(product.getStock()).isEqualTo(0);
             verify(productRepositoryPort, never()).save(product);
@@ -118,14 +119,14 @@ class ProductServiceTest {
 
         @Test
         @DisplayName("실패: 존재하지 않는 상품이면 예외가 발생한다")
-        void decreaseStockByFunding_ProductNotFound() {
+        void decreaseStockByOrder_ProductNotFound() {
             // given
             Long productId = 999L;
             given(productSupport.findByIdForUpdate(productId))
                     .willThrow(new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
 
             // when & then
-            assertThatThrownBy(() -> productService.decreaseStockByFunding(productId))
+            assertThatThrownBy(() -> productService.decreaseStockByOrder(Map.of(productId, 1L)))
                     .isInstanceOf(ProductException.class);
         }
     }

--- a/bc/catalog/src/test/java/app/giftify/product/concurrency/ProductStockConcurrencyTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/concurrency/ProductStockConcurrencyTest.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -85,7 +86,7 @@ class ProductStockConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();      // 스레드 시작 대기
-                    productService.decreaseStockByFunding(productId);
+                    productService.decreaseStockByOrder(Map.of(productId, 1L));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();
@@ -153,7 +154,7 @@ class ProductStockConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    productService.decreaseStockByFunding(productId);
+                    productService.decreaseStockByOrder(Map.of(productId, 1L));
                     successCount.incrementAndGet();
                 } catch (ProductException e) {
                     productExceptionCount.incrementAndGet();
@@ -221,7 +222,7 @@ class ProductStockConcurrencyTest {
         int sellerExpectedStock = initialStock;
 
         // when - 펀딩 차감 먼저 실행 (100 → 99)
-        productService.decreaseStockByFunding(productId);
+        productService.decreaseStockByOrder(Map.of(productId, 1L));
 
         // then - 판매자가 재고를 50으로 수정 시도 (expectedStock=100이지만 실제 DB=99)
         ProductUpdateRequestDto updateRequest = new ProductUpdateRequestDto(
@@ -250,6 +251,104 @@ class ProductStockConcurrencyTest {
         assertThat(result.getStock())
                 .as("CAS 실패로 판매자 수정이 반영되지 않아 펀딩 차감 후 재고(99)가 유지되어야 한다")
                 .isEqualTo(initialStock - 1);
+    }
+
+    // 5명이 동시에 여러 상품을 주문하면 재고 부족 상품 때문에 일부 주문이 실패한다
+    @Test
+    @DisplayName("멀티 상품 주문 원자성 검증 - 5명이 동시에 3개 상품을 주문하면 재고가 가장 적은 상품 기준으로 성공/실패가 나뉘고, 실패한 주문은 어떤 상품도 차감하지 않는다")
+    void concurrentMultiProductOrder_shouldBeAtomicPerOrder() throws InterruptedException {
+        // given
+        // 상품A: 재고 3, 상품B: 재고 4, 상품C: 재고 2 (병목)
+        ProductJpa productA = productRepository.saveAndFlush(
+                ProductJpa.builder()
+                        .sellerId(1L).name("상품A").description("테스트용")
+                        .price(10000).stock(3).status(ProductStatus.ACTIVE).build()
+        );
+        ProductJpa productB = productRepository.saveAndFlush(
+                ProductJpa.builder()
+                        .sellerId(1L).name("상품B").description("테스트용")
+                        .price(20000).stock(4).status(ProductStatus.ACTIVE).build()
+        );
+        ProductJpa productC = productRepository.saveAndFlush(
+                ProductJpa.builder()
+                        .sellerId(1L).name("상품C").description("테스트용")
+                        .price(30000).stock(2).status(ProductStatus.ACTIVE).build()
+        );
+
+        Long idA = productA.getId();
+        Long idB = productB.getId();
+        Long idC = productC.getId();
+
+        int userCount = 5;
+        // 각 사용자가 A×1, B×1, C×1 주문
+        Map<Long, Long> orderItems = Map.of(idA, 1L, idB, 1L, idC, 1L);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(userCount);
+        CountDownLatch readyLatch = new CountDownLatch(userCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(userCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger productExceptionCount = new AtomicInteger(0);
+        AtomicInteger otherExceptionCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < userCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+                    productService.decreaseStockByOrder(orderItems);
+                    successCount.incrementAndGet();
+                } catch (ProductException e) {
+                    productExceptionCount.incrementAndGet();
+                } catch (Exception e) {
+                    otherExceptionCount.incrementAndGet();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+        doneLatch.await();
+        executorService.shutdown();
+
+        // then
+        ProductJpa resultA = productRepository.findById(idA).orElseThrow();
+        ProductJpa resultB = productRepository.findById(idB).orElseThrow();
+        ProductJpa resultC = productRepository.findById(idC).orElseThrow();
+
+        System.out.println("=== 멀티 상품 주문 동시성 테스트 결과 ===");
+        System.out.println("사용자 수: " + userCount);
+        System.out.println("주문 성공: " + successCount.get());
+        System.out.println("ProductException(재고 부족): " + productExceptionCount.get());
+        System.out.println("기타 예외: " + otherExceptionCount.get());
+        System.out.println("상품A 재고: 3 → " + resultA.getStock());
+        System.out.println("상품B 재고: 4 → " + resultB.getStock());
+        System.out.println("상품C 재고: 2 → " + resultC.getStock());
+
+        // 상품C 재고(2)가 병목 → 최대 2명만 성공
+        assertThat(successCount.get())
+                .as("상품C 재고가 2이므로 최대 2명만 주문에 성공해야 한다")
+                .isEqualTo(2);
+        assertThat(productExceptionCount.get())
+                .as("나머지 3명은 재고 부족으로 실패해야 한다")
+                .isEqualTo(3);
+        assertThat(otherExceptionCount.get())
+                .as("기타 예외는 발생하지 않아야 한다")
+                .isEqualTo(0);
+
+        // 성공한 2건만큼만 차감 (실패한 주문은 롤백 → 부분 차감 없음)
+        assertThat(resultA.getStock())
+                .as("상품A: 성공한 주문 수만큼만 차감되어야 한다 (3 - 2 = 1)")
+                .isEqualTo(1);
+        assertThat(resultB.getStock())
+                .as("상품B: 성공한 주문 수만큼만 차감되어야 한다 (4 - 2 = 2)")
+                .isEqualTo(2);
+        assertThat(resultC.getStock())
+                .as("상품C: 재고가 정확히 0이어야 한다 (2 - 2 = 0)")
+                .isEqualTo(0);
     }
 
     // 판매자가 최신 재고를 확인하고 수정하면 정상 반영된다

--- a/bc/catalog/src/test/java/app/giftify/product/concurrency/ProductStockConcurrencyTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/concurrency/ProductStockConcurrencyTest.java
@@ -86,7 +86,7 @@ class ProductStockConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();      // 스레드 시작 대기
-                    productService.decreaseStockByOrder(Map.of(productId, 1L));
+                    productService.decreaseStockByOrder(Map.of(productId, 1));
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();
@@ -154,7 +154,7 @@ class ProductStockConcurrencyTest {
                 try {
                     readyLatch.countDown();
                     startLatch.await();
-                    productService.decreaseStockByOrder(Map.of(productId, 1L));
+                    productService.decreaseStockByOrder(Map.of(productId, 1));
                     successCount.incrementAndGet();
                 } catch (ProductException e) {
                     productExceptionCount.incrementAndGet();
@@ -222,7 +222,7 @@ class ProductStockConcurrencyTest {
         int sellerExpectedStock = initialStock;
 
         // when - 펀딩 차감 먼저 실행 (100 → 99)
-        productService.decreaseStockByOrder(Map.of(productId, 1L));
+        productService.decreaseStockByOrder(Map.of(productId, 1));
 
         // then - 판매자가 재고를 50으로 수정 시도 (expectedStock=100이지만 실제 DB=99)
         ProductUpdateRequestDto updateRequest = new ProductUpdateRequestDto(
@@ -281,7 +281,7 @@ class ProductStockConcurrencyTest {
 
         int userCount = 5;
         // 각 사용자가 A×1, B×1, C×1 주문
-        Map<Long, Long> orderItems = Map.of(idA, 1L, idB, 1L, idC, 1L);
+        Map<Long, Integer> orderItems = Map.of(idA, 1, idB, 1, idC, 1);
 
         ExecutorService executorService = Executors.newFixedThreadPool(userCount);
         CountDownLatch readyLatch = new CountDownLatch(userCount);

--- a/bc/shared/src/main/java/app/giftify/shared/domain/vo/ConfirmItem.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/vo/ConfirmItem.java
@@ -2,13 +2,13 @@ package app.giftify.shared.domain.vo;
 
 public record ConfirmItem(
         Long productId,
-        Long quantity
+        int quantity
 ) {
     public static ConfirmItem ofFunding(Long productId) {
-        return new ConfirmItem(productId, 1L);
+        return new ConfirmItem(productId, 1);
     }
 
-    public static ConfirmItem of(Long productId, Long quantity) {
+    public static ConfirmItem of(Long productId, int quantity) {
         return new ConfirmItem(productId, quantity);
     }
 }


### PR DESCRIPTION
## Summary

기존에는 펀딩 주문의 재고 차감만 구현되어 있었고(decreaseStockByFunding), 일반 주문 재고 차감은 todo로 남아 있었습니다.          
                                         
이번 PR에서는 펀딩/일반 주문의 재고 차감을 `decreaseStockByOrder(Map<Long, Long>)`로 통합합니다. 
**주문 모듈**이 `OrderConfirmPendingEvent`를 발행하면, **상품 모듈**이 `ConfirmItem(productId, quantity) 리스트`를 수신하여 상품별 수량만큼 재고를 차감합니다.

```mermaid
sequenceDiagram
    participant O as 주문 모듈 (Order BC)
    participant PEL as ProductEventListener
    participant PS as DecreaseProductStockUseCase
    participant P as Product
    participant SH as StockHistory

    O->>PEL: OrderConfirmPendingEvent(items: List<ConfirmItem>)

    PEL->>PS: decreaseStockByOrder(Map<productId, quantity>)

    loop 상품별 반복
        PS->>P: SELECT ... FOR UPDATE\n(배타 잠금 획득)
        PS->>P: decreaseStock(quantity)
        PS->>P: save()
        P-->>PEL: ProductStockUpdatedEvent
    end

    PEL->>SH: handleStockUpdated() 재고 이력 저장
```
리뷰 포인트:
  - ProductService.decreaseStockByOrder()의 TreeMap 정렬 → 배타 잠금 → 차감 흐름이 데드락 방지 및 원자성 관점에서 적절한지

---

## What's Changed

  - 펀딩/일반 주문의 재고 차감을 decreaseStockByOrder(Map<Long, Long>)로 통합                                                                              
  - OrderConfirmPendingEvent 수신 → 상품별 수량만큼 재고 차감하는 흐름 구현
  - 데드락 방지를 위해 productId 오름차순 배타 잠금 획득                                                                
  - 멀티 상품 주문 동시성 테스트 추가 (5명 동시 주문 → 병목 상품 기준 성공/실패 분리 및 트랜잭션 원자성 검증) 
<img width="631" height="210" alt="image" src="https://github.com/user-attachments/assets/c520b0f2-9d0b-4039-8195-5cbd03be8644" />

---

## Decisions & Trade-offs

### TreeMap 정렬로 데드락 방지

여러 상품을 포함한 주문이 동시에 들어올 때, 트랜잭션마다 서로 다른 순서로 배타 잠금을 잡으면 순환 대기(데드락)가 발생할 수 있습니다. 
모든 트랜잭션이 productId 오름차순으로 잠금을 획득하도록 TreeMap으로 통일하여 이를 방지했습니다.

### 주문 단위 원자성

 @Transactional 하나로 주문 내 모든 상품의 재고 차감을 묶어, 중간에 특정 상품의 재고가 부족하면 전체 롤백됩니다. 

---

## Future Improvements

- 재고 차감 실패 시 보상 트랜잭션: 분산 환경 확장 시 Saga 패턴 적용 고려