### PR TITLE
펀딩 거절/종료 시 주문&결제 취소 누락 해소

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
@@ -9,6 +9,7 @@ import app.giftify.shared.api.exception.InfraException;
 import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.shared.domain.event.funding.FundingAcceptedEvent;
 import app.giftify.shared.domain.event.funding.FundingConfirmPendingEvent;
+import app.giftify.shared.domain.event.funding.FundingCanceledEvent;
 import app.giftify.shared.domain.event.funding.FundingExpiredEvent;
 import app.giftify.shared.domain.event.order.OrderConfirmFailedEvent;
 import app.giftify.shared.domain.event.order.OrderConfirmedEvent;
@@ -69,6 +70,21 @@ public class OrderEventListener {
                         event.getFundingId(),
                         Money.of(event.getExpiredAmount()
                         )
+                ));
+    }
+
+    @Retryable(
+            retryFor = InfraException.class,
+			exceptionExpression = "#root.errorCode.isRetryable",
+            backoff = @Backoff(delay = 100, multiplier = 2.0, random = true)
+    )
+    @ApplicationModuleListener
+    public void on(FundingCanceledEvent event) {
+        log.info("[이벤트 수신] 펀딩 취소 -> 주문 취소 반영 시작. FundingId: {}", event.getFundingId());
+        fundingOrderService.requestCancelFundingOrder(
+                new CancelFundingOrderCommand(
+                        event.getFundingId(),
+                        Money.of(event.getCanceledAmount())
                 ));
     }
 

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -9,7 +9,10 @@ import app.giftify.shared.api.exception.DomainException;
 import app.giftify.shared.api.exception.InfraErrorCode;
 import app.giftify.shared.api.exception.InfraException;
 import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.order.application.inbound.command.CancelFundingOrderCommand;
+import app.giftify.shared.domain.event.funding.FundingCanceledEvent;
 import app.giftify.shared.domain.event.funding.FundingConfirmPendingEvent;
+import app.giftify.shared.domain.vo.Money;
 import app.giftify.shared.domain.event.order.OrderConfirmFailedEvent;
 import app.giftify.shared.domain.event.order.OrderConfirmedEvent;
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
@@ -25,6 +28,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,6 +85,50 @@ class OrderEventListenerTest {
 
         // then: 실제로 재시도가 발생했는지 횟수 확인
         verify(orderService, atLeast(2)).completeCancel(any());
+    }
+
+    @Nested
+    @DisplayName("FundingCanceledEvent 처리 (on(FundingCanceledEvent))")
+    class OnFundingCanceledEvent {
+
+        private static final Long FUNDING_ID = 1L;
+        private static final Long WISHLIST_ITEM_ID = 10L;
+        private static final Integer CANCELED_AMOUNT = 50000;
+        private static final Long RECEIVER_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 정상 처리 후 requestCancelFundingOrder가 호출된다")
+        void given_success_when_onFundingCanceledEvent_then_callRequestCancelFundingOrder() {
+            // given
+            FundingCanceledEvent event = new FundingCanceledEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, CANCELED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            verify(fundingOrderService).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+        }
+
+        @Test
+        @DisplayName("성공: 커맨드에 이벤트의 fundingId와 canceledAmount가 올바르게 전달된다")
+        void given_event_when_onFundingCanceledEvent_then_commandHasCorrectData() {
+            // given
+            FundingCanceledEvent event = new FundingCanceledEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, CANCELED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<CancelFundingOrderCommand> captor =
+                    ArgumentCaptor.forClass(CancelFundingOrderCommand.class);
+            verify(fundingOrderService).requestCancelFundingOrder(captor.capture());
+            assertThat(captor.getValue().fundingId()).isEqualTo(FUNDING_ID);
+            assertThat(captor.getValue().expiredAmount()).isEqualTo(Money.of(CANCELED_AMOUNT));
+        }
     }
 
     @Nested


### PR DESCRIPTION
 ## Summary

  FundingCanceledEvent(수령자 거절/관리자 강제 종료/2주 미수락 자동 종료) 발행 시 OrderEventListener에 핸들러가 없어 **결제 취소가 연쇄되지 않는 문제**를 해결합니다.

 기존에 FundingExpiredEvent(펀딩 만료)는 OrderEventListener에서 수신하여 주문 취소 → PG 환불까지 정상 처리되지만, FundingCanceledEvent는 Wishlist 상태 복원 + 알림만 처리되고 **Payment는 PAID 상태로 남아 재무 불일치**가 발생했습니다.


이 변경이 기존 Order 도메인의 코드 의도와 잘 맞아 떨어지는지 리뷰를 부탁드립니다. 

  ---

  ## What's Changed

  ### `OrderEventListener`에 `FundingCanceledEvent` 핸들러 추가

  기존 FundingExpiredEvent 핸들러와 동일한 패턴으로 추가했습니다. 금액 필드명만 다릅니다: `expiredAmount` → `canceledAmount`

  ### 이벤트 체인 전체 플로우

  <details>
  <summary>펀딩 취소 전체 이벤트 체인 다이어그램 (사용자별 주문 분기 + 부분 취소 플로우 포함 )</summary>

  ```
┌─────────────────────────────────────────────────────────────────────────┐
  │  예시 상황                                                               │
  │                                                                         │
  │  펀딩X (목표 50,000원, ACHIEVED)                                         │
  │  ├─ 사용자A: 20,000원 기여 (Order#1에 펀딩X + 펀딩Y + 상품 포함)          │
  │  ├─ 사용자B: 15,000원 기여 (Order#2에 펀딩X만)                           │
  │  └─ 사용자C: 15,000원 기여 (Order#3에 펀딩X만)                           │
  │                                                                         │
  │  Order#1: OrderItem#1(펀딩X,20k) + OrderItem#4(펀딩Y,10k) + Item#5(상품) │
  │  Order#2: OrderItem#2(펀딩X,15k)                                        │
  │  Order#3: OrderItem#3(펀딩X,15k)                                        │
  └─────────────────────────────────────────────────────────────────────────┘

                  수령자가 "거절" 클릭
                         │
                         ▼
  ┌─ Funding BC ── [Adapter-In] → [Application] ────────────────────────────┐
  │                                                                         │
  │  funding.adpater.inbound.web.FundingController:84        [Adapter-In]   │
  │  POST /api/v2/fundings/{id}/refuse                                      │
  │     ↓                                                                   │
  │  funding.application.FundingRefuseUseCase:39             [Application]  │
  │  funding.refuse() → status: ACHIEVED → REFUSED                          │
  │  publish(FundingCanceledEvent(fundingId, canceledAmount=50000))          │
  │                                                                         │
  │  shared.domain.event.funding.FundingCanceledEvent        [Shared]       │
  │  { fundingId, wishlistItemId, canceledAmount=50000,                     │
  │    receiverId, participantIds=[A,B,C] }                                 │
  │                                                                         │
  └──────────────────────────┬──────────────────────────────────────────────┘
                             │
           ┌─────────────────┼─────────────────┐
           ▼                 ▼                 ▼
    ┌─ Catalog BC ─┐  ┌─ Notification BC ┐  ┌─ Order BC ──────────────────┐
    │ [Adapter-In] │  │ [Adapter-In]     │  │ ★ 이번에 추가한 코드         │
    │ Wishlist     │  │ Notification     │  │                              │
    │ EventListener│  │ EventHandler     │  │ order.adapter.inbound.event  │
    │ :69          │  │ :82              │  │  .OrderEventListener:82-89   │
    │              │  │                  │  │  [Adapter-In]                │
    │ WishlistItem │  │ 수령자 알림      │  │                              │
    │ → PENDING    │  │ 참여자 A,B,C 알림│  │ on(FundingCanceledEvent)     │
    └──────────────┘  └──────────────────┘  └────────────┬─────────────────┘
                                                         │
                                                         ▼
  ┌─ Order BC ── [Application] ─────────────────────────────────────────────┐
  │                                                                         │
  │  order.application.FundingOrderService:36-63             [Application]  │
  │                                                                         │
  │  :39  orderItemRepository.getOrderItemsWithOrderAndFindingId(fundingId) │
  │       → fundingId로 조회: OrderItem#1, #2, #3 (3건)     [Port-Out]     │
  │       ※ OrderItem#4(펀딩Y), #5(상품)는 조회 안 됨                       │
  │                                                                         │
  │  :44  groupOrderItemsByOrder()                                          │
  │       ┌───────────────────────────────────────────────────────┐         │
  │       │ Order#1 (사용자A) → [OrderItem#1]  ← 부분 취소 대상   │         │
  │       │ Order#2 (사용자B) → [OrderItem#2]  ← 전체 취소 대상   │         │
  │       │ Order#3 (사용자C) → [OrderItem#3]  ← 전체 취소 대상   │         │
  │       └───────────────────────────────────────────────────────┘         │
  │                                                                         │
  │  :46  forEach — 각 Order별 독립 취소 (try-catch로 실패 격리)             │
  │                                                                         │
  └────────┬──────────────────────┬──────────────────────┬──────────────────┘
           │                      │                      │
           ▼                      ▼                      ▼
  ┌─ Order#1 (사용자A) ──┐ ┌─ Order#2 (사용자B) ──┐ ┌─ Order#3 (사용자C) ──┐
  │ ★ 부분 취소          │ │ ★ 전체 취소          │ │ ★ 전체 취소          │
  │                      │ │                      │ │                      │
  │ order.application    │ │ (동일 로직)          │ │ (동일 로직)          │
  │  .OrderService       │ │                      │ │                      │
  │  :138-160            │ │ itemIds=[#2]         │ │ itemIds=[#3]         │
  │  [Application]       │ │ cancelAmount=15,000  │ │ cancelAmount=15,000  │
  │  @Transactional      │ │                      │ │                      │
  │  (REQUIRES_NEW)      │ │ Order#2 아이템 전부   │ │ Order#3 아이템 전부   │
  │                      │ │ → 전체 취소           │ │ → 전체 취소           │
  │ itemIds=[#1]만 전달  │ └──────────┬───────────┘ └──────────┬───────────┘
  │ cancelAmount=20,000  │            │                         │
  │                      │            ▼                         ▼
  │ :139 비관적 락       │   OrderCancelRequestedEvent  OrderCancelRequestedEvent
  │ :142 부분취소 검증   │   (orderId, paymentId,       (orderId, paymentId,
  │ :144 OrderItem#1만   │    cancelAmount=15,000)       cancelAmount=15,000)
  │      CANCELING       │
  │                      │
  │ Order#1 아이템 상태: │
  │ ┌────────────────┐   │
  │ │#1 펀딩X 20k    │   │
  │ │ PAID→CANCELING │   │
  │ │                │   │
  │ │#4 펀딩Y 10k    │   │
  │ │ PAID (유지)    │   │
  │ │                │   │
  │ │#5 상품  5k     │   │
  │ │ PAID (유지)    │   │
  │ └────────────────┘   │
  │                      │
  │ :150 publish(        │
  │  OrderCancel         │
  │  RequestedEvent)     │
  │  cancelAmount=20,000 │
  └──────────┬───────────┘
             │
             ▼  (3개 Order 모두 동일 체인)
  ┌─ Payment BC ── [Adapter-In] → [Application] → [Adapter-Out] ───────────┐
  │                                                                         │
  │  payment.adapter.inbound.event                                          │
  │    .OrderCancelEventHandler:22-36                        [Adapter-In]   │
  │                                                                         │
  │  payment.application.CancelPaymentService:50-70          [Application]  │
  │                                                                         │
  │  ┌─────────────────────────────────────────────────────────────────┐     │
  │  │ Order#1 (부분 취소)                                              │     │
  │  │ :95  paymentGateway.cancel(20,000)        [Adapter-Out → Toss]  │     │
  │  │ :98  payment.markAsPartiallyCanceled()    [Domain]              │     │
  │  │      → Payment: PAID → PARTIALLY_CANCELED                       │     │
  │  │      → registerEvent(PaymentCanceledEvent)                      │     │
  │  ├─────────────────────────────────────────────────────────────────┤     │
  │  │ Order#2, #3 (전체 취소)                                          │     │
  │  │ :76  paymentGateway.cancel(15,000)        [Adapter-Out → Toss]  │     │
  │  │ :79  payment.markAsCanceled()             [Domain]              │     │
  │  │      → Payment: PAID → CANCELED                                 │     │
  │  │      → registerEvent(PaymentCanceledEvent)                      │     │
  │  └─────────────────────────────────────────────────────────────────┘     │
  │                                                                         │
  │  :130  domainEvents.forEach(eventPublisher::publish)                    │
  │                                                                         │
  └──────────────────────────┬──────────────────────────────────────────────┘
                             │ PaymentCanceledEvent (×3)
                             ▼
  ┌─ Order BC ── [Adapter-In] → [Application] → [Domain] ──────────────────┐
  │                                                                         │
  │  order.adapter.inbound.event                                            │
  │    .OrderEventListener:43-46                             [Adapter-In]   │
  │  :45  orderService.completeCancel(orderId)                              │
  │                                                                         │
  │  order.application.OrderService:163-176                  [Application]  │
  │  :169  CANCELING 아이템 → CANCELED                                      │
  │  :170  order.synchronizeStatus()                         [Domain]       │
  │                                                                         │
  │  order.domain.OrderStatus.deriveStatus():22              [Domain]       │
  │  ┌─────────────────────────────────────────────────────────────────┐     │
  │  │ Order#1: Item#1=CANCELED, #4=PAID, #5=PAID                      │     │
  │  │   → 혼합 상태 → OrderStatus.PARTIAL_CANCELED                    │     │
  │  ├─────────────────────────────────────────────────────────────────┤     │
  │  │ Order#2: Item#2=CANCELED (전부)                                  │     │
  │  │   → OrderStatus.CANCELED                                        │     │
  │  ├─────────────────────────────────────────────────────────────────┤     │
  │  │ Order#3: Item#3=CANCELED (전부)                                  │     │
  │  │   → OrderStatus.CANCELED                                        │     │
  │  └─────────────────────────────────────────────────────────────────┘     │
  │                                                                         │
  │  :172  publish(OrderCanceledEvent)  (×3)                                │
  │                                                                         │
  └──────────────────────────┬──────────────────────────────────────────────┘
                             │ OrderCanceledEvent (×3)
                             ▼
  ┌─ Funding BC ── [Adapter-In] → [Application] → [Domain] ────────────────┐
  │                                                                         │
  │  funding.adpater.inbound                                                │
  │    .OrderCanceledEventListener:19-36                     [Adapter-In]   │
  │  :22  event.getItems().filter(TargetType.FUNDING)                       │
  │       ※ OrderItem#4(펀딩Y), #5(상품)는 필터링 → 무관                    │
  │                                                                         │
  │  funding.application.WithdrawFundingUseCase:20-32        [Application]  │
  │  ┌─────────────────────────────────────────────────────────────────┐     │
  │  │ Order#1 → Item#1: withdraw(A, 20,000)                           │     │
  │  │   funding.withdraw(20,000)  currentAmount: 50,000 → 30,000     │     │
  │  │   participantRepository.delete(A)                               │     │
  │  ├─────────────────────────────────────────────────────────────────┤     │
  │  │ Order#2 → Item#2: withdraw(B, 15,000)                           │     │
  │  │   funding.withdraw(15,000)  currentAmount: 30,000 → 15,000     │     │
  │  │   participantRepository.delete(B)                               │     │
  │  ├─────────────────────────────────────────────────────────────────┤     │
  │  │ Order#3 → Item#3: withdraw(C, 15,000)                           │     │
  │  │   funding.withdraw(15,000)  currentAmount: 15,000 → 0          │     │
  │  │   participantRepository.delete(C)                               │     │
  │  └─────────────────────────────────────────────────────────────────┘     │
  │                                                                         │
  └─────────────────────────────────────────────────────────────────────────┘

  ┌─ 최종 상태 요약 ────────────────────────────────────────────────────────┐
  │                                                                         │
  │  Funding X:  ACHIEVED → REFUSED, currentAmount: 50,000 → 0             │
  │  참여자:     A, B, C 모두 삭제됨                                         │
  │                                                                         │
  │  ┌──────────────┬────────────┬──────────────┬───────────────────────┐   │
  │  │              │ 사용자A    │ 사용자B      │ 사용자C               │   │
  │  ├──────────────┼────────────┼──────────────┼───────────────────────┤   │
  │  │ Order 상태   │ PARTIAL_   │ CANCELED     │ CANCELED              │   │
  │  │              │ CANCELED   │              │                       │   │
  │  ├──────────────┼────────────┼──────────────┼───────────────────────┤   │
  │  │ Payment 상태 │ PARTIALLY_ │ CANCELED     │ CANCELED              │   │
  │  │              │ CANCELED   │              │                       │   │
  │  ├──────────────┼────────────┼──────────────┼───────────────────────┤   │
  │  │ PG 환불      │ 20,000원   │ 15,000원     │ 15,000원              │   │
  │  │              │ (부분환불) │ (전액환불)   │ (전액환불)            │   │
  │  ├──────────────┼────────────┼──────────────┼───────────────────────┤   │
  │  │ 펀딩Y 영향   │ 없음       │ -            │ -                     │   │
  │  │ (Order#1)    │ Item#4 유지│              │                       │   │
  │  └──────────────┴────────────┴──────────────┴───────────────────────┘   │
  │                                                                         │
  │  Toss PG 총 환불: 50,000원 (20k + 15k + 15k)                           │
  │  Funding Y: 영향 없음 (사용자A의 Order#1에서 펀딩Y 기여는 유지)          │
  │                                                                         │
  └─────────────────────────────────────────────────────────────────────────┘

  ┌─ 격리 메커니즘 ─────────────────────────────────────────────────────────┐
  │                                                                         │
  │  1. fundingId 기반 조회          → 해당 펀딩의 OrderItem만 필터          │
  │     FundingOrderService:39        (다른 펀딩 기여는 건드리지 않음)       │
  │                                                                         │
  │  2. Order별 그룹화 + forEach     → 사용자별 독립 취소                    │
  │     FundingOrderService:44,46     (A 실패해도 B, C 계속 진행)           │
  │                                                                         │
  │  3. REQUIRES_NEW 트랜잭션        → 각 Order 취소가 독립 트랜잭션        │
  │     OrderService:138              (한 Order 롤백이 다른 Order 무영향)   │
  │                                                                         │
  │  4. deriveStatus() 자동 판단     → 부분/전체 취소 상태 자동 결정         │
  │     OrderStatus:22                (전부 CANCELED면 CANCELED,            │
  │                                    혼합이면 PARTIAL_CANCELED)           │
  │                                                                         │
  │  5. TargetType.FUNDING 필터      → 기여 철회 시 펀딩 아이템만 처리       │
  │     OrderCanceledEventListener:23 (상품 OrderItem은 건너뜀)             │
  │                                                                         │
  └─────────────────────────────────────────────────────────────────────────┘
```
  </details>


  ### 부분 취소 시나리오

  하나의 주문에 여러 펀딩 기여가 섞여 있는 경우, 취소 대상 펀딩의 OrderItem만 부분 취소됩니다:

```
  Order#1 (사용자A, 총 35,000원)
  ├─ OrderItem#1: 펀딩X 기여 20,000원  → CANCELED (부분 취소)
  ├─ OrderItem#4: 펀딩Y 기여 10,000원  → PAID 유지
  └─ OrderItem#5: 일반 상품   5,000원  → PAID 유지

  → Payment: PARTIALLY_CANCELED (20,000원만 PG 환불)
  → Order: PARTIAL_CANCELED (deriveStatus 자동 판단)
  → 펀딩Y 기여: 영향 없음

```
  ### 격리 메커니즘 (5단계)

  | # | 메커니즘 | 위치 | 역할 |
  |---|---------|------|------|
  | 1 | fundingId 기반 조회 | FundingOrderService:39 | 해당 펀딩의 OrderItem만 필터 |
  | 2 | Order별 그룹화 + forEach | FundingOrderService:44,46 | 사용자별 독립 취소 (A 실패 시 B,C 계속) |
  | 3 | REQUIRES_NEW 트랜잭션 | OrderService:138 | 각 Order 취소가 독립 트랜잭션 |
  | 4 | deriveStatus() 자동 판단 | OrderStatus:22 | 부분/전체 취소 상태 자동 결정 |
  | 5 | TargetType.FUNDING 필터 | OrderCanceledEventListener:23 | 기여 철회 시 펀딩 아이템만 처리 |

  ---

  ## Decisions & Trade-offs

  ### FundingCanceledEvent에 orderId를 추가하지 않은 이유

  FundingExpiredEvent가 orderId 없이 fundingId만으로 동작하는 것을 보고 이를 벤치마킹했습니다.`FundingOrderService.requestCancelFundingOrder()`에서 fundingId → OrderItem 역조회 패턴이 이미 검증되어 있으므로, 이벤트 스키마 변경 없이 리스너만 추가했습니다.

  ### 기존 패턴 재사용

  새 로직을 작성하지 않고 `FundingExpiredEvent` 핸들러의 패턴을 그대로 복제했습니다.
  `CancelFundingOrderCommand.expiredAmount` 필드에 `canceledAmount`를 매핑하는 점이 네이밍상 약간 어색하지만, Command 클래스를 수정하면 기존 만료 플로우에 영향을 줄 수 있어 일단은 유지했습니다...!

  ---

  ## Future Improvements

  - **CancelFundingOrderCommand 필드명 리팩토링**: `expiredAmount` → `cancelAmount`로 범용화하면
    만료/거절/종료 모든 시나리오에 자연스러운 네이밍이 됩니다
  - **정합성 검증 배치 Job**: Payment=PAID인데 Funding=REFUSED/CLOSED인 건을 주기적으로 감지하는
    모니터링 배치를 추가하면 이벤트 누락 시에도 수동 정정이 가능합니다

  ---

  ### Linked Issues

  - closes #364
