### PR TITLE
PR #431 코드 리뷰 피드백 반영

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/event/OrderEventListener.java
@@ -139,6 +139,32 @@ public class OrderEventListener {
 		throw e;
 	}
 
+	@Recover
+	public void recover(InfraException e, FundingCanceledEvent event) {
+		log.error("================================================================");
+		log.error("[최종 장애] 주문 취소 처리 최종 실패 (시스템 자동 복구 불가)");
+		log.error("Funding ID: {}", event.getFundingId());
+		log.error("Event ID: {}", event.getEventId());
+		log.error("Event Type: {}", event.getClass().getSimpleName());
+		log.error("Reason: {}", e.getMessage());
+		log.error("조치 사항: DB 상태 확인 후 수동 정정 필요");
+		log.error("================================================================");
+		throw e;
+	}
+
+	@Recover
+	public void recover(InfraException e, FundingExpiredEvent event) {
+		log.error("================================================================");
+		log.error("[최종 장애] 주문 취소 처리 최종 실패 (시스템 자동 복구 불가)");
+		log.error("Funding ID: {}", event.getFundingId());
+		log.error("Event ID: {}", event.getEventId());
+		log.error("Event Type: {}", event.getClass().getSimpleName());
+		log.error("Reason: {}", e.getMessage());
+		log.error("조치 사항: DB 상태 확인 후 수동 정정 필요");
+		log.error("================================================================");
+		throw e;
+	}
+
 	private static void log(InfraException e, PaymentEvent event) {
 		Long orderId = event.data().orderId();
 

--- a/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
+++ b/bc/core/src/main/java/app/giftify/order/application/FundingOrderService.java
@@ -39,7 +39,7 @@ public class FundingOrderService {
         List<OrderItem> orderItems = orderItemRepository.getOrderItemsWithOrderAndFindingId(fundingId);
 
         validateItemsNotEmpty(command.fundingId(), orderItems);
-        validateTotalAmountMatch(command.expiredAmount(), orderItems);
+        validateTotalAmountMatch(command.amount(), orderItems);
 
         Map<Order, List<Long>> orderItemsByOrderId = groupOrderItemsByOrder(orderItems);
 

--- a/bc/core/src/main/java/app/giftify/order/application/inbound/command/CancelFundingOrderCommand.java
+++ b/bc/core/src/main/java/app/giftify/order/application/inbound/command/CancelFundingOrderCommand.java
@@ -4,6 +4,6 @@ import app.giftify.shared.domain.vo.Money;
 
 public record CancelFundingOrderCommand(
         Long fundingId,
-        Money expiredAmount
+        Money amount
 ) {
 }

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -12,6 +12,7 @@ import app.giftify.shared.domain.event.EventPublisher;
 import app.giftify.order.application.inbound.command.CancelFundingOrderCommand;
 import app.giftify.shared.domain.event.funding.FundingCanceledEvent;
 import app.giftify.shared.domain.event.funding.FundingConfirmPendingEvent;
+import app.giftify.shared.domain.event.funding.FundingExpiredEvent;
 import app.giftify.shared.domain.vo.Money;
 import app.giftify.shared.domain.event.order.OrderConfirmFailedEvent;
 import app.giftify.shared.domain.event.order.OrderConfirmedEvent;
@@ -128,6 +129,104 @@ class OrderEventListenerTest {
             verify(fundingOrderService).requestCancelFundingOrder(captor.capture());
             assertThat(captor.getValue().fundingId()).isEqualTo(FUNDING_ID);
             assertThat(captor.getValue().amount()).isEqualTo(Money.of(CANCELED_AMOUNT));
+        }
+
+        @Test
+        @DisplayName("실패: InfraException 발생 시 재시도 후 recover가 호출된다")
+        void given_infraException_when_onFundingCanceledEvent_then_retryAndRecover() {
+            // given
+            FundingCanceledEvent event = new FundingCanceledEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, CANCELED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+            InfraException retryableException = new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT);
+            willThrow(retryableException)
+                    .given(fundingOrderService).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event))
+                    .isInstanceOf(InfraException.class);
+
+            verify(fundingOrderService, atLeast(2)).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+        }
+
+        @Test
+        @DisplayName("실패: InfraException 중 재시도 불가능한 에러는 즉시 전파된다")
+        void given_nonRetryableInfraException_when_onFundingCanceledEvent_then_immediatelyPropagated() {
+            // given
+            FundingCanceledEvent event = new FundingCanceledEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, CANCELED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+            InfraException nonRetryableException = new InfraException(InfraErrorCode.DB_CONSTRAINT_VIOLATION);
+            willThrow(nonRetryableException)
+                    .given(fundingOrderService).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event))
+                    .isInstanceOf(InfraException.class);
+
+            verify(fundingOrderService, times(1)).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("FundingExpiredEvent 처리 (on(FundingExpiredEvent))")
+    class OnFundingExpiredEvent {
+
+        private static final Long FUNDING_ID = 1L;
+        private static final Long WISHLIST_ITEM_ID = 10L;
+        private static final Integer EXPIRED_AMOUNT = 50000;
+        private static final Long RECEIVER_ID = 100L;
+
+        @Test
+        @DisplayName("성공: 정상 처리 후 requestCancelFundingOrder가 호출된다")
+        void given_success_when_onFundingExpiredEvent_then_callRequestCancelFundingOrder() {
+            // given
+            FundingExpiredEvent event = new FundingExpiredEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, EXPIRED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            verify(fundingOrderService).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+        }
+
+        @Test
+        @DisplayName("성공: 커맨드에 이벤트의 fundingId와 expiredAmount가 올바르게 전달된다")
+        void given_event_when_onFundingExpiredEvent_then_commandHasCorrectData() {
+            // given
+            FundingExpiredEvent event = new FundingExpiredEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, EXPIRED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+
+            // when
+            orderEventListener.on(event);
+
+            // then
+            ArgumentCaptor<CancelFundingOrderCommand> captor =
+                    ArgumentCaptor.forClass(CancelFundingOrderCommand.class);
+            verify(fundingOrderService).requestCancelFundingOrder(captor.capture());
+            assertThat(captor.getValue().fundingId()).isEqualTo(FUNDING_ID);
+            assertThat(captor.getValue().amount()).isEqualTo(Money.of(EXPIRED_AMOUNT));
+        }
+
+        @Test
+        @DisplayName("실패: InfraException 발생 시 재시도 후 recover가 호출된다")
+        void given_infraException_when_onFundingExpiredEvent_then_retryAndRecover() {
+            // given
+            FundingExpiredEvent event = new FundingExpiredEvent(
+                    FUNDING_ID, WISHLIST_ITEM_ID, EXPIRED_AMOUNT, RECEIVER_ID, List.of(101L, 102L)
+            );
+            InfraException retryableException = new InfraException(InfraErrorCode.DB_LOCK_TIMEOUT);
+            willThrow(retryableException)
+                    .given(fundingOrderService).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
+
+            // when & then
+            assertThatThrownBy(() -> orderEventListener.on(event))
+                    .isInstanceOf(InfraException.class);
+
+            verify(fundingOrderService, atLeast(2)).requestCancelFundingOrder(any(CancelFundingOrderCommand.class));
         }
     }
 

--- a/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/order/adapter/inbound/event/OrderEventListenerTest.java
@@ -127,7 +127,7 @@ class OrderEventListenerTest {
                     ArgumentCaptor.forClass(CancelFundingOrderCommand.class);
             verify(fundingOrderService).requestCancelFundingOrder(captor.capture());
             assertThat(captor.getValue().fundingId()).isEqualTo(FUNDING_ID);
-            assertThat(captor.getValue().expiredAmount()).isEqualTo(Money.of(CANCELED_AMOUNT));
+            assertThat(captor.getValue().amount()).isEqualTo(Money.of(CANCELED_AMOUNT));
         }
     }
 

--- a/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/order/application/FundingOrderServiceTest.java
@@ -72,8 +72,8 @@ class FundingOrderServiceTest {
             ReflectionTestUtils.setField(items.get(0), "id", 1L);
             ReflectionTestUtils.setField(items.get(1), "id", 2L);
 
-            Money expiredAmount = Money.of("2000"); // 아이템 2개 × 1000원
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000"); // 아이템 2개 × 1000원
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(items);
 
@@ -106,8 +106,8 @@ class FundingOrderServiceTest {
             allItems.addAll(order1.getItems());
             allItems.addAll(order2.getItems());
 
-            Money expiredAmount = Money.of("2000"); // 주문 2개 × 1000원
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000"); // 주문 2개 × 1000원
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(allItems);
 
@@ -162,8 +162,8 @@ class FundingOrderServiceTest {
             Order order = OrderFixture.createOrderWithItems(BUYER_ID, 2);
             ReflectionTestUtils.setField(order, "id", ORDER_ID);
 
-            Money expiredAmount = Money.of("2000");
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000");
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(order.getItems());
             given(orderService.requestCancelOrderItems(any()))
@@ -181,8 +181,8 @@ class FundingOrderServiceTest {
             Order order = OrderFixture.createOrderWithItems(BUYER_ID, 2);
             ReflectionTestUtils.setField(order, "id", ORDER_ID);
 
-            Money expiredAmount = Money.of("2000");
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000");
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(order.getItems());
             given(orderService.requestCancelOrderItems(any()))
@@ -200,8 +200,8 @@ class FundingOrderServiceTest {
             Order order = OrderFixture.createOrderWithItems(BUYER_ID, 2);
             ReflectionTestUtils.setField(order, "id", ORDER_ID);
 
-            Money expiredAmount = Money.of("2000");
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000");
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(order.getItems());
             given(orderService.requestCancelOrderItems(any()))
@@ -228,8 +228,8 @@ class FundingOrderServiceTest {
             allItems.addAll(order1.getItems());
             allItems.addAll(order2.getItems());
 
-            Money expiredAmount = Money.of("2000");
-            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, expiredAmount);
+            Money amount = Money.of("2000");
+            CancelFundingOrderCommand command = new CancelFundingOrderCommand(FUNDING_ID, amount);
 
             given(orderItemRepository.getOrderItemsWithOrderAndFindingId(FUNDING_ID)).willReturn(allItems);
             // 첫 번째 호출에서 예외 발생, 두 번째 호출은 정상 처리


### PR DESCRIPTION
## Summary

PR #431 (FundingCanceledEvent 결제 취소 누락 해소) 코드 리뷰에서 지적된 4건을 반영합니다.

### 변경 사항

- **T1.10**: `CancelFundingOrderCommand.expiredAmount` → `amount` 필드 rename (도메인 중립 네이밍)
- **T1.9**: FundingCanceledEvent, FundingExpiredEvent에 `@Recover` 핸들러 추가 (재시도 최종 실패 시 운영 로그)
- **T1.11**: 실패 시나리오 테스트 4건 추가 (InfraException 재시도, 비재시도 즉시 전파, FundingExpiredEvent 전체)
- **T1.12**: `@EventIdempotent` 필요성 조사 완료 — `requestCancelFundingOrder()`는 자연 멱등 (readOnly + 조회 후 위임), 불필요 판정

## Test plan

- [x] `OrderEventListenerTest` 전체 통과 (13개 테스트)
- [x] `./gradlew build` 전체 빌드 + 테스트 통과
- [x] `expiredAmount` 잔존 여부 Grep 확인 (이벤트 클래스는 의도적 유지)