### PR TITLE
order_items target_type 값을 GENERAL_PRODUCT에서 DIRECT_PURCHASE로 수정

### DIFF
--- a/bootstrap/api-server/src/main/resources/data-local.sql
+++ b/bootstrap/api-server/src/main/resources/data-local.sql
@@ -444,21 +444,21 @@ ALTER TABLE orders
 -- -----------------------------------------------------------------------------
 INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
                          price, amount, status, cancelled_at, created_at, updated_at)
-VALUES (1, 1, 1, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 2,
+VALUES (1, 1, 1, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 2,
         359000.00, 359000.00, 'PAID', NULL, '2026-02-05 17:00:00', '2026-02-05 17:05:00'),
 
-       (2, 2, 2, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 2,
+       (2, 2, 2, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 2,
         23000.00, 23000.00, 'PAID', NULL, '2026-02-05 17:10:00', '2026-02-06 10:00:00'),
 
-       (3, 3, 3, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 5,
+       (3, 3, 3, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 5,
         415000.00, 415000.00, 'CREATED', NULL, '2026-02-07 12:00:00', '2026-02-07 12:00:00'),
 
-       (4, 4, 2, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 6,
+       (4, 4, 2, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 6,
         23000.00, 23000.00, 'PAID', NULL, '2026-02-08 14:00:00', '2026-02-08 14:05:00'),
-       (5, 4, 3, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 6,
+       (5, 4, 3, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 6,
         415000.00, 415000.00, 'PAID', NULL, '2026-02-08 14:00:00', '2026-02-08 14:05:00'),
 
-       (6, 5, 5, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 5,
+       (6, 5, 5, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 5,
         89000.00, 89000.00, 'CANCELED', '2026-02-08 16:00:00', '2026-02-08 15:00:00', '2026-02-08 16:00:00');
 
 ALTER TABLE order_items

--- a/bootstrap/api-server/src/main/resources/db/migration/order/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/order/R__seed.sql
@@ -38,21 +38,21 @@ SELECT setval('orders_id_seq', 100, false);
 
 INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
                          price, amount, status, cancelled_at, created_at, updated_at)
-VALUES (1, 1, 1, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 2,
+VALUES (1, 1, 1, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 2,
         359000.00, 359000.00, 'PAID', NULL, '2026-02-05 17:00:00', '2026-02-05 17:05:00'),
 
-       (2, 2, 2, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 2,
+       (2, 2, 2, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 2,
         23000.00, 23000.00, 'PAID', NULL, '2026-02-05 17:10:00', '2026-02-06 10:00:00'),
 
-       (3, 3, 3, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 5,
+       (3, 3, 3, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 5,
         415000.00, 415000.00, 'CREATED', NULL, '2026-02-07 12:00:00', '2026-02-07 12:00:00'),
 
-       (4, 4, 2, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 6,
+       (4, 4, 2, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 6,
         23000.00, 23000.00, 'PAID', NULL, '2026-02-08 14:00:00', '2026-02-08 14:05:00'),
-       (5, 4, 3, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 6,
+       (5, 4, 3, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 6,
         415000.00, 415000.00, 'PAID', NULL, '2026-02-08 14:00:00', '2026-02-08 14:05:00'),
 
-       (6, 5, 5, 'GENERAL_PRODUCT', 'NORMAL_ORDER', 3, 5,
+       (6, 5, 5, 'DIRECT_PURCHASE', 'NORMAL_ORDER', 3, 5,
         89000.00, 89000.00, 'CANCELED', '2026-02-08 16:00:00', '2026-02-08 15:00:00', '2026-02-08 16:00:00');
 
 SELECT setval('order_items_id_seq', 100, false);


### PR DESCRIPTION


## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

- data-local.sql과 R__seed.sql의 order_items 데이터에서 target_type 필드 값 전면 수정
- 데이터 정합성 및 비즈니스 로직 명세 일치성을 위한 변경
- 주문 생성 로직을 수정하는 과정에서 TargetType 수정 및 추가 발생
- 시드 데이터에 이 변경 사항이 반영되지 않은 상태로 유지되어 dev 환경에서 에러 발생

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

- data-local.sql과 R__seed.sql의 order_items 데이터에서 target_type 필드 값을 GENERAL_PRODUCT에서 DIRECT_PURCHASE로 수정

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.


---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.


---

### Linked Issues

- closes #
