### PR TITLE
주문 BC용 상품 스냅샷 내부 API 구현

### DIFF
--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/web/controller/InternalProductController.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/web/controller/InternalProductController.java
@@ -2,6 +2,7 @@ package app.giftify.product.adapter.inbound.web.controller;
 
 import app.giftify.product.application.port.in.GetProductSnapshotUseCase;
 import app.giftify.shared.domain.vo.ProductSnapshot;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ public class InternalProductController {
 
     @PostMapping("/snapshots")
     public Map<Long, ProductSnapshot> getSnapshotList(
-            @RequestBody List<Long> productIds
+            @RequestBody @NotEmpty List<Long> productIds
     ) {
         return getProductSnapshotUseCase.getSnapshots(productIds);
     }

--- a/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/web/controller/InternalProductController.java
+++ b/bc/catalog/src/main/java/app/giftify/product/adapter/inbound/web/controller/InternalProductController.java
@@ -1,0 +1,27 @@
+package app.giftify.product.adapter.inbound.web.controller;
+
+import app.giftify.product.application.port.in.GetProductSnapshotUseCase;
+import app.giftify.shared.domain.vo.ProductSnapshot;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/internal/products")
+@RequiredArgsConstructor
+public class InternalProductController {
+
+    private final GetProductSnapshotUseCase getProductSnapshotUseCase;
+
+    @PostMapping("/snapshots")
+    public Map<Long, ProductSnapshot> getSnapshotList(
+            @RequestBody List<Long> productIds
+    ) {
+        return getProductSnapshotUseCase.getSnapshots(productIds);
+    }
+}

--- a/bc/catalog/src/main/java/app/giftify/product/application/port/in/GetProductSnapshotUseCase.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/port/in/GetProductSnapshotUseCase.java
@@ -1,0 +1,10 @@
+package app.giftify.product.application.port.in;
+
+import app.giftify.shared.domain.vo.ProductSnapshot;
+
+import java.util.List;
+import java.util.Map;
+
+public interface GetProductSnapshotUseCase {
+    Map<Long, ProductSnapshot> getSnapshots(List<Long> productIds);
+}

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductSnapshotService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductSnapshotService.java
@@ -1,0 +1,36 @@
+package app.giftify.product.application.service;
+
+import app.giftify.product.application.port.in.GetProductSnapshotUseCase;
+import app.giftify.product.application.support.ProductSupport;
+import app.giftify.product.domain.Product;
+import app.giftify.shared.domain.vo.ProductSnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductSnapshotService implements GetProductSnapshotUseCase {
+
+    private final ProductSupport productSupport;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Long, ProductSnapshot> getSnapshots(List<Long> productIds) {
+
+        List<Product> productList = productSupport.findAllById(productIds);
+        productSupport.validatePurchasable(productList); // 상품 검증 (ACTIVE && 재고!=0)
+
+        return productList.stream()
+                .collect(Collectors.toMap(
+                        Product::getId,
+                        p -> new ProductSnapshot(p.getId(), p.getPrice(), p.getSellerId())
+                ));
+    }
+}

--- a/bc/catalog/src/main/java/app/giftify/product/application/service/ProductSnapshotService.java
+++ b/bc/catalog/src/main/java/app/giftify/product/application/service/ProductSnapshotService.java
@@ -3,6 +3,7 @@ package app.giftify.product.application.service;
 import app.giftify.product.application.port.in.GetProductSnapshotUseCase;
 import app.giftify.product.application.support.ProductSupport;
 import app.giftify.product.domain.Product;
+import app.giftify.product.domain.ProductStatus;
 import app.giftify.shared.domain.vo.ProductSnapshot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,12 +26,22 @@ public class ProductSnapshotService implements GetProductSnapshotUseCase {
     public Map<Long, ProductSnapshot> getSnapshots(List<Long> productIds) {
 
         List<Product> productList = productSupport.findAllById(productIds);
-        productSupport.validatePurchasable(productList); // 상품 검증 (ACTIVE && 재고!=0)
+
+        if (productList.size() != productIds.size()) {
+            List<Long> foundIds = productList.stream().map(Product::getId).toList();
+            List<Long> missingIds = productIds.stream().filter(id -> !foundIds.contains(id)).toList();
+            log.warn("[ProductSnapshot] 존재하지 않는 상품 요청. missingIds={}", missingIds);
+        }
 
         return productList.stream()
                 .collect(Collectors.toMap(
                         Product::getId,
-                        p -> new ProductSnapshot(p.getId(), p.getPrice(), p.getSellerId())
+                        p -> new ProductSnapshot(
+                                p.getId(),
+                                p.getPrice(),
+                                p.getSellerId(),
+                                p.getStatus() == ProductStatus.ACTIVE && p.getStock() > 0
+                        )
                 ));
     }
 }

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductSnapshotServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductSnapshotServiceTest.java
@@ -1,0 +1,147 @@
+package app.giftify.product.application.service;
+
+import app.giftify.product.application.support.ProductSupport;
+import app.giftify.product.domain.Product;
+import app.giftify.product.domain.ProductStatus;
+import app.giftify.product.domain.exception.ProductNotActiveException;
+import app.giftify.product.domain.exception.ProductOutOfStockException;
+import app.giftify.shared.domain.vo.ProductSnapshot;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ProductSnapshotServiceTest {
+
+    @Mock
+    private ProductSupport productSupport;
+
+    @InjectMocks
+    private ProductSnapshotService productSnapshotService;
+
+    @Nested
+    @DisplayName("상품 스냅샷 조회 (getSnapshots)")
+    class GetSnapshotsTests {
+
+        @Test
+        @DisplayName("성공: 상품 ID 목록으로 스냅샷을 조회한다")
+        void getSnapshots_Success() {
+            // given
+            List<Long> productIds = List.of(1L, 2L);
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 5),
+                    createProduct(2L, 200L, 20000, 3)
+            );
+            given(productSupport.findAllById(productIds)).willReturn(products);
+
+            // when
+            Map<Long, ProductSnapshot> result = productSnapshotService.getSnapshots(productIds);
+
+            // then
+            assertThat(result).hasSize(2);
+
+            assertThat(result.get(1L).productId()).isEqualTo(1L);
+            assertThat(result.get(1L).price()).isEqualTo(10000);
+            assertThat(result.get(1L).sellerId()).isEqualTo(100L);
+
+            assertThat(result.get(2L).productId()).isEqualTo(2L);
+            assertThat(result.get(2L).price()).isEqualTo(20000);
+            assertThat(result.get(2L).sellerId()).isEqualTo(200L);
+
+            verify(productSupport).validatePurchasable(products);
+        }
+
+        @Test
+        @DisplayName("성공: 단건 상품 스냅샷을 조회한다")
+        void getSnapshots_SingleProduct() {
+            // given
+            List<Long> productIds = List.of(1L);
+            List<Product> products = List.of(createProduct(1L, 100L, 15000, 10));
+            given(productSupport.findAllById(productIds)).willReturn(products);
+
+            // when
+            Map<Long, ProductSnapshot> result = productSnapshotService.getSnapshots(productIds);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(1L).productId()).isEqualTo(1L);
+            assertThat(result.get(1L).price()).isEqualTo(15000);
+            assertThat(result.get(1L).sellerId()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("실패: 판매 중이 아닌 상품이 포함되면 ProductNotActiveException이 발생한다")
+        void getSnapshots_Fail_ProductNotActive() {
+            // given
+            List<Long> productIds = List.of(1L, 2L);
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 5),
+                    createProduct(2L, 200L, 20000, 3)
+            );
+            given(productSupport.findAllById(productIds)).willReturn(products);
+            Mockito.doThrow(new ProductNotActiveException(2L))
+                    .when(productSupport).validatePurchasable(products);
+
+            // when & then
+            assertThatThrownBy(() -> productSnapshotService.getSnapshots(productIds))
+                    .isInstanceOf(ProductNotActiveException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 재고가 없는 상품이 포함되면 ProductOutOfStockException이 발생한다")
+        void getSnapshots_Fail_ProductOutOfStock() {
+            // given
+            List<Long> productIds = List.of(1L, 2L);
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 5),
+                    createProduct(2L, 200L, 20000, 3)
+            );
+            given(productSupport.findAllById(productIds)).willReturn(products);
+            Mockito.doThrow(new ProductOutOfStockException(2L))
+                    .when(productSupport).validatePurchasable(products);
+
+            // when & then
+            assertThatThrownBy(() -> productSnapshotService.getSnapshots(productIds))
+                    .isInstanceOf(ProductOutOfStockException.class);
+        }
+
+        @Test
+        @DisplayName("성공: 빈 목록을 전달하면 빈 Map을 반환한다")
+        void getSnapshots_EmptyList() {
+            // given
+            List<Long> productIds = List.of();
+            given(productSupport.findAllById(productIds)).willReturn(List.of());
+
+            // when
+            Map<Long, ProductSnapshot> result = productSnapshotService.getSnapshots(productIds);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    private Product createProduct(Long id, Long sellerId, int price, int stock) {
+        return Product.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .name("테스트 상품")
+                .description("테스트 설명")
+                .price(price)
+                .stock(stock)
+                .status(ProductStatus.ACTIVE)
+                .build();
+    }
+}

--- a/bc/catalog/src/test/java/app/giftify/product/application/service/ProductSnapshotServiceTest.java
+++ b/bc/catalog/src/test/java/app/giftify/product/application/service/ProductSnapshotServiceTest.java
@@ -3,8 +3,6 @@ package app.giftify.product.application.service;
 import app.giftify.product.application.support.ProductSupport;
 import app.giftify.product.domain.Product;
 import app.giftify.product.domain.ProductStatus;
-import app.giftify.product.domain.exception.ProductNotActiveException;
-import app.giftify.product.domain.exception.ProductOutOfStockException;
 import app.giftify.shared.domain.vo.ProductSnapshot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,16 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ProductSnapshotServiceTest {
@@ -42,8 +37,8 @@ class ProductSnapshotServiceTest {
             // given
             List<Long> productIds = List.of(1L, 2L);
             List<Product> products = List.of(
-                    createProduct(1L, 100L, 10000, 5),
-                    createProduct(2L, 200L, 20000, 3)
+                    createProduct(1L, 100L, 10000, 5, ProductStatus.ACTIVE),
+                    createProduct(2L, 200L, 20000, 3, ProductStatus.ACTIVE)
             );
             given(productSupport.findAllById(productIds)).willReturn(products);
 
@@ -56,20 +51,56 @@ class ProductSnapshotServiceTest {
             assertThat(result.get(1L).productId()).isEqualTo(1L);
             assertThat(result.get(1L).price()).isEqualTo(10000);
             assertThat(result.get(1L).sellerId()).isEqualTo(100L);
+            assertThat(result.get(1L).purchasable()).isTrue();
 
             assertThat(result.get(2L).productId()).isEqualTo(2L);
             assertThat(result.get(2L).price()).isEqualTo(20000);
             assertThat(result.get(2L).sellerId()).isEqualTo(200L);
-
-            verify(productSupport).validatePurchasable(products);
+            assertThat(result.get(2L).purchasable()).isTrue();
         }
 
         @Test
-        @DisplayName("성공: 단건 상품 스냅샷을 조회한다")
-        void getSnapshots_SingleProduct() {
+        @DisplayName("성공: 비활성 상품은 purchasable=false로 반환한다")
+        void getSnapshots_InactiveProduct() {
             // given
             List<Long> productIds = List.of(1L);
-            List<Product> products = List.of(createProduct(1L, 100L, 15000, 10));
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 5, ProductStatus.INACTIVE)
+            );
+            given(productSupport.findAllById(productIds)).willReturn(products);
+
+            // when
+            Map<Long, ProductSnapshot> result = productSnapshotService.getSnapshots(productIds);
+
+            // then
+            assertThat(result.get(1L).purchasable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 재고가 0인 상품은 purchasable=false로 반환한다")
+        void getSnapshots_OutOfStock() {
+            // given
+            List<Long> productIds = List.of(1L);
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 0, ProductStatus.ACTIVE)
+            );
+            given(productSupport.findAllById(productIds)).willReturn(products);
+
+            // when
+            Map<Long, ProductSnapshot> result = productSnapshotService.getSnapshots(productIds);
+
+            // then
+            assertThat(result.get(1L).purchasable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 존재하지 않는 상품 ID는 Map에서 누락된다")
+        void getSnapshots_MissingProduct() {
+            // given
+            List<Long> productIds = List.of(1L, 999L);
+            List<Product> products = List.of(
+                    createProduct(1L, 100L, 10000, 5, ProductStatus.ACTIVE)
+            );
             given(productSupport.findAllById(productIds)).willReturn(products);
 
             // when
@@ -77,45 +108,8 @@ class ProductSnapshotServiceTest {
 
             // then
             assertThat(result).hasSize(1);
-            assertThat(result.get(1L).productId()).isEqualTo(1L);
-            assertThat(result.get(1L).price()).isEqualTo(15000);
-            assertThat(result.get(1L).sellerId()).isEqualTo(100L);
-        }
-
-        @Test
-        @DisplayName("실패: 판매 중이 아닌 상품이 포함되면 ProductNotActiveException이 발생한다")
-        void getSnapshots_Fail_ProductNotActive() {
-            // given
-            List<Long> productIds = List.of(1L, 2L);
-            List<Product> products = List.of(
-                    createProduct(1L, 100L, 10000, 5),
-                    createProduct(2L, 200L, 20000, 3)
-            );
-            given(productSupport.findAllById(productIds)).willReturn(products);
-            Mockito.doThrow(new ProductNotActiveException(2L))
-                    .when(productSupport).validatePurchasable(products);
-
-            // when & then
-            assertThatThrownBy(() -> productSnapshotService.getSnapshots(productIds))
-                    .isInstanceOf(ProductNotActiveException.class);
-        }
-
-        @Test
-        @DisplayName("실패: 재고가 없는 상품이 포함되면 ProductOutOfStockException이 발생한다")
-        void getSnapshots_Fail_ProductOutOfStock() {
-            // given
-            List<Long> productIds = List.of(1L, 2L);
-            List<Product> products = List.of(
-                    createProduct(1L, 100L, 10000, 5),
-                    createProduct(2L, 200L, 20000, 3)
-            );
-            given(productSupport.findAllById(productIds)).willReturn(products);
-            Mockito.doThrow(new ProductOutOfStockException(2L))
-                    .when(productSupport).validatePurchasable(products);
-
-            // when & then
-            assertThatThrownBy(() -> productSnapshotService.getSnapshots(productIds))
-                    .isInstanceOf(ProductOutOfStockException.class);
+            assertThat(result).containsKey(1L);
+            assertThat(result).doesNotContainKey(999L);
         }
 
         @Test
@@ -133,7 +127,7 @@ class ProductSnapshotServiceTest {
         }
     }
 
-    private Product createProduct(Long id, Long sellerId, int price, int stock) {
+    private Product createProduct(Long id, Long sellerId, int price, int stock, ProductStatus status) {
         return Product.builder()
                 .id(id)
                 .sellerId(sellerId)
@@ -141,7 +135,7 @@ class ProductSnapshotServiceTest {
                 .description("테스트 설명")
                 .price(price)
                 .stock(stock)
-                .status(ProductStatus.ACTIVE)
+                .status(status)
                 .build();
     }
 }

--- a/bc/core/src/test/java/app/giftify/order/application/OrderServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/order/application/OrderServiceTest.java
@@ -51,12 +51,18 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class OrderServiceTest {
 
-    @Mock private OrderRepository orderRepository;
-    @Mock private ProductPort productPort;
-    @Mock private FundingQueryPort fundingQueryPort;
-    @Mock private EventPublisher eventPublisher;
-    @Mock private TargetTypeResolver targetTypeResolver;
-    @Mock private TargetIdResolver targetIdResolver;
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private ProductPort productPort;
+    @Mock
+    private FundingQueryPort fundingQueryPort;
+    @Mock
+    private EventPublisher eventPublisher;
+    @Mock
+    private TargetTypeResolver targetTypeResolver;
+    @Mock
+    private TargetIdResolver targetIdResolver;
 
     @InjectMocks
     private OrderService orderService;
@@ -68,7 +74,8 @@ class OrderServiceTest {
             new ProductSnapshot(
                     productId,
                     200000,
-                    200L
+                    200L,
+                    true
             )
     );
 

--- a/bc/shared/src/main/java/app/giftify/shared/domain/vo/ProductSnapshot.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/vo/ProductSnapshot.java
@@ -3,6 +3,7 @@ package app.giftify.shared.domain.vo;
 public record ProductSnapshot(
         Long productId,
         int price,
-        Long sellerId
+        Long sellerId,
+        boolean purchasable
 ) {
 }


### PR DESCRIPTION
## Summary

주문 BC에서 상품 정보를 스냅샷으로 조회할 수 있는 내부 API를 구현했습니다. 

기존에는 주문 생성 시 상품 스냅샷을 제공하는 catalog 측 엔드포인트가 없어서, 주문 BC의 `ProductClient` 가 호출할 서버가 구현되지 않은 상태였습니다. 이번 PR에서 catalog BC에 해당 엔드포인트와 서비스 계층을 추가하여 주문 생성 플로우를 완성합니다.     

```                                                                                                          
주문 BC                              Catalog BC
  ──────                               ──────────
  OrderService.createOrder()                                                                                                                                                                          
    │
    ├─ ProductClient ── HTTP POST ──→ InternalProductController                                                                                                                                       
    │   /api/internal/products/snapshots     │                                                                                                                                                      
    │                                  GetProductSnapshotUseCase                                                                                                                                    
    │                                        │
    │                                  ProductSnapshotService
    │                                   ├─ findAllById()
    │                                   ├─ 누락 ID 로깅 (예외 없음)
    │                                   └─ Map<Long, ProductSnapshot> 변환
    │                                        │  (purchasable 필드 포함)
    │                                        │
    ◄──── Map<Long, ProductSnapshot> ────────┘
    │
    ├─ Map에 없는 ID → SNAPSHOTS_NOT_FOUND 예외
    ├─ purchasable == false → 주문 생성 중단
    └─ OrderItem 생성 (snapshot.price 기반)

```
#### ProductSnapshot이 전달하는 항목:

필드 | 타입 | 용도
-- | -- | --
productId | Long | 상품 식별자 (Map key로도 사용)
price | int | 주문 시점의 상품 가격 → OrderItem.price에 고정
sellerId | Long | 판매자 식별 → 판매자별 주문 알림, 정산에 활용
purchasable | boolean | 상품 판매 가능 상태 여부

---

## What's Changed


파일 | 설명
-- | --
GetProductSnapshotUseCase | 상품 스냅샷 조회 전용 인바운드 포트
ProductSnapshotService | 유스케이스 구현체 
InternalProductController | POST /api/internal/products/snapshots 엔드포인트
ProductSnapshotServiceTest | 단위 테스트 5건 (성공/실패/빈 목록)

---

## Decisions & Trade-offs

###  Collectors.toMap 중복 키 안전성                                                                                                                                                                     
                                                                                                                                                                                                    
Collectors.toMap은 동일한 key가 존재하면 **IllegalStateException**을 던집니다.
하지만 JPA의 `findAllById`는 중복 ID를 넘겨도 같은 엔티티를 중복 반환하지 않으므로, **실제로 중복 key 문제는 발생하지 않는다고 판단**하여 별도 merge function 없이 `Map<Long, ProductSnapshot>`으로 반환하도록 구현했습니다.

### ProductGetUseCase에 합치지 않고 별도 인터페이스로 분리

ProductGetUseCase는 "상품 단건 조회 → ProductResult 반환"이라는 책임을 가지고 있고, 소비자는 ProductController(외부 API)입니다. 반면 ProductSnapshot은 주문 BC가 소비하는 내부 API용 계약이므로, ISP(인터페이스 분리 원칙)에 따라 별도 유스케이스로 분리했습니다.

### ProductService가 아닌 ProductSnapshotService로 구현체 분리

ProductService는 이미 9개의 유스케이스를 구현하고 있어 비대한 상태입니다. 
"다른 BC를 위한 데이터 서빙"은 기존 유스케이스들(자체 도메인 CRUD)과 책임의 성격이 다르므로 별도 서비스 클래스로 분리하여 SRP를 유지했습니다.

### 스냅샷 변환을 서비스 계층에서 수행

Product 도메인 엔티티에 toSnapshot() 메서드를 두는 방안도 있었지만, ProductSnapshot은 shared 모듈의 BC 간 통신 계약이므로 도메인이 외부 계약을 알지 않도록 서비스 계층에서 getter를 통해 조립하는 방식을 선택했습니다.

---

## 코드 리뷰 반영

### validatePurchasable() 제거 → purchasable 필드로 대체
카탈로그 BC는 데이터 제공자 역할이므로, 구매 가능 여부를 판단해서 예외를 던지는 것이 아니라 `purchasable` 필드로 상태만 전달하도록 변경했습니다. 구매 불가 시 주문 생성 중단 등의 비즈니스 판단은 주문 BC에서 수행합니다.

### 존재하지 않는 상품 — 로깅
`findAllById`는 JPA 기본 동작으로 없는 ID를 무시하고 있는 것만 반환합니다. 카탈로그에서 예외를 던지지 않고 log.warn으로 누락 ID만 기록하며, **주문 BC**에서 Map에 해당 key가 없으면 `SNAPSHOTS_NOT_FOUND 예외`를 던져 주문 생성을 중단합니다.