### PR TITLE
Swagger 문서화에 사용하는 API 인터페이스 네이밍 V2ApiSpec 패턴으로 통일

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderController.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderController.java
@@ -30,7 +30,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v2/orders")
 @RequiredArgsConstructor
-public class OrderController implements OrderControllerSpec {
+public class OrderController implements OrderV2ApiSpec {
 
     private final CoreFacade coreFacade;
     private final OrderService orderService;

--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderV2ApiSpec.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderV2ApiSpec.java
@@ -19,7 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Order V2", description = "주문 API (v2)")
-public interface OrderControllerSpec {
+public interface OrderV2ApiSpec {
     @Operation(summary = "주문 생성", description = "로그인된 회원 ID로 단일/복수 주문 항목에 대해 주문을 생성합니다.")
     @ApiResponse(responseCode = "201", description = "주문 생성 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 요청")

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletController.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletController.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v2/wallet")
 @RequiredArgsConstructor
 @Validated
-public class WalletController implements WalletV2Api {
+public class WalletController implements WalletV2ApiSpec {
 	private final WithdrawWalletUseCase withdrawWalletUseCase;
 	private final QueryWalletUseCase queryWalletUseCase;
 	private final QueryWalletHistoryUseCase queryWalletHistoryUseCase;

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletV2ApiSpec.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/web/WalletV2ApiSpec.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
 @Tag(name = "Wallet V2", description = "예치금 지갑 API (v2)")
-public interface WalletV2Api {
+public interface WalletV2ApiSpec {
 
     @Operation(
             summary = "예치금 출금 요청",
@@ -93,12 +93,12 @@ public interface WalletV2Api {
             summary = "예치금 거래 내역 조회",
             description = """
                     현재 로그인한 사용자의 예치금 거래 내역을 조회합니다.
-                    
+
                     **거래 유형**:
                     - CHARGE: 충전
                     - WITHDRAW: 출금
                     - PAYMENT: 결제
-                    
+
                     **페이징**:
                     - page: 페이지 번호 (0부터 시작, 기본값: 0)
                     - size: 페이지 크기 (기본값: 20, 최대: 100)

--- a/bc/member/src/main/java/app/giftify/member/adapter/in/web/MemberV2ApiSpec.java
+++ b/bc/member/src/main/java/app/giftify/member/adapter/in/web/MemberV2ApiSpec.java
@@ -22,9 +22,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
 @Tag(name = "Member V2", description = "회원 정보 관리 API (v2)")
-public interface MemberV2Api {
-
-    // ========== 가입된 회원 전용 (memberId 사용) ==========
+public interface MemberV2ApiSpec {
 
     @Operation(
             summary = "내 정보 조회",
@@ -76,8 +74,6 @@ public interface MemberV2Api {
             @Parameter(hidden = true) @CurrentMemberId Long memberId
     );
 
-    // ========== 미가입 사용자도 호출 가능 (authSub 사용) ==========
-
     @Operation(
             summary = "회원가입 (추가 정보 입력)",
             description = """
@@ -115,8 +111,6 @@ public interface MemberV2Api {
     ResponseEntity<RsData<RegistrationStatusResponse>> checkRegistration(
             @Parameter(hidden = true) @CurrentAuthSub String authSub
     );
-
-    // ========== 인증 불필요 ==========
 
     @Operation(
             summary = "닉네임 중복 확인",

--- a/bc/member/src/main/java/app/giftify/member/adapter/in/web/MemberV2Controller.java
+++ b/bc/member/src/main/java/app/giftify/member/adapter/in/web/MemberV2Controller.java
@@ -40,7 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v2/members")
 @RequiredArgsConstructor
 @Validated
-public class MemberV2Controller implements MemberV2Api {
+public class MemberV2Controller implements MemberV2ApiSpec {
 
     private final GetMemberUseCase getMemberUseCase;
     private final RegisterMemberUseCase registerMemberUseCase;

--- a/bc/settlement/build.gradle.kts
+++ b/bc/settlement/build.gradle.kts
@@ -3,6 +3,7 @@ dependencies {
     implementation(project(":support:common"))
     implementation(project(":support:security"))
     implementation(project(":support:jpa"))
+    implementation(project(":support:web"))
     implementation(project(":bc:shared"))
 
     // Spring Boot Starters

--- a/bc/settlement/src/main/java/app/giftify/settlement/adapter/inbound/web/controller/SettlementController.java
+++ b/bc/settlement/src/main/java/app/giftify/settlement/adapter/inbound/web/controller/SettlementController.java
@@ -18,10 +18,11 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/settlements")
 @RequiredArgsConstructor
-public class SettlementController {
+public class SettlementController implements SettlementV2ApiSpec {
 
     private final SettlementItemService settlementItemService;
 
+    @Override
     @GetMapping
     public ResponseEntity<RsData<PageResponse<SettlementSummary>>> getSettlementSummary(
             @CurrentMemberId Long sellerId,

--- a/bc/settlement/src/main/java/app/giftify/settlement/adapter/inbound/web/controller/SettlementV2ApiSpec.java
+++ b/bc/settlement/src/main/java/app/giftify/settlement/adapter/inbound/web/controller/SettlementV2ApiSpec.java
@@ -1,0 +1,27 @@
+package app.giftify.settlement.adapter.inbound.web.controller;
+
+import app.giftify.settlement.application.service.dto.SettlementSummary;
+import app.giftify.shared.api.paging.PageResponse;
+import app.giftify.shared.api.response.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Settlement", description = "정산 API")
+public interface SettlementV2ApiSpec {
+
+    @Operation(
+        summary = "정산 내역 요약 조회",
+        description = "판매자의 월별 정산 내역을 페이지네이션으로 조회합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 토큰 누락 또는 유효하지 않음", content = @Content)
+    ResponseEntity<RsData<PageResponse<SettlementSummary>>> getSettlementSummary(
+        @Parameter(hidden = true) Long sellerId,
+        Pageable pageable
+    );
+}

--- a/bootstrap/api-server/src/main/resources/application-prod.yml
+++ b/bootstrap/api-server/src/main/resources/application-prod.yml
@@ -61,6 +61,13 @@ logging:
     app.giftify: INFO
 
 
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+
 management:
   metrics:
     tags:


### PR DESCRIPTION
## Summary

  MemberV2Api, WalletV2Api, OrderControllerSpec 3개 인터페이스를 V2ApiSpec 접미사 패턴으로 리네이밍하여 기존 인터페이스들과 네이밍 통일

- MemberV2Api → MemberV2ApiSpec
- WalletV2Api → WalletV2ApiSpec
- OrderControllerSpec → OrderV2ApiSpec
- 각 Controller의 implements 참조 수정
