### PR TITLE
README Tech Stack 버전 배지 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@
 [![CI - Build & Test](https://github.com/prgrms-be-adv-devcourse/beadv4_4_Team201_BE/actions/workflows/ci.yml/badge.svg)](https://github.com/prgrms-be-adv-devcourse/beadv4_4_Team201_BE/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/prgrms-be-adv-devcourse/beadv4_4_Team201_BE/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/prgrms-be-adv-devcourse/beadv4_4_Team201_BE/actions/workflows/github-code-scanning/codeql)
 [![Release](https://img.shields.io/github/v/release/prgrms-be-adv-devcourse/beadv4_4_Team201_BE?label=Release)](https://github.com/prgrms-be-adv-devcourse/beadv4_4_Team201_BE/releases)
+
 ![Java](https://img.shields.io/badge/Java-25-orange)
-![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.3-6DB33F)
+![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.3-6DB33F?logo=springboot&logoColor=white)
+![Spring Modulith](https://img.shields.io/badge/Spring%20Modulith-2.0.3-6DB33F?logo=spring&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-336791?logo=postgresql&logoColor=white)
+![QueryDSL](https://img.shields.io/badge/QueryDSL-5.1.0-0078D4)
+![Gradle](https://img.shields.io/badge/Gradle-8.14-02303A?logo=gradle&logoColor=white)
+![SpringDoc OpenAPI](https://img.shields.io/badge/SpringDoc-3.0.2-85EA2D?logo=swagger&logoColor=black)
 
 ---
 


### PR DESCRIPTION
## Summary

README.md에 주요 기술 스택 버전을 shields.io 배지로 표시합니다.

### 추가된 배지
- Java 25, Spring Boot 4.0.3, Spring Modulith 2.0.3
- PostgreSQL 16, QueryDSL 5.1.0, Gradle 8.14, SpringDoc 3.0.2

모든 버전은 `gradle/libs.versions.toml` 및 프로젝트 설정과 일치합니다.

## Test plan

- [x] 배지 URL이 올바른 shields.io 형식인지 확인
- [x] 기존 README 구조 유지 확인