### PR TITLE
판매자 주문 인입 실시간 알림 구현

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
@@ -36,8 +36,10 @@ public class ProductEventListener {
         List<SellerOrderItem> sellerOrderItems = decreaseProductStockUseCase.decreaseStockByOrder(productQuantityMap);
         log.info("[product] 주문 상품 재고 차감 완료 | 상품 수: {}", productQuantityMap.size());
 
-        eventPublisher.publish(new ProductSellerOrderReceivedEvent(sellerOrderItems));
-        log.info("[product] 판매자 주문 인입 이벤트 발행 완료 | 항목 수: {}", sellerOrderItems.size());
+        if (!sellerOrderItems.isEmpty()) {
+            eventPublisher.publish(new ProductSellerOrderReceivedEvent(sellerOrderItems));
+            log.info("[product] 판매자 주문 인입 이벤트 발행 완료 | 항목 수: {}", sellerOrderItems.size());
+        }
     }
 
     // 재고 이력 생성

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/event/ProductEventListener.java
@@ -3,14 +3,18 @@ package app.giftify.product.adapter.inbound.event;
 import app.giftify.product.application.port.in.DecreaseProductStockUseCase;
 import app.giftify.product.application.port.in.StockHistoryCreateUseCase;
 import app.giftify.product.domain.event.ProductStockUpdatedEvent;
+import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
+import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
 import app.giftify.shared.domain.vo.ConfirmItem;
+import app.giftify.shared.domain.vo.SellerOrderItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -20,6 +24,7 @@ import java.util.stream.Collectors;
 public class ProductEventListener {
     private final DecreaseProductStockUseCase decreaseProductStockUseCase;
     private final StockHistoryCreateUseCase stockHistoryCreateUseCase;
+    private final EventPublisher eventPublisher;
 
     // 주문의 이벤트를 받아 상품 재고 감소 (펀딩/일반 주문 통합)
     @EventListener
@@ -28,8 +33,11 @@ public class ProductEventListener {
                 .collect(Collectors.toMap(ConfirmItem::productId, ConfirmItem::quantity));
         log.info("[product] 주문 확정 진행 이벤트를 받았습니다. | 상품 수: {}", productQuantityMap.size());
 
-        decreaseProductStockUseCase.decreaseStockByOrder(productQuantityMap);
+        List<SellerOrderItem> sellerOrderItems = decreaseProductStockUseCase.decreaseStockByOrder(productQuantityMap);
         log.info("[product] 주문 상품 재고 차감 완료 | 상품 수: {}", productQuantityMap.size());
+
+        eventPublisher.publish(new ProductSellerOrderReceivedEvent(sellerOrderItems));
+        log.info("[product] 판매자 주문 인입 이벤트 발행 완료 | 항목 수: {}", sellerOrderItems.size());
     }
 
     // 재고 이력 생성

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/in/DecreaseProductStockUseCase.java
@@ -1,8 +1,11 @@
 package app.giftify.product.application.port.in;
 
+import app.giftify.shared.domain.vo.SellerOrderItem;
+
+import java.util.List;
 import java.util.Map;
 
 public interface DecreaseProductStockUseCase {
     // 주문에 의한 재고 감소 (펀딩/일반 주문 통합)
-    void decreaseStockByOrder(Map<Long, Integer> productQuantityMap);
+    List<SellerOrderItem> decreaseStockByOrder(Map<Long, Integer> productQuantityMap);
 }

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductService.java
@@ -17,6 +17,7 @@ import app.giftify.shared.api.paging.PageResponse;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.product.ProductDeletedEvent;
 import app.giftify.shared.domain.event.product.ProductUpdatedEvent;
+import app.giftify.shared.domain.vo.SellerOrderItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.PessimisticLockingFailureException;
@@ -25,10 +26,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static app.giftify.product.domain.ProductStatus.ACTIVE;
@@ -231,8 +229,9 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
      */
     @Transactional
     @Override
-    public void decreaseStockByOrder(Map<Long, Integer> productQuantityMap) {
+    public List<SellerOrderItem> decreaseStockByOrder(Map<Long, Integer> productQuantityMap) {
         var sorted = new TreeMap<>(productQuantityMap); // ProductId를 오름차순으로 정렬
+        List<SellerOrderItem> sellerOrderItems = new ArrayList<>(sorted.size());
 
         for (var entry : sorted.entrySet()) {
             Long productId = entry.getKey();
@@ -249,7 +248,13 @@ public class ProductService implements ProductCreateUseCase, ProductGetUseCase, 
             productRepositoryPort.saveAndFlush(product);
 
             product.pullEvents().forEach(eventPublisher::publish);
+
+            sellerOrderItems.add(new SellerOrderItem(
+                    product.getSellerId(), product.getId(), product.getName(), quantity
+            ));
         }
+
+        return sellerOrderItems;
     }
 
     // 도메인 -> ProductResult(애플리케이션 전용 dto/queryModel)

--- a/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/adapter/inbound/event/ProductEventListenerTest.java
@@ -7,8 +7,11 @@ import app.giftify.product.domain.StockChangeType;
 import app.giftify.product.domain.event.ProductStockUpdatedEvent;
 import app.giftify.product.domain.exception.ProductErrorCode;
 import app.giftify.product.domain.exception.ProductException;
+import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.order.OrderConfirmPendingEvent;
+import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
 import app.giftify.shared.domain.vo.ConfirmItem;
+import app.giftify.shared.domain.vo.SellerOrderItem;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,8 +26,10 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class ProductEventListenerTest {
@@ -38,8 +43,11 @@ class ProductEventListenerTest {
     @InjectMocks
     private ProductEventListener productEventListener;
 
+    @Mock
+    private EventPublisher eventPublisher;
+
     @Test
-    @DisplayName("주문 확정 이벤트를 받으면 상품별 재고를 감소시킨다")
+    @DisplayName("주문 확정 이벤트를 받으면 상품별 재고를 감소시키고 판매자 주문 인입 이벤트를 발행한다")
     void handleOrderConfirmed_Success() {
         // given
         List<ConfirmItem> items = List.of(
@@ -47,6 +55,12 @@ class ProductEventListenerTest {
                 ConfirmItem.of(2L, 3)
         );
         OrderConfirmPendingEvent event = new OrderConfirmPendingEvent(items);
+
+        List<SellerOrderItem> sellerOrderItems = List.of(
+                new SellerOrderItem(10L, 1L, "상품A", 2),
+                new SellerOrderItem(20L, 2L, "상품B", 3)
+        );
+        given(decreaseProductStockUseCase.decreaseStockByOrder(anyMap())).willReturn(sellerOrderItems);
 
         // when
         productEventListener.handleOrderConfirmed(event);
@@ -59,10 +73,15 @@ class ProductEventListenerTest {
         Map<Long, Integer> captured = captor.getValue();
         assertThat(captured).containsEntry(1L, 2);
         assertThat(captured).containsEntry(2L, 3);
+
+        ArgumentCaptor<ProductSellerOrderReceivedEvent> eventCaptor =
+                ArgumentCaptor.forClass(ProductSellerOrderReceivedEvent.class);
+        verify(eventPublisher).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getItems()).hasSize(2);
     }
 
     @Test
-    @DisplayName("주문 확정 이벤트 처리 중 재고가 부족하면 예외가 전파된다")
+    @DisplayName("주문 확정 이벤트 처리 중 재고가 부족하면 예외가 전파되고 이벤트가 발행되지 않는다")
     void handleOrderConfirmed_OutOfStock() {
         // given
         List<ConfirmItem> items = List.of(ConfirmItem.of(1L, 5));
@@ -74,10 +93,11 @@ class ProductEventListenerTest {
         // when & then
         assertThatThrownBy(() -> productEventListener.handleOrderConfirmed(event))
                 .isInstanceOf(ProductException.class);
+        verify(eventPublisher, never()).publish(org.mockito.ArgumentMatchers.any());
     }
 
     @Test
-    @DisplayName("주문 확정 이벤트 처리 중 상품이 존재하지 않으면 예외가 전파된다")
+    @DisplayName("주문 확정 이벤트 처리 중 상품이 존재하지 않으면 예외가 전파되고 이벤트가 발행되지 않는다")
     void handleOrderConfirmed_ProductNotFound() {
         // given
         List<ConfirmItem> items = List.of(ConfirmItem.of(999L, 1));
@@ -89,6 +109,7 @@ class ProductEventListenerTest {
         // when & then
         assertThatThrownBy(() -> productEventListener.handleOrderConfirmed(event))
                 .isInstanceOf(ProductException.class);
+        verify(eventPublisher, never()).publish(org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/bc/notification/src/main/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandler.java
+++ b/bc/notification/src/main/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandler.java
@@ -18,11 +18,12 @@ import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentSucceededEvent;
 import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
 import app.giftify.shared.domain.vo.FundingDetail;
-import app.giftify.shared.domain.vo.SellerOrderItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -145,15 +146,18 @@ public class NotificationEventHandler {
         var meta = typeRegistry.resolve(event.getClass());
         CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "product-seller-order");
 
-        for (SellerOrderItem item : event.getItems()) {
-            String content = "[%s] %d개의 주문이 인입되었습니다".formatted(item.productName(), item.quantity());
-            Notification notification = notificationFactory.createSingle(
-                    item.sellerId(), meta.notificationType(),
-                    String.valueOf(item.productId()), "PRODUCT",
-                    ce, content);
-            Notification saved = notificationRepository.save(notification);
-            pushPort.send(item.sellerId(), saved);
-        }
+        List<Notification> notifications = event.getItems().stream()
+                .map(item -> {
+                    String content = "[%s] %d개의 주문이 인입되었습니다".formatted(item.productName(), item.quantity());
+                    return notificationFactory.createSingle(
+                            item.sellerId(), meta.notificationType(),
+                            String.valueOf(item.productId()), "PRODUCT",
+                            ce, content);
+                })
+                .toList();
+
+        List<Notification> saved = notificationRepository.saveAll(notifications);
+        saved.forEach(n -> pushPort.send(n.getRecipientId(), n));
     }
 
     // -- 헬퍼 --

--- a/bc/notification/src/main/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandler.java
+++ b/bc/notification/src/main/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandler.java
@@ -1,50 +1,54 @@
 package app.giftify.notification.adapter.inbound.event;
 
-import app.giftify.shared.domain.event.funding.*;
-import app.giftify.shared.domain.vo.FundingDetail;
-import org.springframework.modulith.events.ApplicationModuleListener;
-import org.springframework.stereotype.Component;
-
 import app.giftify.notification.application.CloudEventEnvelope;
+import app.giftify.notification.application.outbound.NotificationPushPort;
+import app.giftify.notification.application.outbound.NotificationRepository;
 import app.giftify.notification.application.support.CloudEventMapper;
 import app.giftify.notification.application.support.CloudEventTypeRegistry;
 import app.giftify.notification.application.support.NotificationFactory;
-import app.giftify.notification.application.outbound.NotificationPushPort;
-import app.giftify.notification.application.outbound.NotificationRepository;
 import app.giftify.notification.domain.Notification;
 import app.giftify.notification.domain.NotificationType;
+import app.giftify.shared.domain.event.funding.FundingAchievedEvent;
+import app.giftify.shared.domain.event.funding.FundingCanceledEvent;
+import app.giftify.shared.domain.event.funding.FundingCreatedEvent;
+import app.giftify.shared.domain.event.funding.FundingExpiredEvent;
 import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentSucceededEvent;
+import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
+import app.giftify.shared.domain.vo.FundingDetail;
+import app.giftify.shared.domain.vo.SellerOrderItem;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class NotificationEventHandler {
 
-	private final CloudEventMapper cloudEventMapper;
-	private final CloudEventTypeRegistry typeRegistry;
-	private final NotificationFactory notificationFactory;
-	private final NotificationRepository notificationRepository;
-	private final NotificationPushPort pushPort;
+    private final CloudEventMapper cloudEventMapper;
+    private final CloudEventTypeRegistry typeRegistry;
+    private final NotificationFactory notificationFactory;
+    private final NotificationRepository notificationRepository;
+    private final NotificationPushPort pushPort;
 
-	@ApplicationModuleListener
-	public void handleFundingCreated(FundingCreatedEvent event) {
-		for (FundingDetail detail : event.getFundings()) {
-			log.info("[Notification] FundingCreatedEvent: fundingId={}, receiverId={}", detail.fundingId(), detail.receiverId());
+    @ApplicationModuleListener
+    public void handleFundingCreated(FundingCreatedEvent event) {
+        for (FundingDetail detail : event.getFundings()) {
+            log.info("[Notification] FundingCreatedEvent: fundingId={}, receiverId={}", detail.fundingId(), detail.receiverId());
             var meta = typeRegistry.resolve(event.getClass());
             CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "funding-" + detail.fundingId());
             createAndPush(detail.receiverId(), meta.notificationType(),
-                String.valueOf(detail.fundingId()), "FUNDING", ce);
-		}
-	}
+                    String.valueOf(detail.fundingId()), "FUNDING", ce);
+        }
+    }
 
-	@ApplicationModuleListener
-	public void handleFundingAchieved(FundingAchievedEvent event) {
-		log.info("[Notification] FundingAchievedEvent: fundingId={}", event.getFundingId());
+    @ApplicationModuleListener
+    public void handleFundingAchieved(FundingAchievedEvent event) {
+        log.info("[Notification] FundingAchievedEvent: fundingId={}", event.getFundingId());
         var meta = typeRegistry.resolve(event.getClass());
         CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "funding-" + event.getFundingId());
 
@@ -54,16 +58,16 @@ public class NotificationEventHandler {
 
         // 참여자들에게 알림 전송
         if (event.getParticipantIds() != null && !event.getParticipantIds().isEmpty()) {
-        for (Long participantId : event.getParticipantIds()) {
-            createAndPush(participantId, meta.notificationType(),
-                    String.valueOf(event.getFundingId()), "FUNDING", ce);
+            for (Long participantId : event.getParticipantIds()) {
+                createAndPush(participantId, meta.notificationType(),
+                        String.valueOf(event.getFundingId()), "FUNDING", ce);
             }
         }
     }
 
-	@ApplicationModuleListener
-	public void handleFundingExpired(FundingExpiredEvent event) {
-		log.info("[Notification] FundingExpiredEvent: fundingId={}", event.getFundingId());
+    @ApplicationModuleListener
+    public void handleFundingExpired(FundingExpiredEvent event) {
+        log.info("[Notification] FundingExpiredEvent: fundingId={}", event.getFundingId());
         var meta = typeRegistry.resolve(event.getClass());
         CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "funding-" + event.getFundingId());
 
@@ -76,11 +80,11 @@ public class NotificationEventHandler {
                         String.valueOf(event.getFundingId()), "FUNDING", ce);
             }
         }
-	}
+    }
 
-	@ApplicationModuleListener
-	public void handleFundingCanceled(FundingCanceledEvent event) {
-		log.info("[Notification] FundingCanceledEvent: fundingId={}", event.getFundingId());
+    @ApplicationModuleListener
+    public void handleFundingCanceled(FundingCanceledEvent event) {
+        log.info("[Notification] FundingCanceledEvent: fundingId={}", event.getFundingId());
         var meta = typeRegistry.resolve(event.getClass());
         CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "funding-" + event.getFundingId());
 
@@ -93,53 +97,72 @@ public class NotificationEventHandler {
                         String.valueOf(event.getFundingId()), "FUNDING", ce);
             }
         }
-	}
+    }
 
-	// -- Payment 이벤트 --
+    // -- Payment 이벤트 --
 
-	@ApplicationModuleListener
-	public void handlePaymentSucceeded(PaymentSucceededEvent event) {
-		log.info("[Notification] PaymentSucceededEvent: paymentId={}", event.data().paymentId());
-		var meta = typeRegistry.resolve(event.getClass());
-		CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
-		createAndPush(event.data().memberId(), meta.notificationType(),
-			String.valueOf(event.data().paymentId()), "PAYMENT", ce);
-	}
+    @ApplicationModuleListener
+    public void handlePaymentSucceeded(PaymentSucceededEvent event) {
+        log.info("[Notification] PaymentSucceededEvent: paymentId={}", event.data().paymentId());
+        var meta = typeRegistry.resolve(event.getClass());
+        CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
+        createAndPush(event.data().memberId(), meta.notificationType(),
+                String.valueOf(event.data().paymentId()), "PAYMENT", ce);
+    }
 
-	@ApplicationModuleListener
-	public void handlePaymentFailed(PaymentFailedEvent event) {
-		log.info("[Notification] PaymentFailedEvent: paymentId={}", event.data().paymentId());
-		var meta = typeRegistry.resolve(event.getClass());
-		CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
-		createAndPush(event.data().memberId(), meta.notificationType(),
-			String.valueOf(event.data().paymentId()), "PAYMENT", ce);
-	}
+    @ApplicationModuleListener
+    public void handlePaymentFailed(PaymentFailedEvent event) {
+        log.info("[Notification] PaymentFailedEvent: paymentId={}", event.data().paymentId());
+        var meta = typeRegistry.resolve(event.getClass());
+        CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
+        createAndPush(event.data().memberId(), meta.notificationType(),
+                String.valueOf(event.data().paymentId()), "PAYMENT", ce);
+    }
 
-	@ApplicationModuleListener
-	public void handlePaymentCanceled(PaymentCanceledEvent event) {
-		log.info("[Notification] PaymentCanceledEvent: paymentId={}", event.data().paymentId());
-		var meta = typeRegistry.resolve(event.getClass());
-		CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
-		createAndPush(event.data().memberId(), meta.notificationType(),
-			String.valueOf(event.data().paymentId()), "PAYMENT", ce);
-	}
+    @ApplicationModuleListener
+    public void handlePaymentCanceled(PaymentCanceledEvent event) {
+        log.info("[Notification] PaymentCanceledEvent: paymentId={}", event.data().paymentId());
+        var meta = typeRegistry.resolve(event.getClass());
+        CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
+        createAndPush(event.data().memberId(), meta.notificationType(),
+                String.valueOf(event.data().paymentId()), "PAYMENT", ce);
+    }
 
-	@ApplicationModuleListener
-	public void handlePaymentCancelFailed(PaymentCancelFailedEvent event) {
-		log.info("[Notification] PaymentCancelFailedEvent: paymentId={}", event.data().paymentId());
-		var meta = typeRegistry.resolve(event.getClass());
-		CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
-		createAndPush(event.data().memberId(), meta.notificationType(),
-			String.valueOf(event.data().paymentId()), "PAYMENT", ce);
-	}
+    @ApplicationModuleListener
+    public void handlePaymentCancelFailed(PaymentCancelFailedEvent event) {
+        log.info("[Notification] PaymentCancelFailedEvent: paymentId={}", event.data().paymentId());
+        var meta = typeRegistry.resolve(event.getClass());
+        CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "payment-" + event.data().paymentId());
+        createAndPush(event.data().memberId(), meta.notificationType(),
+                String.valueOf(event.data().paymentId()), "PAYMENT", ce);
+    }
 
-	// -- 헬퍼 --
+    // -- Product 이벤트 --
 
-	private void createAndPush(Long recipientId, NotificationType type,
-		String referenceId, String referenceType, CloudEventEnvelope ce) {
-		Notification notification = notificationFactory.createSingle(
-			recipientId, type, referenceId, referenceType, ce);
-		Notification saved = notificationRepository.save(notification);
-		pushPort.send(recipientId, saved);
-	}
+    @ApplicationModuleListener
+    public void handleProductSellerOrderReceived(ProductSellerOrderReceivedEvent event) {
+        log.info("[Notification] ProductSellerOrderReceivedEvent: 항목 수={}", event.getItems().size());
+        var meta = typeRegistry.resolve(event.getClass());
+        CloudEventEnvelope ce = cloudEventMapper.fromDomainEvent(event, "product-seller-order");
+
+        for (SellerOrderItem item : event.getItems()) {
+            String content = "[%s] %d개의 주문이 인입되었습니다".formatted(item.productName(), item.quantity());
+            Notification notification = notificationFactory.createSingle(
+                    item.sellerId(), meta.notificationType(),
+                    String.valueOf(item.productId()), "PRODUCT",
+                    ce, content);
+            Notification saved = notificationRepository.save(notification);
+            pushPort.send(item.sellerId(), saved);
+        }
+    }
+
+    // -- 헬퍼 --
+
+    private void createAndPush(Long recipientId, NotificationType type,
+                               String referenceId, String referenceType, CloudEventEnvelope ce) {
+        Notification notification = notificationFactory.createSingle(
+                recipientId, type, referenceId, referenceType, ce);
+        Notification saved = notificationRepository.save(notification);
+        pushPort.send(recipientId, saved);
+    }
 }

--- a/bc/notification/src/main/java/app/giftify/notification/application/support/CloudEventTypeRegistry.java
+++ b/bc/notification/src/main/java/app/giftify/notification/application/support/CloudEventTypeRegistry.java
@@ -1,55 +1,57 @@
 package app.giftify.notification.application.support;
 
-import java.net.URI;
-import java.util.Map;
-
-import app.giftify.shared.domain.event.funding.FundingCreatedEvent;
-import org.springframework.stereotype.Component;
-
 import app.giftify.notification.domain.NotificationType;
 import app.giftify.shared.domain.event.funding.FundingAchievedEvent;
 import app.giftify.shared.domain.event.funding.FundingCanceledEvent;
+import app.giftify.shared.domain.event.funding.FundingCreatedEvent;
 import app.giftify.shared.domain.event.funding.FundingExpiredEvent;
 import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
 import app.giftify.shared.domain.event.payment.PaymentSucceededEvent;
+import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Map;
 
 @Component
 public class CloudEventTypeRegistry {
 
-	private static final URI SOURCE_FUNDING = URI.create("/giftify/funding");
-	private static final URI SOURCE_PAYMENT = URI.create("/giftify/payment");
-	private static final URI SOURCE_MEMBER = URI.create("/giftify/member");
-	public static final URI SOURCE_NOTIFICATION = URI.create("/giftify/notification");
+    private static final URI SOURCE_FUNDING = URI.create("/giftify/funding");
+    private static final URI SOURCE_PAYMENT = URI.create("/giftify/payment");
+    private static final URI SOURCE_MEMBER = URI.create("/giftify/member");
+    public static final URI SOURCE_NOTIFICATION = URI.create("/giftify/notification");
+    private static final URI SOURCE_PRODUCT = URI.create("/giftify/product");
 
-	public record CloudEventMeta(String ceType, URI ceSource, NotificationType notificationType) {
-	}
+    public record CloudEventMeta(String ceType, URI ceSource, NotificationType notificationType) {
+    }
 
-	private static final Map<Class<?>, CloudEventMeta> REGISTRY = Map.of(
-		FundingCreatedEvent.class, new CloudEventMeta("app.giftify.funding.created", SOURCE_FUNDING, NotificationType.FUNDING_CREATED),
-		FundingAchievedEvent.class, new CloudEventMeta("app.giftify.funding.achieved", SOURCE_FUNDING, NotificationType.FUNDING_ACHIEVED),
-		FundingExpiredEvent.class, new CloudEventMeta("app.giftify.funding.expired", SOURCE_FUNDING, NotificationType.FUNDING_EXPIRED),
-		FundingCanceledEvent.class, new CloudEventMeta("app.giftify.funding.canceled", SOURCE_FUNDING, NotificationType.FUNDING_CANCELED),
-		PaymentSucceededEvent.class, new CloudEventMeta("app.giftify.payment.succeeded", SOURCE_PAYMENT, NotificationType.PAYMENT_SUCCEEDED),
-		PaymentFailedEvent.class, new CloudEventMeta("app.giftify.payment.failed", SOURCE_PAYMENT, NotificationType.PAYMENT_FAILED),
-		PaymentCanceledEvent.class, new CloudEventMeta("app.giftify.payment.canceled", SOURCE_PAYMENT, NotificationType.PAYMENT_CANCEL_SUCCEEDED),
-		PaymentCancelFailedEvent.class, new CloudEventMeta("app.giftify.payment.cancel-failed", SOURCE_PAYMENT, NotificationType.PAYMENT_CANCEL_FAILED)
-	);
+    private static final Map<Class<?>, CloudEventMeta> REGISTRY = Map.of(
+            FundingCreatedEvent.class, new CloudEventMeta("app.giftify.funding.created", SOURCE_FUNDING, NotificationType.FUNDING_CREATED),
+            FundingAchievedEvent.class, new CloudEventMeta("app.giftify.funding.achieved", SOURCE_FUNDING, NotificationType.FUNDING_ACHIEVED),
+            FundingExpiredEvent.class, new CloudEventMeta("app.giftify.funding.expired", SOURCE_FUNDING, NotificationType.FUNDING_EXPIRED),
+            FundingCanceledEvent.class, new CloudEventMeta("app.giftify.funding.canceled", SOURCE_FUNDING, NotificationType.FUNDING_CANCELED),
+            PaymentSucceededEvent.class, new CloudEventMeta("app.giftify.payment.succeeded", SOURCE_PAYMENT, NotificationType.PAYMENT_SUCCEEDED),
+            PaymentFailedEvent.class, new CloudEventMeta("app.giftify.payment.failed", SOURCE_PAYMENT, NotificationType.PAYMENT_FAILED),
+            PaymentCanceledEvent.class, new CloudEventMeta("app.giftify.payment.canceled", SOURCE_PAYMENT, NotificationType.PAYMENT_CANCEL_SUCCEEDED),
+            PaymentCancelFailedEvent.class, new CloudEventMeta("app.giftify.payment.cancel-failed", SOURCE_PAYMENT, NotificationType.PAYMENT_CANCEL_FAILED),
+            ProductSellerOrderReceivedEvent.class, new CloudEventMeta("app.giftify.product.seller-order-received", SOURCE_PRODUCT, NotificationType.PRODUCT_SELLER_ORDER_RECEIVED)
+    );
 
-	public CloudEventMeta resolve(Class<?> eventClass) {
-		CloudEventMeta meta = REGISTRY.get(eventClass);
-		if (meta == null) {
-			throw new IllegalArgumentException("Unmapped event class: " + eventClass.getName());
-		}
-		return meta;
-	}
+    public CloudEventMeta resolve(Class<?> eventClass) {
+        CloudEventMeta meta = REGISTRY.get(eventClass);
+        if (meta == null) {
+            throw new IllegalArgumentException("Unmapped event class: " + eventClass.getName());
+        }
+        return meta;
+    }
 
-	public boolean supports(Class<?> eventClass) {
-		return REGISTRY.containsKey(eventClass);
-	}
+    public boolean supports(Class<?> eventClass) {
+        return REGISTRY.containsKey(eventClass);
+    }
 
-	public static String toNotificationCeType(NotificationType type) {
-		return "app.giftify.notification." + type.name().toLowerCase().replace('_', '-');
-	}
+    public static String toNotificationCeType(NotificationType type) {
+        return "app.giftify.notification." + type.name().toLowerCase().replace('_', '-');
+    }
 }

--- a/bc/notification/src/main/java/app/giftify/notification/application/support/NotificationFactory.java
+++ b/bc/notification/src/main/java/app/giftify/notification/application/support/NotificationFactory.java
@@ -1,51 +1,64 @@
 package app.giftify.notification.application.support;
 
-import java.util.List;
-
-import org.springframework.stereotype.Component;
-
 import app.giftify.notification.application.CloudEventEnvelope;
 import app.giftify.notification.domain.Notification;
 import app.giftify.notification.domain.NotificationType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class NotificationFactory {
 
-	public Notification createSingle(
-		Long recipientId, NotificationType type,
-		String referenceId, String referenceType,
-		CloudEventEnvelope sourceEvent
-	) {
-		return new Notification(
-			recipientId, type,
-			type.getTitle(), resolveContent(type),
-			referenceId, referenceType,
-			sourceEvent.id(), sourceEvent.type(), sourceEvent.source()
-		);
-	}
+    public Notification createSingle(
+            Long recipientId, NotificationType type,
+            String referenceId, String referenceType,
+            CloudEventEnvelope sourceEvent
+    ) {
+        return new Notification(
+                recipientId, type,
+                type.getTitle(), resolveContent(type),
+                referenceId, referenceType,
+                sourceEvent.id(), sourceEvent.type(), sourceEvent.source()
+        );
+    }
 
-	public List<Notification> createForMultipleRecipients(
-		List<Long> recipientIds, NotificationType type,
-		String referenceId, String referenceType,
-		CloudEventEnvelope sourceEvent
-	) {
-		return recipientIds.stream()
-			.map(id -> createSingle(id, type, referenceId, referenceType, sourceEvent))
-			.toList();
-	}
+    public Notification createSingle(
+            Long recipientId, NotificationType type,
+            String referenceId, String referenceType,
+            CloudEventEnvelope sourceEvent, String customContent
+    ) {
+        return new Notification(
+                recipientId, type,
+                type.getTitle(), customContent,
+                referenceId, referenceType,
+                sourceEvent.id(), sourceEvent.type(), sourceEvent.source()
+        );
+    }
 
-	private String resolveContent(NotificationType type) {
-		return switch (type) {
-			case FUNDING_CREATED -> "위시리스트 아이템에 새로운 펀딩이 시작되었습니다";
-			case FUNDING_ACHIEVED -> "펀딩이 목표 금액을 달성했습니다";
-			case FUNDING_EXPIRED -> "펀딩이 기한이 지나 만료되었습니다";
-			case FUNDING_CANCELED -> "펀딩이 취소되었습니다";
-			case FRIEND_REQUEST_RECEIVED -> "새로운 친구 요청을 확인해보세요";
-			case FRIEND_REQUEST_ACCEPTED -> "친구 요청이 수락되어 친구가 되었습니다";
-			case PAYMENT_SUCCEEDED -> "결제가 성공적으로 처리되었습니다";
-			case PAYMENT_FAILED -> "결제 처리 중 문제가 발생했습니다";
-			case PAYMENT_CANCEL_SUCCEEDED -> "결제 취소가 정상적으로 처리되었습니다";
-			case PAYMENT_CANCEL_FAILED -> "결제 취소 처리 중 문제가 발생했습니다";
-		};
-	}
+    public List<Notification> createForMultipleRecipients(
+            List<Long> recipientIds, NotificationType type,
+            String referenceId, String referenceType,
+            CloudEventEnvelope sourceEvent
+    ) {
+        return recipientIds.stream()
+                .map(id -> createSingle(id, type, referenceId, referenceType, sourceEvent))
+                .toList();
+    }
+
+    private String resolveContent(NotificationType type) {
+        return switch (type) {
+            case FUNDING_CREATED -> "위시리스트 아이템에 새로운 펀딩이 시작되었습니다";
+            case FUNDING_ACHIEVED -> "펀딩이 목표 금액을 달성했습니다";
+            case FUNDING_EXPIRED -> "펀딩이 기한이 지나 만료되었습니다";
+            case FUNDING_CANCELED -> "펀딩이 취소되었습니다";
+            case FRIEND_REQUEST_RECEIVED -> "새로운 친구 요청을 확인해보세요";
+            case FRIEND_REQUEST_ACCEPTED -> "친구 요청이 수락되어 친구가 되었습니다";
+            case PAYMENT_SUCCEEDED -> "결제가 성공적으로 처리되었습니다";
+            case PAYMENT_FAILED -> "결제 처리 중 문제가 발생했습니다";
+            case PAYMENT_CANCEL_SUCCEEDED -> "결제 취소가 정상적으로 처리되었습니다";
+            case PAYMENT_CANCEL_FAILED -> "결제 취소 처리 중 문제가 발생했습니다";
+            case PRODUCT_SELLER_ORDER_RECEIVED -> "판매 중인 상품에 대해 새로운 주문이 인입되었습니다";
+        };
+    }
 }

--- a/bc/notification/src/main/java/app/giftify/notification/domain/NotificationType.java
+++ b/bc/notification/src/main/java/app/giftify/notification/domain/NotificationType.java
@@ -1,22 +1,25 @@
 package app.giftify.notification.domain;
 
 public enum NotificationType {
-	FUNDING_CREATED("새로운 펀딩이 시작되었습니다"),
-	FUNDING_ACHIEVED("펀딩이 완료되었습니다"),
-	FUNDING_EXPIRED("펀딩이 만료되었습니다"),
-	FUNDING_CANCELED("펀딩이 취소되었습니다"),
-	FRIEND_REQUEST_RECEIVED("친구 요청이 도착했습니다"),
-	FRIEND_REQUEST_ACCEPTED("친구 요청이 수락되었습니다"),
-	PAYMENT_SUCCEEDED("결제가 완료되었습니다"),
-	PAYMENT_FAILED("결제에 실패했습니다"),
-	PAYMENT_CANCEL_SUCCEEDED("결제 취소가 완료되었습니다"),
-	PAYMENT_CANCEL_FAILED("결제 취소에 실패했습니다");
+    FUNDING_CREATED("새로운 펀딩이 시작되었습니다"),
+    FUNDING_ACHIEVED("펀딩이 완료되었습니다"),
+    FUNDING_EXPIRED("펀딩이 만료되었습니다"),
+    FUNDING_CANCELED("펀딩이 취소되었습니다"),
+    FRIEND_REQUEST_RECEIVED("친구 요청이 도착했습니다"),
+    FRIEND_REQUEST_ACCEPTED("친구 요청이 수락되었습니다"),
+    PAYMENT_SUCCEEDED("결제가 완료되었습니다"),
+    PAYMENT_FAILED("결제에 실패했습니다"),
+    PAYMENT_CANCEL_SUCCEEDED("결제 취소가 완료되었습니다"),
+    PAYMENT_CANCEL_FAILED("결제 취소에 실패했습니다"),
+    PRODUCT_SELLER_ORDER_RECEIVED("[판매자 알림] 새로운 주문이 인입되었습니다");
 
-	private final String title;
+    private final String title;
 
-	NotificationType(String title) {
-		this.title = title;
-	}
+    NotificationType(String title) {
+        this.title = title;
+    }
 
-	public String getTitle() { return title; }
+    public String getTitle() {
+        return title;
+    }
 }

--- a/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
+++ b/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
@@ -229,12 +229,11 @@ class NotificationEventHandlerTest {
                     eq("1"), eq("PRODUCT"), eq(ce), eq("[상품A] 2개의 주문이 인입되었습니다"))).willReturn(notifA);
             given(notificationFactory.createSingle(eq(sellerB), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
                     eq("2"), eq("PRODUCT"), eq(ce), eq("[상품B] 3개의 주문이 인입되었습니다"))).willReturn(notifB);
-            given(notificationRepository.save(notifA)).willReturn(savedA);
-            given(notificationRepository.save(notifB)).willReturn(savedB);
+            given(notificationRepository.saveAll(List.of(notifA, notifB))).willReturn(List.of(savedA, savedB));
 
             eventHandler.handleProductSellerOrderReceived(event);
 
-            then(notificationRepository).should(times(2)).save(any(Notification.class));
+            then(notificationRepository).should().saveAll(List.of(notifA, notifB));
             then(pushPort).should().send(sellerA, savedA);
             then(pushPort).should().send(sellerB, savedB);
         }
@@ -266,11 +265,11 @@ class NotificationEventHandlerTest {
                     eq("1"), eq("PRODUCT"), eq(ce), eq("[상품A] 4개의 주문이 인입되었습니다"))).willReturn(notifA);
             given(notificationFactory.createSingle(eq(sellerId), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
                     eq("2"), eq("PRODUCT"), eq(ce), eq("[상품B] 2개의 주문이 인입되었습니다"))).willReturn(notifB);
-            given(notificationRepository.save(any(Notification.class))).willAnswer(inv -> inv.getArgument(0));
+            given(notificationRepository.saveAll(List.of(notifA, notifB))).willReturn(List.of(notifA, notifB));
 
             eventHandler.handleProductSellerOrderReceived(event);
 
-            then(notificationRepository).should(times(2)).save(any(Notification.class));
+            then(notificationRepository).should().saveAll(List.of(notifA, notifB));
             then(pushPort).should(times(2)).send(eq(sellerId), any(Notification.class));
         }
     }

--- a/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
+++ b/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
@@ -1,19 +1,5 @@
 package app.giftify.notification.adapter.inbound.event;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-
-import java.time.OffsetDateTime;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
 import app.giftify.notification.application.CloudEventEnvelope;
 import app.giftify.notification.application.outbound.NotificationPushPort;
 import app.giftify.notification.application.outbound.NotificationRepository;
@@ -23,184 +9,287 @@ import app.giftify.notification.application.support.CloudEventTypeRegistry.Cloud
 import app.giftify.notification.application.support.NotificationFactory;
 import app.giftify.notification.domain.Notification;
 import app.giftify.notification.domain.NotificationType;
-import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
-import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
-import app.giftify.shared.domain.event.payment.PaymentEventData;
-import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
-import app.giftify.shared.domain.event.payment.PaymentSucceededEvent;
+import app.giftify.shared.domain.event.payment.*;
+import app.giftify.shared.domain.event.product.ProductSellerOrderReceivedEvent;
 import app.giftify.shared.domain.type.CancelType;
 import app.giftify.shared.domain.type.PaymentMethod;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
+import app.giftify.shared.domain.vo.SellerOrderItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationEventHandlerTest {
 
-	@Mock
-	CloudEventMapper cloudEventMapper;
+    @Mock
+    CloudEventMapper cloudEventMapper;
 
-	@Mock
-	CloudEventTypeRegistry typeRegistry;
+    @Mock
+    CloudEventTypeRegistry typeRegistry;
 
-	@Mock
-	NotificationFactory notificationFactory;
+    @Mock
+    NotificationFactory notificationFactory;
 
-	@Mock
-	NotificationRepository notificationRepository;
+    @Mock
+    NotificationRepository notificationRepository;
 
-	@Mock
-	NotificationPushPort pushPort;
+    @Mock
+    NotificationPushPort pushPort;
 
-	@InjectMocks
-	NotificationEventHandler eventHandler;
+    @InjectMocks
+    NotificationEventHandler eventHandler;
 
-	@Nested
-	@DisplayName("handlePaymentSucceeded")
-	class HandlePaymentSucceeded {
+    @Nested
+    @DisplayName("handlePaymentSucceeded")
+    class HandlePaymentSucceeded {
 
-		@Test
-		@DisplayName("결제 성공 이벤트를 수신하면 알림을 생성하고 푸시한다")
-		void createsAndPushes() {
-			Long paymentId = 1L;
-			Long memberId = 100L;
-			PaymentSucceededEvent event = PaymentSucceededEvent.create(
-				PaymentEventData.forSuccess(paymentId, 10L, memberId, "ORD-001",
-					Money.of(10000), PaymentMethod.CARD, PaymentType.FUNDING, "pk", "txn"));
+        @Test
+        @DisplayName("결제 성공 이벤트를 수신하면 알림을 생성하고 푸시한다")
+        void createsAndPushes() {
+            Long paymentId = 1L;
+            Long memberId = 100L;
+            PaymentSucceededEvent event = PaymentSucceededEvent.create(
+                    PaymentEventData.forSuccess(paymentId, 10L, memberId, "ORD-001",
+                            Money.of(10000), PaymentMethod.CARD, PaymentType.FUNDING, "pk", "txn"));
 
-			CloudEventMeta meta = new CloudEventMeta(
-				"app.giftify.payment.succeeded", java.net.URI.create("/giftify/payment"),
-				NotificationType.PAYMENT_SUCCEEDED);
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
-				"payment-1", OffsetDateTime.now());
-			Notification notification = createNotification(memberId);
-			Notification saved = createNotification(memberId);
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.payment.succeeded", java.net.URI.create("/giftify/payment"),
+                    NotificationType.PAYMENT_SUCCEEDED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
+                    "payment-1", OffsetDateTime.now());
+            Notification notification = createNotification(memberId);
+            Notification saved = createNotification(memberId);
 
-			given(typeRegistry.resolve(PaymentSucceededEvent.class)).willReturn(meta);
-			given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
-			given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_SUCCEEDED,
-				String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
-			given(notificationRepository.save(notification)).willReturn(saved);
+            given(typeRegistry.resolve(PaymentSucceededEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
+            given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_SUCCEEDED,
+                    String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
+            given(notificationRepository.save(notification)).willReturn(saved);
 
-			eventHandler.handlePaymentSucceeded(event);
+            eventHandler.handlePaymentSucceeded(event);
 
-			then(notificationRepository).should().save(notification);
-			then(pushPort).should().send(memberId, saved);
-		}
-	}
+            then(notificationRepository).should().save(notification);
+            then(pushPort).should().send(memberId, saved);
+        }
+    }
 
-	@Nested
-	@DisplayName("handlePaymentFailed")
-	class HandlePaymentFailed {
+    @Nested
+    @DisplayName("handlePaymentFailed")
+    class HandlePaymentFailed {
 
-		@Test
-		@DisplayName("결제 실패 이벤트를 수신하면 알림을 생성하고 푸시한다")
-		void createsAndPushes() {
-			Long paymentId = 2L;
-			Long memberId = 200L;
-			PaymentFailedEvent event = PaymentFailedEvent.create(
-				PaymentEventData.forFailure(paymentId, 10L, memberId, "ORD-002",
-					Money.of(5000), PaymentMethod.CARD, PaymentType.FUNDING));
+        @Test
+        @DisplayName("결제 실패 이벤트를 수신하면 알림을 생성하고 푸시한다")
+        void createsAndPushes() {
+            Long paymentId = 2L;
+            Long memberId = 200L;
+            PaymentFailedEvent event = PaymentFailedEvent.create(
+                    PaymentEventData.forFailure(paymentId, 10L, memberId, "ORD-002",
+                            Money.of(5000), PaymentMethod.CARD, PaymentType.FUNDING));
 
-			CloudEventMeta meta = new CloudEventMeta(
-				"app.giftify.payment.failed", java.net.URI.create("/giftify/payment"),
-				NotificationType.PAYMENT_FAILED);
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-2", "/giftify/payment", "app.giftify.payment.failed",
-				"payment-2", OffsetDateTime.now());
-			Notification notification = createNotification(memberId);
-			Notification saved = createNotification(memberId);
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.payment.failed", java.net.URI.create("/giftify/payment"),
+                    NotificationType.PAYMENT_FAILED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-2", "/giftify/payment", "app.giftify.payment.failed",
+                    "payment-2", OffsetDateTime.now());
+            Notification notification = createNotification(memberId);
+            Notification saved = createNotification(memberId);
 
-			given(typeRegistry.resolve(PaymentFailedEvent.class)).willReturn(meta);
-			given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
-			given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_FAILED,
-				String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
-			given(notificationRepository.save(notification)).willReturn(saved);
+            given(typeRegistry.resolve(PaymentFailedEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
+            given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_FAILED,
+                    String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
+            given(notificationRepository.save(notification)).willReturn(saved);
 
-			eventHandler.handlePaymentFailed(event);
+            eventHandler.handlePaymentFailed(event);
 
-			then(notificationRepository).should().save(notification);
-			then(pushPort).should().send(memberId, saved);
-		}
-	}
+            then(notificationRepository).should().save(notification);
+            then(pushPort).should().send(memberId, saved);
+        }
+    }
 
-	@Nested
-	@DisplayName("handlePaymentCanceled")
-	class HandlePaymentCanceled {
+    @Nested
+    @DisplayName("handlePaymentCanceled")
+    class HandlePaymentCanceled {
 
-		@Test
-		@DisplayName("결제 취소 이벤트를 수신하면 알림을 생성하고 푸시한다")
-		void createsAndPushes() {
-			Long paymentId = 3L;
-			Long memberId = 300L;
-			PaymentCanceledEvent event = PaymentCanceledEvent.create(
-				PaymentEventData.forCancel(paymentId, 10L, memberId, "ORD-003",
-					Money.of(3000), PaymentMethod.CARD, PaymentType.FUNDING,
-					CancelType.CANCEL, "사용자 요청", "txn-key-001"));
+        @Test
+        @DisplayName("결제 취소 이벤트를 수신하면 알림을 생성하고 푸시한다")
+        void createsAndPushes() {
+            Long paymentId = 3L;
+            Long memberId = 300L;
+            PaymentCanceledEvent event = PaymentCanceledEvent.create(
+                    PaymentEventData.forCancel(paymentId, 10L, memberId, "ORD-003",
+                            Money.of(3000), PaymentMethod.CARD, PaymentType.FUNDING,
+                            CancelType.CANCEL, "사용자 요청", "txn-key-001"));
 
-			CloudEventMeta meta = new CloudEventMeta(
-				"app.giftify.payment.canceled", java.net.URI.create("/giftify/payment"),
-				NotificationType.PAYMENT_CANCEL_SUCCEEDED);
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-3", "/giftify/payment", "app.giftify.payment.canceled",
-				"payment-3", OffsetDateTime.now());
-			Notification notification = createNotification(memberId);
-			Notification saved = createNotification(memberId);
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.payment.canceled", java.net.URI.create("/giftify/payment"),
+                    NotificationType.PAYMENT_CANCEL_SUCCEEDED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-3", "/giftify/payment", "app.giftify.payment.canceled",
+                    "payment-3", OffsetDateTime.now());
+            Notification notification = createNotification(memberId);
+            Notification saved = createNotification(memberId);
 
-			given(typeRegistry.resolve(PaymentCanceledEvent.class)).willReturn(meta);
-			given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
-			given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_CANCEL_SUCCEEDED,
-				String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
-			given(notificationRepository.save(notification)).willReturn(saved);
+            given(typeRegistry.resolve(PaymentCanceledEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
+            given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_CANCEL_SUCCEEDED,
+                    String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
+            given(notificationRepository.save(notification)).willReturn(saved);
 
-			eventHandler.handlePaymentCanceled(event);
+            eventHandler.handlePaymentCanceled(event);
 
-			then(notificationRepository).should().save(notification);
-			then(pushPort).should().send(memberId, saved);
-		}
-	}
+            then(notificationRepository).should().save(notification);
+            then(pushPort).should().send(memberId, saved);
+        }
+    }
 
-	@Nested
-	@DisplayName("handlePaymentCancelFailed")
-	class HandlePaymentCancelFailed {
+    @Nested
+    @DisplayName("handlePaymentCancelFailed")
+    class HandlePaymentCancelFailed {
 
-		@Test
-		@DisplayName("결제 취소 실패 이벤트를 수신하면 알림을 생성하고 푸시한다")
-		void createsAndPushes() {
-			Long paymentId = 4L;
-			Long memberId = 400L;
-			PaymentCancelFailedEvent event = PaymentCancelFailedEvent.create(
-				PaymentEventData.forCancelFailed(paymentId, 10L, memberId, "ORD-004",
-					PaymentMethod.CARD, PaymentType.FUNDING, "{\"code\":\"PG_ERROR\"}"));
+        @Test
+        @DisplayName("결제 취소 실패 이벤트를 수신하면 알림을 생성하고 푸시한다")
+        void createsAndPushes() {
+            Long paymentId = 4L;
+            Long memberId = 400L;
+            PaymentCancelFailedEvent event = PaymentCancelFailedEvent.create(
+                    PaymentEventData.forCancelFailed(paymentId, 10L, memberId, "ORD-004",
+                            PaymentMethod.CARD, PaymentType.FUNDING, "{\"code\":\"PG_ERROR\"}"));
 
-			CloudEventMeta meta = new CloudEventMeta(
-				"app.giftify.payment.cancel-failed", java.net.URI.create("/giftify/payment"),
-				NotificationType.PAYMENT_CANCEL_FAILED);
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-4", "/giftify/payment", "app.giftify.payment.cancel-failed",
-				"payment-4", OffsetDateTime.now());
-			Notification notification = createNotification(memberId);
-			Notification saved = createNotification(memberId);
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.payment.cancel-failed", java.net.URI.create("/giftify/payment"),
+                    NotificationType.PAYMENT_CANCEL_FAILED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-4", "/giftify/payment", "app.giftify.payment.cancel-failed",
+                    "payment-4", OffsetDateTime.now());
+            Notification notification = createNotification(memberId);
+            Notification saved = createNotification(memberId);
 
-			given(typeRegistry.resolve(PaymentCancelFailedEvent.class)).willReturn(meta);
-			given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
-			given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_CANCEL_FAILED,
-				String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
-			given(notificationRepository.save(notification)).willReturn(saved);
+            given(typeRegistry.resolve(PaymentCancelFailedEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("payment-" + paymentId))).willReturn(ce);
+            given(notificationFactory.createSingle(memberId, NotificationType.PAYMENT_CANCEL_FAILED,
+                    String.valueOf(paymentId), "PAYMENT", ce)).willReturn(notification);
+            given(notificationRepository.save(notification)).willReturn(saved);
 
-			eventHandler.handlePaymentCancelFailed(event);
+            eventHandler.handlePaymentCancelFailed(event);
 
-			then(notificationRepository).should().save(notification);
-			then(pushPort).should().send(memberId, saved);
-		}
-	}
+            then(notificationRepository).should().save(notification);
+            then(pushPort).should().send(memberId, saved);
+        }
+    }
 
-	private Notification createNotification(Long recipientId) {
-		return new Notification(
-			recipientId, NotificationType.PAYMENT_SUCCEEDED,
-			"결제가 완료되었습니다", "결제가 성공적으로 처리되었습니다",
-			"1", "PAYMENT",
-			"evt-001", "app.giftify.payment.succeeded", "/giftify/payment"
-		);
-	}
+    @Nested
+    @DisplayName("handleProductSellerOrderReceived")
+    class HandleProductSellerOrderReceived {
+
+        @Test
+        @DisplayName("상품별로 판매자 알림을 생성하고 푸시한다")
+        void createsPerItemAndPushes() {
+            Long sellerA = 10L;
+            Long sellerB = 20L;
+            List<SellerOrderItem> items = List.of(
+                    new SellerOrderItem(sellerA, 1L, "상품A", 2),
+                    new SellerOrderItem(sellerB, 2L, "상품B", 3)
+            );
+            ProductSellerOrderReceivedEvent event = new ProductSellerOrderReceivedEvent(items);
+
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.product.seller-order-received",
+                    java.net.URI.create("/giftify/product"),
+                    NotificationType.PRODUCT_SELLER_ORDER_RECEIVED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/product", "app.giftify.product.seller-order-received",
+                    "product-seller-order", OffsetDateTime.now());
+
+            Notification notifA = createProductNotification(sellerA, "1");
+            Notification savedA = createProductNotification(sellerA, "1");
+            Notification notifB = createProductNotification(sellerB, "2");
+            Notification savedB = createProductNotification(sellerB, "2");
+
+            given(typeRegistry.resolve(ProductSellerOrderReceivedEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("product-seller-order"))).willReturn(ce);
+            given(notificationFactory.createSingle(eq(sellerA), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
+                    eq("1"), eq("PRODUCT"), eq(ce), eq("[상품A] 2개의 주문이 인입되었습니다"))).willReturn(notifA);
+            given(notificationFactory.createSingle(eq(sellerB), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
+                    eq("2"), eq("PRODUCT"), eq(ce), eq("[상품B] 3개의 주문이 인입되었습니다"))).willReturn(notifB);
+            given(notificationRepository.save(notifA)).willReturn(savedA);
+            given(notificationRepository.save(notifB)).willReturn(savedB);
+
+            eventHandler.handleProductSellerOrderReceived(event);
+
+            then(notificationRepository).should(times(2)).save(any(Notification.class));
+            then(pushPort).should().send(sellerA, savedA);
+            then(pushPort).should().send(sellerB, savedB);
+        }
+
+        @Test
+        @DisplayName("동일 판매자의 서로 다른 상품에 대해 각각 알림을 생성한다")
+        void createsSeparateNotificationsForSameSeller() {
+            Long sellerId = 10L;
+            List<SellerOrderItem> items = List.of(
+                    new SellerOrderItem(sellerId, 1L, "상품A", 4),
+                    new SellerOrderItem(sellerId, 2L, "상품B", 2)
+            );
+            ProductSellerOrderReceivedEvent event = new ProductSellerOrderReceivedEvent(items);
+
+            CloudEventMeta meta = new CloudEventMeta(
+                    "app.giftify.product.seller-order-received",
+                    java.net.URI.create("/giftify/product"),
+                    NotificationType.PRODUCT_SELLER_ORDER_RECEIVED);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/product", "app.giftify.product.seller-order-received",
+                    "product-seller-order", OffsetDateTime.now());
+
+            Notification notifA = createProductNotification(sellerId, "1");
+            Notification notifB = createProductNotification(sellerId, "2");
+
+            given(typeRegistry.resolve(ProductSellerOrderReceivedEvent.class)).willReturn(meta);
+            given(cloudEventMapper.fromDomainEvent(eq(event), eq("product-seller-order"))).willReturn(ce);
+            given(notificationFactory.createSingle(eq(sellerId), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
+                    eq("1"), eq("PRODUCT"), eq(ce), eq("[상품A] 4개의 주문이 인입되었습니다"))).willReturn(notifA);
+            given(notificationFactory.createSingle(eq(sellerId), eq(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED),
+                    eq("2"), eq("PRODUCT"), eq(ce), eq("[상품B] 2개의 주문이 인입되었습니다"))).willReturn(notifB);
+            given(notificationRepository.save(any(Notification.class))).willAnswer(inv -> inv.getArgument(0));
+
+            eventHandler.handleProductSellerOrderReceived(event);
+
+            then(notificationRepository).should(times(2)).save(any(Notification.class));
+            then(pushPort).should(times(2)).send(eq(sellerId), any(Notification.class));
+        }
+    }
+
+    private Notification createNotification(Long recipientId) {
+        return new Notification(
+                recipientId, NotificationType.PAYMENT_SUCCEEDED,
+                "결제가 완료되었습니다", "결제가 성공적으로 처리되었습니다",
+                "1", "PAYMENT",
+                "evt-001", "app.giftify.payment.succeeded", "/giftify/payment"
+        );
+    }
+
+    private Notification createProductNotification(Long recipientId, String productId) {
+        return new Notification(
+                recipientId, NotificationType.PRODUCT_SELLER_ORDER_RECEIVED,
+                "[판매자 알림] 새로운 주문이 인입되었습니다", "주문이 인입되었습니다",
+                productId, "PRODUCT",
+                "evt-001", "app.giftify.product.seller-order-received", "/giftify/product"
+        );
+    }
 }

--- a/bc/notification/src/test/java/app/giftify/notification/application/support/NotificationFactoryTest.java
+++ b/bc/notification/src/test/java/app/giftify/notification/application/support/NotificationFactoryTest.java
@@ -1,129 +1,153 @@
 package app.giftify.notification.application.support;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.OffsetDateTime;
-import java.util.List;
-
+import app.giftify.notification.application.CloudEventEnvelope;
+import app.giftify.notification.domain.Notification;
+import app.giftify.notification.domain.NotificationType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import app.giftify.notification.application.CloudEventEnvelope;
-import app.giftify.notification.domain.Notification;
-import app.giftify.notification.domain.NotificationType;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class NotificationFactoryTest {
 
-	NotificationFactory factory = new NotificationFactory();
+    NotificationFactory factory = new NotificationFactory();
 
-	@Nested
-	@DisplayName("createSingle")
-	class CreateSingle {
+    @Nested
+    @DisplayName("createSingle")
+    class CreateSingle {
 
-		@Test
-		@DisplayName("모든 필드가 올바르게 매핑된 알림을 생성한다")
-		void mapsAllFields() {
-			Long recipientId = 100L;
-			NotificationType type = NotificationType.PAYMENT_SUCCEEDED;
-			String referenceId = "pay-1";
-			String referenceType = "PAYMENT";
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
-				"payment-1", OffsetDateTime.now()
-			);
+        @Test
+        @DisplayName("모든 필드가 올바르게 매핑된 알림을 생성한다")
+        void mapsAllFields() {
+            Long recipientId = 100L;
+            NotificationType type = NotificationType.PAYMENT_SUCCEEDED;
+            String referenceId = "pay-1";
+            String referenceType = "PAYMENT";
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
+                    "payment-1", OffsetDateTime.now()
+            );
 
-			Notification notification = factory.createSingle(
-				recipientId, type, referenceId, referenceType, ce
-			);
+            Notification notification = factory.createSingle(
+                    recipientId, type, referenceId, referenceType, ce
+            );
 
-			assertThat(notification.getRecipientId()).isEqualTo(recipientId);
-			assertThat(notification.getType()).isEqualTo(type);
-			assertThat(notification.getTitle()).isEqualTo(type.getTitle());
-			assertThat(notification.getReferenceId()).isEqualTo(referenceId);
-			assertThat(notification.getReferenceType()).isEqualTo(referenceType);
-			assertThat(notification.getSourceEventId()).isEqualTo("evt-1");
-			assertThat(notification.getSourceEventType()).isEqualTo("app.giftify.payment.succeeded");
-			assertThat(notification.getSourceEventSource()).isEqualTo("/giftify/payment");
-			assertThat(notification.isRead()).isFalse();
-		}
+            assertThat(notification.getRecipientId()).isEqualTo(recipientId);
+            assertThat(notification.getType()).isEqualTo(type);
+            assertThat(notification.getTitle()).isEqualTo(type.getTitle());
+            assertThat(notification.getReferenceId()).isEqualTo(referenceId);
+            assertThat(notification.getReferenceType()).isEqualTo(referenceType);
+            assertThat(notification.getSourceEventId()).isEqualTo("evt-1");
+            assertThat(notification.getSourceEventType()).isEqualTo("app.giftify.payment.succeeded");
+            assertThat(notification.getSourceEventSource()).isEqualTo("/giftify/payment");
+            assertThat(notification.isRead()).isFalse();
+        }
 
-		@Test
-		@DisplayName("PAYMENT_SUCCEEDED 타입의 title과 content가 정확하다")
-		void paymentSucceededContent() {
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
-				"payment-1", OffsetDateTime.now()
-			);
+        @Test
+        @DisplayName("PAYMENT_SUCCEEDED 타입의 title과 content가 정확하다")
+        void paymentSucceededContent() {
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/payment", "app.giftify.payment.succeeded",
+                    "payment-1", OffsetDateTime.now()
+            );
 
-			Notification notification = factory.createSingle(
-				1L, NotificationType.PAYMENT_SUCCEEDED, "1", "PAYMENT", ce
-			);
+            Notification notification = factory.createSingle(
+                    1L, NotificationType.PAYMENT_SUCCEEDED, "1", "PAYMENT", ce
+            );
 
-			assertThat(notification.getTitle()).isEqualTo("결제가 완료되었습니다");
-			assertThat(notification.getContent()).isEqualTo("결제가 성공적으로 처리되었습니다");
-		}
+            assertThat(notification.getTitle()).isEqualTo("결제가 완료되었습니다");
+            assertThat(notification.getContent()).isEqualTo("결제가 성공적으로 처리되었습니다");
+        }
 
-		@Test
-		@DisplayName("PAYMENT_FAILED 타입의 content가 정확하다")
-		void paymentFailedContent() {
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-2", "/giftify/payment", "app.giftify.payment.failed",
-				"payment-2", OffsetDateTime.now()
-			);
+        @Test
+        @DisplayName("PAYMENT_FAILED 타입의 content가 정확하다")
+        void paymentFailedContent() {
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-2", "/giftify/payment", "app.giftify.payment.failed",
+                    "payment-2", OffsetDateTime.now()
+            );
 
-			Notification notification = factory.createSingle(
-				1L, NotificationType.PAYMENT_FAILED, "2", "PAYMENT", ce
-			);
+            Notification notification = factory.createSingle(
+                    1L, NotificationType.PAYMENT_FAILED, "2", "PAYMENT", ce
+            );
 
-			assertThat(notification.getTitle()).isEqualTo("결제에 실패했습니다");
-			assertThat(notification.getContent()).isEqualTo("결제 처리 중 문제가 발생했습니다");
-		}
+            assertThat(notification.getTitle()).isEqualTo("결제에 실패했습니다");
+            assertThat(notification.getContent()).isEqualTo("결제 처리 중 문제가 발생했습니다");
+        }
 
-		@Test
-		@DisplayName("FUNDING_CREATED 타입의 content가 정확하다")
-		void fundingCreatedContent() {
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-3", "/giftify/funding", "app.giftify.funding.created",
-				"funding-1", OffsetDateTime.now()
-			);
+        @Test
+        @DisplayName("FUNDING_CREATED 타입의 content가 정확하다")
+        void fundingCreatedContent() {
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-3", "/giftify/funding", "app.giftify.funding.created",
+                    "funding-1", OffsetDateTime.now()
+            );
 
-			Notification notification = factory.createSingle(
-				1L, NotificationType.FUNDING_CREATED, "1", "FUNDING", ce
-			);
+            Notification notification = factory.createSingle(
+                    1L, NotificationType.FUNDING_CREATED, "1", "FUNDING", ce
+            );
 
-			assertThat(notification.getTitle()).isEqualTo("새로운 펀딩이 시작되었습니다");
-			assertThat(notification.getContent()).isEqualTo("위시리스트 아이템에 새로운 펀딩이 시작되었습니다");
-		}
-	}
+            assertThat(notification.getTitle()).isEqualTo("새로운 펀딩이 시작되었습니다");
+            assertThat(notification.getContent()).isEqualTo("위시리스트 아이템에 새로운 펀딩이 시작되었습니다");
+        }
+    }
 
-	@Nested
-	@DisplayName("createForMultipleRecipients")
-	class CreateForMultipleRecipients {
+    @Nested
+    @DisplayName("createSingle with customContent")
+    class CreateSingleWithCustomContent {
 
-		@Test
-		@DisplayName("수신자 수만큼 알림을 생성하고 각각 고유한 recipientId를 가진다")
-		void createsForEachRecipient() {
-			List<Long> recipientIds = List.of(1L, 2L, 3L);
-			CloudEventEnvelope ce = CloudEventEnvelope.of(
-				"evt-1", "/giftify/funding", "app.giftify.funding.achieved",
-				"funding-1", OffsetDateTime.now()
-			);
+        @Test
+        @DisplayName("커스텀 content가 resolveContent 대신 사용된다")
+        void usesCustomContent() {
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/product", "app.giftify.product.seller-order-received",
+                    "product-seller-order", OffsetDateTime.now()
+            );
+            String customContent = "[상품A] 4개의 주문이 인입되었습니다";
 
-			List<Notification> notifications = factory.createForMultipleRecipients(
-				recipientIds, NotificationType.FUNDING_ACHIEVED,
-				"1", "FUNDING", ce
-			);
+            Notification notification = factory.createSingle(
+                    100L, NotificationType.PRODUCT_SELLER_ORDER_RECEIVED,
+                    "1", "PRODUCT", ce, customContent
+            );
 
-			assertThat(notifications).hasSize(3);
-			assertThat(notifications)
-				.extracting(Notification::getRecipientId)
-				.containsExactly(1L, 2L, 3L);
-			assertThat(notifications)
-				.allSatisfy(n -> {
-					assertThat(n.getType()).isEqualTo(NotificationType.FUNDING_ACHIEVED);
-					assertThat(n.getReferenceId()).isEqualTo("1");
-				});
-		}
-	}
+            assertThat(notification.getTitle()).isEqualTo(NotificationType.PRODUCT_SELLER_ORDER_RECEIVED.getTitle());
+            assertThat(notification.getContent()).isEqualTo(customContent);
+            assertThat(notification.getReferenceId()).isEqualTo("1");
+            assertThat(notification.getReferenceType()).isEqualTo("PRODUCT");
+        }
+    }
+
+    @Nested
+    @DisplayName("createForMultipleRecipients")
+    class CreateForMultipleRecipients {
+
+        @Test
+        @DisplayName("수신자 수만큼 알림을 생성하고 각각 고유한 recipientId를 가진다")
+        void createsForEachRecipient() {
+            List<Long> recipientIds = List.of(1L, 2L, 3L);
+            CloudEventEnvelope ce = CloudEventEnvelope.of(
+                    "evt-1", "/giftify/funding", "app.giftify.funding.achieved",
+                    "funding-1", OffsetDateTime.now()
+            );
+
+            List<Notification> notifications = factory.createForMultipleRecipients(
+                    recipientIds, NotificationType.FUNDING_ACHIEVED,
+                    "1", "FUNDING", ce
+            );
+
+            assertThat(notifications).hasSize(3);
+            assertThat(notifications)
+                    .extracting(Notification::getRecipientId)
+                    .containsExactly(1L, 2L, 3L);
+            assertThat(notifications)
+                    .allSatisfy(n -> {
+                        assertThat(n.getType()).isEqualTo(NotificationType.FUNDING_ACHIEVED);
+                        assertThat(n.getReferenceId()).isEqualTo("1");
+                    });
+        }
+    }
 }

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/product/ProductSellerOrderReceivedEvent.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/product/ProductSellerOrderReceivedEvent.java
@@ -1,0 +1,28 @@
+package app.giftify.shared.domain.event.product;
+
+import app.giftify.shared.domain.event.BaseDomainEvent;
+import app.giftify.shared.domain.vo.SellerOrderItem;
+
+import java.util.List;
+
+public class ProductSellerOrderReceivedEvent extends BaseDomainEvent {
+    private final List<SellerOrderItem> items;
+
+    public ProductSellerOrderReceivedEvent(List<SellerOrderItem> items) {
+        super();
+        this.items = items;
+    }
+
+    public List<SellerOrderItem> getItems() {
+        return items;
+    }
+
+    @Override
+    public String toString() {
+        return "ProductSellerOrderReceivedEvent{" +
+                "items=" + items +
+                ", eventId='" + getEventId() + "'" +
+                ", occurredAt=" + getOccurredAt() +
+                '}';
+    }
+}

--- a/bc/shared/src/main/java/app/giftify/shared/domain/vo/SellerOrderItem.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/vo/SellerOrderItem.java
@@ -1,0 +1,9 @@
+package app.giftify.shared.domain.vo;
+
+public record SellerOrderItem(
+        Long sellerId,
+        Long productId,
+        String productName,
+        int quantity
+) {
+}


### PR DESCRIPTION
## Summary

```mermaid
sequenceDiagram
    participant Order as 주문 모듈
    participant Product as 상품 모듈<br/>(@EventListener)
    participant Notification as 알림 모듈<br/>(@ApplicationModuleListener)

    rect rgb(220, 240, 220)
        Note over Order,Product: 트랜잭션
        Order->>Product: 1. OrderConfirmPendingEvent 발행
        Product->>Product: 2. 재고 차감
        Product-->>Order: 성공
        Order->>Order: 3. OrderStatus = CONFIRMED
    end

    Note over Order: 트랜잭션 커밋

    Order--)Notification: AFTER_COMMIT 이벤트 전달
    Notification->>Notification: 판매자 알림 전송 (상품별 1개)
```
주문 확정(재고 차감) 성공 후 판매자에게 "주문 인입" 알림을 실시간 전송하는 기능을 구현했습니다.

기존에는 주문이 확정되어도 판매자가 직접 확인하기 전까지 새 주문 인입 사실을 알 수 없었습니다. 이번 변경으로 재고 차감이 완료된 시점에 `ProductSellerOrderReceivedEvent`를 발행하고, 트랜잭션 커밋 이후 (@ApplicationModuleListener) 알림 모듈이 상품별로 판매자 알림을 생성 + SSE 푸시합니다.

  리뷰 포인트:
  - DecreaseProductStockUseCase 반환타입 변경(void → List<SellerOrderItem>)이 기존 호출부에 영향 없는지
  - 이벤트 발행 위치가 ProductEventListener(catalog 모듈)인 점이 모듈 책임 분리 관점에서 적절한지
  - 알림 생성 전략(판매자별 그룹핑 vs 상품별 개별 알림)

<img width="2048" height="938" alt="image" src="https://github.com/user-attachments/assets/f15a0c00-2152-4583-99e1-29b69fc8d866" />
<img width="2048" height="619" alt="image" src="https://github.com/user-attachments/assets/a74bb3da-a4bb-42c8-a1c3-0e8ee8f9585f" />
<img width="2048" height="1169" alt="image" src="https://github.com/user-attachments/assets/04b50624-4b4c-4cce-b076-5a8bac4e24ac" />


---

## What's Changed

### 재고 차감 시 판매자 정보 수집                                                                                                                       
                                         
기존에는 재고만 차감하고 끝났지만, 이제 차감 루프 안에서 SellerOrderItem(sellerId, productId, productName, quantity)을 수집하여 반환합니다.

  - DecreaseProductStockUseCase 반환타입: void → List<SellerOrderItem>
  - ProductEventListener가 반환값을 받아 ProductSellerOrderReceivedEvent를 발행

### 알림 모듈에서 상품별 판매자 알림 생성

필드 | 값
-- | --
title | "[판매자 알림] 새로운 주문이 인입되었습니다" (NotificationType.getTitle())
content | "[상품A] 4개의 주문이 인입되었습니다" (커스텀 컨텐츠)
referenceId | productId
referenceType | "PRODUCT"

  NotificationEventHandler가 트랜잭션 커밋 후 이벤트를 수신하여 `SellerOrderItem`마다 알림을 생성합니다.

  - content: "[상품A] 4개의 주문이 인입되었습니다" (상품명 + 수량 동적 생성)
  - referenceId = productId, referenceType = "PRODUCT" → 알림 클릭 시 상품 페이지 이동 (_프론트엔드 TODO_)
  - **NotificationFactory.createSingle 6파라미터 오버로드 추가 (동적 content 전달용)**

### 테스트

  - ProductEventListenerTest — 성공/재고부족/상품미존재 시 이벤트 발행 여부 검증
  - NotificationEventHandlerTest — 다른 판매자 상품별 알림, 동일 판매자 상품별 개별 알림 검증
  - NotificationFactoryTest — customContent가 resolveContent() 대신 사용되는지 검증

---

## Decisions & Trade-offs

### OrderConfirmPendingEvent가 아닌 별도의 이벤트(ProductSellerOrderReceivedEvent)
  - OrderConfirmPendingEvent에는 productId와 quantity만 있고 sellerId가 없음
  - Product 엔티티가 sellerId를 알고 있으므로, 상품 모듈에서 재고 차감 시 SellerOrderItem을 수집하여 이벤트를 발행하는 것이 자연스러움
  - 주문 모듈이 상품의 판매자 정보를 알 필요 없이 모듈 간 결합도를 낮춤

### 판매자별 그룹핑 대신 상품별 개별 알림
  - 판매자별로 묶으면 referenceId에 단일 productId를 넣을 수 없어 알림 클릭 시 특정 상품 페이지로 이동 불가 (_프론트엔드 TODO_)
  - 상품별 알림 1개씩 생성 → referenceId = productId, referenceType = "PRODUCT"로 상품 재고이력 페이지 딥링크 가능
  - 알림 단위는 상품별 1개이지만, DB 저장은 `saveAll`로 벌크 처리하므로 상품 수가 늘어도 DB 부하는 최소화 가능

### @EventListener(동기) + @ApplicationModuleListener(비동기) 조합
  - 재고 차감은 주문 확정과 같은 트랜잭션이어야 하므로 @EventListener(동기)
  - 알림 전송은 커밋 성공 후에만 수행되어야 하므로 @ApplicationModuleListener(AFTER_COMMIT)
  - 트랜잭션 롤백 시 알림이 전송되지 않아 데이터 정합성 보장

---

## Future Improvements

  - 알림 수신 설정: 판매자가 주문 인입 알림을 끌 수 있는 알림 설정 기능

---

### Linked Issues

- closes #278 
