### PR TITLE
 영속성 컨텍스트 초기화에 의한 재고 차감 데이터 정합성 문제 해결

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/ProductAdapter.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/outbound/jpa/ProductAdapter.java
@@ -31,6 +31,12 @@ public class ProductAdapter implements ProductRepositoryPort {
     }
 
     @Override
+    public void saveAndFlush(Product product) {
+        ProductJpa entity = productMapper.toEntity(product);
+        productRepository.saveAndFlush(entity);
+    }
+
+    @Override
     public Optional<Product> findById(Long productId) {
         return productRepository.findById(productId)
                 .map(productMapper::toDomain);

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/out/ProductRepositoryPort.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/out/ProductRepositoryPort.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface ProductRepositoryPort {
     Product save(Product product);
 
+    void saveAndFlush(Product product);
+
     Optional<Product> findById(Long productId);
 
     Optional<Product> findByIdAndSellerId(Long productId, Long sellerId);

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -246,7 +246,7 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
             }
 
             product.decreaseStock(quantity);
-            productRepositoryPort.save(product);
+            productRepositoryPort.saveAndFlush(product);
 
             product.pullEvents().forEach(eventPublisher::publish);
         }

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductServiceTest.java
@@ -81,7 +81,7 @@ class ProductServiceTest {
 
             // then
             assertThat(product.getStock()).isEqualTo(3);
-            verify(productRepositoryPort).save(product);
+            verify(productRepositoryPort).saveAndFlush(product);
             verify(eventPublisher).publish(any(ProductStockUpdatedEvent.class));
         }
 
@@ -98,7 +98,7 @@ class ProductServiceTest {
 
             // then
             assertThat(product.getStock()).isEqualTo(0);
-            verify(productRepositoryPort).save(product);
+            verify(productRepositoryPort).saveAndFlush(product);
             verify(eventPublisher).publish(any(ProductSaleDisabledEvent.class));
         }
 


### PR DESCRIPTION
## Summary

펀딩 수락 처리 과정에서 상품 재고 이력은 생성되지만 (= 부모 트랜잭션 커밋 후), 실제 상품 테이블의 재고가 차감되지 않는 데이터 유실 현상을 해결하였습니다.

#### 핵심 매커니즘:
1. 주문(Order) 모듈의 **@Modifying(clearAutomatically = true)** 옵션이 실행되면서 현재 트랜잭션의 영속성 컨텍스트를 강제로 비웁니다.
2. 이때 상품(Product) 모듈에서 아직 flush 되지 않은 재고 차감 변경 사항(Dirty 상태)이 함께 소멸되는 문제를 확인했습니다.
3. 이를 방지하기 위해 `saveAndFlush()`를 도입하여, 벌크 연산이 실행되기 전 재고 데이터를 DB 쓰기 지연 저장소로 안전하게 밀어내어 보호합니다.

#### 트랜잭션 원자성(Atomicity) 유지
주문 확정 프로세스 중 예외가 발생하면 이미 전송된 재고 차감 쿼리도 완벽하게 **롤백**되므로, 데이터 정합성과 트랜잭션의 원칙을 동시에 충족합니다.

---

## What's Changed

#### [Catalog 모듈] 재고 차감 로직 정합성 강화
- ProductRepositoryPort 및 ProductAdapter에 `void saveAndFlush(Product product) `메서드 추가
- ProductService.decreaseStockByOrder에서 기존 save()를 `saveAndFlush()`로 대체하여 **벌크 연산 전 데이터 반영 보장**

---

## Decisions & Trade-offs

#### saveAndFlush()를 통한 모듈 간 독립성 확보
  타 모듈(Order)의 벌크 업데이트 옵션(clearAutomatically)을 수정하는 대신, 상품의 재고 변경 사항을 DB에 미리 반영(flush)하는 방식을 택했습니다.