### PR TITLE
펀딩 수락 확정 통합 테스트 작성 및 데이터 정합성 검증

### DIFF
--- a/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/jpa/JpaOrderItemRepository.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/outbound/persistence/jpa/JpaOrderItemRepository.java
@@ -24,7 +24,7 @@ public interface JpaOrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     @Query("SELECT oi.order.id as orderId, oi.id as itemId FROM OrderItem oi " +
             "WHERE oi.targetId = :targetId AND oi.targetType = :targetType")
-    List<OrderIdMapping> findRawMappings(@Param("fundingId") Long fundingId,
+    List<OrderIdMapping> findRawMappings(@Param("targetId") Long fundingId,
                                          @Param("targetType") TargetType targetType);
 
     default Map<Long, List<Long>> findItemIdMapByFundingId(Long fundingId, TargetType targetType) {

--- a/bootstrap/api-server/src/test/java/app/giftify/integration/FundingConfirmIntegrationTest.java
+++ b/bootstrap/api-server/src/test/java/app/giftify/integration/FundingConfirmIntegrationTest.java
@@ -1,0 +1,281 @@
+package app.giftify.integration;
+
+import app.giftify.funding.adpater.inbound.FundingScheduler;
+import app.giftify.funding.adpater.outbound.repository.FundingRepository;
+import app.giftify.funding.application.FundingFacade;
+import app.giftify.funding.application.FundingGetUseCase;
+import app.giftify.order.adapter.outbound.batch.ExpirationBatchScheduler;
+import app.giftify.order.adapter.outbound.persistence.jpa.JpaOrderItemRepository;
+import app.giftify.order.domain.OrderItemStatus;
+import app.giftify.product.adapter.inbound.event.ProductEsEventListener;
+import app.giftify.product.adapter.outbound.jpa.repository.ProductRepository;
+import app.giftify.product.application.service.ProductEsService;
+import app.giftify.shared.domain.type.FundingStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = FundingConfirmTestApp.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class FundingConfirmIntegrationTest {
+
+    @Autowired private FundingFacade fundingFacade;
+    @Autowired private FundingRepository fundingRepository;
+    @Autowired private JpaOrderItemRepository orderItemRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean FundingScheduler scheduler;
+    @MockitoBean FundingGetUseCase getFundingUseCase;
+    @MockitoBean ExpirationBatchScheduler expirationBatchScheduler;
+    @MockitoBean ProductEsEventListener productEsEventListener;
+    @MockitoBean ProductEsService productEsService;
+
+    private final Long fundingId = 1L;
+    private final Long productId = 1L;
+    private final List<Long> orderItemIds = List.of(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
+    private final Long receiverId = 2L;
+
+    @AfterEach
+    void cleanUp() throws InterruptedException {
+        Thread.sleep(200);
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+        jdbcTemplate.execute("TRUNCATE TABLE order_items");
+        jdbcTemplate.execute("TRUNCATE TABLE orders");
+        jdbcTemplate.execute("TRUNCATE TABLE payment_cancels");
+        jdbcTemplate.execute("TRUNCATE TABLE payment_histories");
+        jdbcTemplate.execute("TRUNCATE TABLE payments");
+        jdbcTemplate.execute("TRUNCATE TABLE wallet_histories");
+        jdbcTemplate.execute("TRUNCATE TABLE wallets");
+        jdbcTemplate.execute("TRUNCATE TABLE FUNDING_PARTICIPANT_MEMBERS");
+        jdbcTemplate.execute("TRUNCATE TABLE fundings");
+        jdbcTemplate.execute("TRUNCATE TABLE PRODUCT_STOCK_HISTORIES");
+        jdbcTemplate.execute("TRUNCATE TABLE wishlist_items");
+        jdbcTemplate.execute("TRUNCATE TABLE wishlists");
+        jdbcTemplate.execute("TRUNCATE TABLE products");
+        jdbcTemplate.execute("TRUNCATE TABLE CORE_MEMBER_REPLICAS");
+        jdbcTemplate.execute("TRUNCATE TABLE members");
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    @Test
+    @DisplayName("수령 확정 요청 시 재고가 차감되고, 주문·펀딩 BC의 상태가 일치한다.")
+    @Sql("/sql/funding-confirm-success.sql")
+    void 정상_흐름_BC간_정합성_검증() {
+        // given
+        final int stock = 50;
+
+        // when
+        fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+
+        // then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .pollInterval(500, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    // 펀딩 확정 완료
+                    FundingStatus status = fundingRepository.findById(1L).orElseThrow().getStatus();
+                    assertThat(status).isEqualTo(FundingStatus.ACCEPTED);
+
+                    // 펀딩 주문 확정 완료 (ID 1~8)
+                    boolean isAllOrderItemConfirmed = orderItemIds.stream()
+                            .allMatch(id -> orderItemRepository.findById(id).orElseThrow().getStatus() == OrderItemStatus.CONFIRMED);
+                    assertTrue(isAllOrderItemConfirmed);
+
+                    // 재고 차감 완료
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock - 1);
+                });
+    }
+
+    @Test
+    @DisplayName("재고 부족으로 차감 실패 시, 주문은 롤백되고 펀딩은 보상 처리된다.")
+    @Sql("/sql/funding-confirm-no-stock.sql")
+    void 재고_차감_실패시_보상처리_정합성_검증() {
+        // given
+        final int stock = 0;
+
+        // when
+        fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+
+        // then
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 주문 롤백 — @EventListener 동기 처리라 같은 트랜잭션 롤백
+                    boolean isAllRollback = orderItemIds.stream()
+                            .allMatch(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.PAID);
+                    long countByConfirmed = orderItemIds.stream()
+                            .filter(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.CONFIRMED)
+                            .count();
+
+                    assertTrue(isAllRollback);
+                    assertThat(countByConfirmed).isZero();
+
+                    // 펀딩 보상 처리 — @ApplicationModuleListener 비동기, 관리자 수동 처리
+                    assertThat(fundingRepository.findById(fundingId).orElseThrow().getStatus())
+                            .isEqualTo(FundingStatus.ACCEPT_FAILED);
+
+                    // 재고 변화 없음
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock);
+                });
+    }
+
+    @Test
+    @DisplayName("동시에 동일한 확정 요청이 들어와도 중복 처리되지 않는다.")
+    @Sql("/sql/funding-confirm-duplicate.sql")
+    void 동시_중복_요청_멱등성_보장() throws InterruptedException {
+        // given
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+
+        final int stock = 50;
+
+        // when
+        for (int i = 0; i < 2; i++) {
+            executor.submit(() -> {
+                try {
+                    fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+                } catch (Exception ignored) {
+                    // 중복 요청 중 하나는 낙관적 락 또는 상태 전이 예외로 실패할 수 있음
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await(5, TimeUnit.SECONDS);
+
+        // then
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 펀딩 확정 완료
+                    FundingStatus status = fundingRepository.findById(1L).orElseThrow().getStatus();
+                    assertThat(status).isEqualTo(FundingStatus.ACCEPTED);
+
+                    // 펀딩 주문 확정 완료
+                    boolean isAllOrderItemConfirmed = orderItemIds.stream()
+                            .allMatch(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.CONFIRMED);
+                    assertTrue(isAllOrderItemConfirmed);
+
+                    // 재고 차감 완료
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock - 1);  // 1번만 차감
+                });
+    }
+
+    @Test
+    @DisplayName("이미 확정된 펀딩에 재확정 요청 시 잘못된 상태 전이를 차단한다.")
+    @Sql("/sql/funding-confirm-already-done.sql")
+    void 이미_확정된_주문_재확정_시도시_차단() {
+        // given
+        final int stock = 50;
+
+        // when — 이미 ACCEPTED 상태이므로 FundingException(ALREADY_DECIDED) 발생, 상태 변화 없음
+        try {
+            fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+        } catch (Exception ignored) {}
+
+        // then
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 펀딩 확정 변화 없음
+                    FundingStatus status = fundingRepository.findById(1L).orElseThrow().getStatus();
+                    assertThat(status).isEqualTo(FundingStatus.ACCEPTED);
+
+                    // 주문 확정 변화 없음
+                    boolean isAllOrderItemConfirmed = orderItemIds.stream()
+                            .allMatch(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.CONFIRMED);
+                    assertTrue(isAllOrderItemConfirmed);
+
+                    // 재고 변화 없음
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock);
+                });
+    }
+
+    @Test
+    @DisplayName("펀딩 확정은 펀딩 달성 상태에서만 가능하다.")
+    @Sql("/sql/funding-confirm-invalid-funding-status.sql")
+    void 확정_불가능한_펀딩_상태_확정_시도시_차단() {
+        // given
+        final int stock = 50;
+
+        // when — IN_PROGRESS 상태이므로 FundingException 발생, 이벤트 미발행, 상태 변화 없음
+        try {
+            fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+        } catch (Exception ignored) {}
+
+        // then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 펀딩 상태 변화 없음 (IN_PROGRESS 유지)
+                    FundingStatus status = fundingRepository.findById(1L).orElseThrow().getStatus();
+                    assertThat(status).isEqualTo(FundingStatus.IN_PROGRESS);
+
+
+                    // 주문 상태 변화 없음 (SQL에 8개 아이템 ID 1~8 존재, 모두 PAID)
+                    boolean isAllExistingOrderItemPaid = orderItemIds.stream()
+                            .allMatch(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.PAID);
+                    assertTrue(isAllExistingOrderItemPaid);
+
+                    // 재고 변화 없음
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock);
+                });
+    }
+
+    @Test
+    @DisplayName("펀딩 확정은 펀딩 주문 결제 완료 상태에서만 가능하다.")
+    @Sql("/sql/funding-confirm-invalid-order-status.sql")
+    void 확정_불가능한_주문_상태_확정_시도시_차단() {
+        // given
+        final int stock = 50;
+        final int savedCanceled = 4;
+        final int savePaid = 4;
+
+        // when
+        fundingFacade.requestFundingAcceptance(fundingId, receiverId);
+
+        // then
+        Awaitility.await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    // 펀딩 확정 실패
+                    FundingStatus status = fundingRepository.findById(1L).orElseThrow().getStatus();
+                    assertThat(status).isEqualTo(FundingStatus.ACCEPT_FAILED);
+
+                    // 주문 상태 변화 없음
+                    long countByCanceled = orderItemIds.stream()
+                            .filter(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.CANCELED)
+                            .count();
+                    long countByPaid = orderItemIds.stream()
+                            .filter(i -> orderItemRepository.findById(i).orElseThrow().getStatus() == OrderItemStatus.PAID)
+                            .count();
+
+                    assertThat(countByCanceled).isEqualTo(savedCanceled);
+                    assertThat(countByPaid).isEqualTo(savePaid);
+
+                    // 재고 변화 없음
+                    assertThat(productRepository.findById(productId).orElseThrow().getStock())
+                            .isEqualTo(stock);
+                });
+    }
+}

--- a/bootstrap/api-server/src/test/java/app/giftify/integration/FundingConfirmTestApp.java
+++ b/bootstrap/api-server/src/test/java/app/giftify/integration/FundingConfirmTestApp.java
@@ -1,0 +1,62 @@
+package app.giftify.integration;
+
+import app.giftify.security.common.config.SharedSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@SpringBootApplication(
+        exclude = {SharedSecurityAutoConfiguration.class},
+        excludeName = {
+                "org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration",
+                "org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterAutoConfiguration",
+                "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration",
+                "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration",
+                "org.springframework.boot.batch.autoconfigure.BatchAutoConfiguration",
+                "org.springframework.modulith.runtime.autoconfigure.SpringModulithRuntimeAutoConfiguration",
+                "org.springframework.boot.data.elasticsearch.autoconfigure.ElasticsearchClientAutoConfiguration",
+                "org.springframework.boot.data.elasticsearch.autoconfigure.ElasticsearchRepositoriesAutoConfiguration",
+                "org.springframework.boot.data.elasticsearch.autoconfigure.ReactiveElasticsearchClientAutoConfiguration"
+        }
+)
+@ComponentScan(
+        basePackages = {
+                "app.giftify.funding",
+                "app.giftify.order",
+                "app.giftify.payment",
+                "app.giftify.wallet",
+                "app.giftify.facade",
+                "app.giftify.product",
+                "app.giftify.shared.config",
+                "app.giftify.support.common",
+                "app.giftify.support.jpa"
+        },
+        excludeFilters = {
+                @ComponentScan.Filter(
+                        type = FilterType.REGEX,
+                        pattern = "app\\.giftify\\.product\\.adapter\\.outbound\\.elasticsearch\\..*"
+                ),
+                @ComponentScan.Filter(
+                        type = FilterType.REGEX,
+                        pattern = "app\\.giftify\\.support\\.common\\.config\\.RedisConfig"
+                )
+        }
+)
+@EnableJpaRepositories(basePackages = {
+        "app.giftify",
+        "org.springframework.modulith.events.jpa"
+})
+@EntityScan(basePackages = {
+        "app.giftify",
+        "org.springframework.modulith.events.jpa"
+})
+@EnableJpaAuditing
+@EnableRetry
+@EnableAsync
+class FundingConfirmTestApp {
+}

--- a/bootstrap/api-server/src/test/resources/application.yml
+++ b/bootstrap/api-server/src/test/resources/application.yml
@@ -9,6 +9,7 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+    defer-datasource-initialization: true
 
   flyway:
     enabled: false
@@ -16,6 +17,14 @@ spring:
   jackson:
     use-jackson2-defaults: true
 
+  batch:
+    job:
+      enabled: false
+
+
 logging:
   level:
     org.springframework.modulith: DEBUG
+
+internal-api:
+  base-url: http://localhost:8080

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-already-done.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-already-done.sql
@@ -1,0 +1,119 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+    '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+    '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+    '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+    '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+    '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+    '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+    '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+    '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+    '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 50 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 50, 'ACTIVE',
+        'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: COMPLETED (펀딩 수령)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'COMPLETED', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: ACCEPTED (펀딩 수령)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 449000, 'ACCEPTED','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'CONFIRMED', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'CONFIRMED', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'CONFIRMED', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'CONFIRMED', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'CONFIRMED', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'CONFIRMED', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'CONFIRMED', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'CONFIRMED', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CONFIRMED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+
+

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-duplicate.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-duplicate.sql
@@ -1,0 +1,119 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+    '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+    '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+    '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+    '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+    '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+    '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+    '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+    '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+    '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 50 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 50, 'ACTIVE',
+        'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: REQUESTED_CONFIRM (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'REQUESTED_CONFIRM', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: ACHIEVED (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 449000, 'ACHIEVED','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'PAID', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'PAID', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'PAID', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'PAID', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'PAID', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'PAID', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'PAID', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'PAID', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+
+

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-invalid-funding-status.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-invalid-funding-status.sql
@@ -1,0 +1,117 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+    '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+    '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+    '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+    '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+    '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+    '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+    '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+    '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+    '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 50 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 50, 'ACTIVE',
+        'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: IN_PROGRESS (펀딩 진행 중)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'IN_PROGRESS', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: IN_PROGRESS (펀딩 진행 중)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 392875, 'IN_PROGRESS','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'PAID', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'PAID', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'PAID', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'PAID', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'PAID', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'PAID', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'PAID', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'PAID', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-invalid-order-status.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-invalid-order-status.sql
@@ -1,0 +1,119 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+    '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+    '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+    '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+    '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+    '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+    '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+    '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+    '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+    '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 50 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 50, 'ACTIVE',
+        'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: REQUESTED_CONFIRM (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'REQUESTED_CONFIRM', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: ACHIEVED (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 449000, 'ACHIEVED','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개 (CANCELED: 4개, PAID: 4개)
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'CANCELED', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'CANCELED', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'CANCELED', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'CANCELED', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'PAID', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'PAID', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'PAID', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'PAID', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개 (CANCELED: 4개, PAID: 4개)
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CANCELED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CANCELED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CANCELED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'CANCELED', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+
+

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-no-stock.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-no-stock.sql
@@ -1,0 +1,118 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+        '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+        '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+        '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+        '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+        '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+        '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+        '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+        '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+        '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 0 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES
+    -- ELECTRONICS (11-30)
+    (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 0, 'ACTIVE',
+     'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: REQUESTED_CONFIRM (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'REQUESTED_CONFIRM', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: ACHIEVED (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 449000, 'ACHIEVED','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'PAID', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'PAID', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'PAID', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'PAID', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'PAID', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'PAID', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'PAID', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'PAID', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');

--- a/bootstrap/api-server/src/test/resources/sql/funding-confirm-success.sql
+++ b/bootstrap/api-server/src/test/resources/sql/funding-confirm-success.sql
@@ -1,0 +1,119 @@
+-- -----------------------------------------------------------------------------
+-- 1. MEMBERS - 총 10 명
+-- SELLER: 1 명
+-- BUYER: 9 명
+-- -----------------------------------------------------------------------------
+INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
+                     created_at, updated_at, created_by, updated_by)
+VALUES (1, 'qa-seller-giftify@team201.dev', '멍청한돼지0009', '1975-11-08', 'SELLER', '서울시 종로구',
+        '010-1234-5678', '김주영', 'ACTIVE', 'auth0|6981838d48f8397cae06ddb0', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (2, 'qa-buyer2-giftify@team201.dev', '졸린토끼0042', '1998-07-22', 'BUYER', '서울시 마포구',
+    '010-3333-4444', '이수현', 'ACTIVE', 'auth0|698184500000000000000001', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (3, 'qa-seller-03-giftify@team201.dev', '용감한여우0017', '1990-03-15', 'BUYER', '서울시 강남구',
+    '010-1001-0003', '박민준', 'ACTIVE', 'auth0|6981838d48f8397cae06dd03', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (4, 'qa-seller-04-giftify@team201.dev', '빠른독수리0031', '1985-09-27', 'BUYER', '서울시 송파구',
+    '010-1001-0004', '최지은', 'ACTIVE', 'auth0|6981838d48f8397cae06dd04', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (5, 'qa-seller-05-giftify@team201.dev', '조용한고양이0055', '1992-12-03', 'BUYER', '서울시 용산구',
+    '010-1001-0005', '정해린', 'ACTIVE', 'auth0|6981838d48f8397cae06dd05', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (6, 'qa-seller-06-giftify@team201.dev', '날쌘토끼0088', '1980-06-19', 'BUYER', '서울시 서초구',
+    '010-1001-0006', '한동훈', 'ACTIVE', 'auth0|6981838d48f8397cae06dd06', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (7, 'qa-seller-07-giftify@team201.dev', '배고픈곰0023', '1995-01-30', 'BUYER', '서울시 광진구',
+    '010-1001-0007', '오세진', 'ACTIVE', 'auth0|6981838d48f8397cae06dd07', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (8, 'qa-seller-08-giftify@team201.dev', '신비한고래0066', '1988-08-11', 'BUYER', '서울시 동작구',
+    '010-1001-0008', '윤아름', 'ACTIVE', 'auth0|6981838d48f8397cae06dd08', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (9, 'qa-seller-09-giftify@team201.dev', '느린거북이0044', '1993-04-25', 'BUYER', '서울시 은평구',
+    '010-1001-0009', '임태양', 'ACTIVE', 'auth0|6981838d48f8397cae06dd09', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),
+    (10, 'qa-seller-10-giftify@team201.dev', '영리한여우0077', '1982-10-07', 'BUYER', '서울시 노원구',
+    '010-1001-0010', '강서연', 'ACTIVE', 'auth0|6981838d48f8397cae06dd10', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+
+-- -----------------------------------------------------------------------------
+-- 2. PRODUCT (상품) — 총 1 개
+-- seller_id: 1 번 (SELLER)
+-- stock: 50 개
+-- -----------------------------------------------------------------------------
+INSERT INTO products (id, seller_id, name, description, price, stock, status, image_key, category,
+                      created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, '소니 WH-1000XM5', '압도적인 정적, 최고의 노이즈 캔슬링 헤드폰', 449000, 50, 'ACTIVE',
+        'products/11/sony-xm5.jpg', 'ELECTRONICS', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 3. WISHLIST (위시리스트) — 총 1 개
+-- member_id: 2 번
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
+VALUES (1, 2, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM');
+
+-- -----------------------------------------------------------------------------
+-- 4. WISHLIST_ITEM (위시리스트 아이템) — 총 1 개
+-- wishlist_id: 1 번
+-- product_id: 1 번
+-- wishlist_item_status: REQUESTED_CONFIRM (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO wishlist_items (id, wishlist_id, product_id, wishlist_item_status, added_at, created_at, updated_at, created_by, updated_by)
+VALUES (1, 1, 1, 'REQUESTED_CONFIRM', '2026-02-27 04:38:07.137213', '2026-02-27 04:38:07.137213', '2026-02-27 05:02:52.542501',
+        NULL, NULL);
+
+-- -----------------------------------------------------------------------------
+-- 5. FUNDING (펀딩) — 총 1 개
+-- wishlist_item_id: 1
+-- product_id: 1
+-- status: ACHIEVED (펀딩 달성)
+-- -----------------------------------------------------------------------------
+INSERT INTO fundings (
+    id, version, wishlist_item_id, product_id, product_name, image_key, receiver_id,
+    target_amount, current_amount, status,
+    deadline, achieved_at, closed_at,
+    created_at, updated_at, created_by, updated_by
+)
+VALUES
+    (1, 1, 1, 1, '소니 WH-1000XM5', 'products/11/sony-xm5.jpg', 2,
+     449000, 449000, 'ACHIEVED','2999-03-14 04:46:27.808092','2026-02-27 04:46:27.853178',
+     '2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499','2026-02-27 04:46:27.809499',NULL, NULL);
+
+-- ──────────────────────────────────────────
+-- 6. ORDER (주문) - 총 8 개
+-- 회원 3~10번, 각 1개 (총 8개)
+-- ──────────────────────────────────────────
+INSERT INTO orders (id, buyer_id, order_number, total_amount, quantity, payment_method, status,
+                    payment_id, origin_transaction_key, paid_at, confirmed_at, cancelled_at,
+                    created_at, updated_at)
+VALUES
+    (1,  3, 'ORD-20260227-000000000001', 56125.00, 1, 'CARD', 'PAID', 1,  'toss_tx_20260227_0001', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (2,  4, 'ORD-20260227-000000000002', 56125.00, 1, 'CARD', 'PAID', 2,  'toss_tx_20260227_0002', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (3,  5, 'ORD-20260227-000000000003', 56125.00, 1, 'CARD', 'PAID', 3,  'toss_tx_20260227_0003', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (4,  6, 'ORD-20260227-000000000004', 56125.00, 1, 'CARD', 'PAID', 4,  'toss_tx_20260227_0004', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (5,  7, 'ORD-20260227-000000000005', 56125.00, 1, 'CARD', 'PAID', 5,  'toss_tx_20260227_0005', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (6,  8, 'ORD-20260227-000000000006', 56125.00, 1, 'CARD', 'PAID', 6,  'toss_tx_20260227_0006', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (7,  9, 'ORD-20260227-000000000007', 56125.00, 1, 'CARD', 'PAID', 7,  'toss_tx_20260227_0007', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    (8, 10, 'ORD-20260227-000000000008', 56125.00, 1, 'CARD', 'PAID', 8,  'toss_tx_20260227_0008', '2026-02-27 04:46:27', NULL, NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+-- ──────────────────────────────────────────
+-- 7. ORDER_ITEM (주문 아이템) - 총 8 개
+-- 주문당 1개 (펀딩1)
+-- seller_id: 1번 (SELLER)
+-- receiver_id: 2번 (펀딩 receiver)
+-- target_type: FUNDING
+-- ──────────────────────────────────────────
+INSERT INTO order_items (id, order_id, target_id, target_type, order_item_type, seller_id, receiver_id,
+                         price, amount, status, cancelled_at, created_at, updated_at)
+VALUES
+    -- 회원 3번 주문 (order_id=1)
+    (1,  1, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 4번 주문 (order_id=2)
+    (2,  2, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 5번 주문 (order_id=3)
+    (3,  3, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 6번 주문 (order_id=4)
+    (4,  4, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 7번 주문 (order_id=5)
+    (5,  5, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 8번 주문 (order_id=6)
+    (6, 6, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 9번 주문 (order_id=7)
+    (7, 7, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27'),
+    -- 회원 10번 주문 (order_id=8)
+    (8, 8, 1, 'FUNDING', 'FUNDING_GIFT', 1, 2, 449000.00, 56125.00, 'PAID', NULL, '2026-02-27 04:46:27', '2026-02-27 04:46:27');
+
+
+


### PR DESCRIPTION
## Summary

> 이 `PR`에서 `제공`하는 `솔루션`과 그 `설계 의도`를 설명해 주세요. _( like 흑백요리사 )_
> `변경사항`이 필요한 이유, 즉 `컨텍스트` 와 해결하려는 `문제의 핵심`을 `요약`하고, `리뷰어`가 `어떤 관점`에서 봐줬으면 좋겠는지 명시해주세요.

펀딩 수락 확정 흐름 전반에 걸쳐 통합 테스트를 작성하고,                                                                                                                                                                                           
실제 DB 상태 기준으로 데이터 정합성이 올바르게 유지됨을 확인했습니다.

  ## 테스트 시나리오                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  | 시나리오 | 검증 포인트 |                                                                                                                                                                                                                        
  |---|---|                                                                                                                                                                                                                                       
  | **정상 확정** | 펀딩·주문·주문아이템 상태 전이, 재고 차감 정합성 |                                                                                                                                                                                  
  | **재고 부족** | 확정 실패 시 상태 롤백 및 재고 불변 보장 |                                                                                                                                                                                          
  | **이미 확정된 펀딩 재확정** | 예외 발생 후 상태 변경 없음 |                                                                                                                                                                                         
  | **확정 불가 펀딩 상태** | IN_PROGRESS 상태 유지, markAcceptFailed 불가 |                                                                                                                                                                            
  | **유효하지 않은 주문 상태** | 상태 전이 거부, 데이터 무결성 유지 |                                                                                                                                                                                  
  | **중복 요청 (멱등성)** | 동시 다중 요청에서 한 번만 처리됨을 보장 | 

---

## What's Changed

> `PR`에서 `변경되는 점`들을 설명해 주세요. `UI 변경`이 있다면 `스크린샷`을 첨부해주세요.

#### 주요 변경 사항
 - **`FundingConfirmIntegrationTest`**: 6가지 시나리오 통합 테스트 작성                                                                                                                                                                            
  - **`FundingConfirmTestApp`**: 통합 테스트 전용 Spring 컨텍스트 구성                                                                                                                                                                            
  - **SQL 픽스처 파일 6종**: 각 시나리오별 독립적인 테스트 데이터 구성                                                                                                                                                                              
  - **버그 수정**:                                                                                                                                                                                                                                  
    - `JpaOrderItemRepository` `@Param` 불일치 (`fundingId` → `targetId`) 수정                                                                                                                                                                      
    - `@BeforeEach` → `@AfterEach` 전환 (Spring `@Sql`과 실행 순서 충돌 해결)                                                                                                                                                                       
    - `IntStream.get(i)` → `stream()` 방식으로 `IndexOutOfBoundsException` 수정

#### 검증 결과                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                    
  - 정상 확정 경로: 펀딩·주문·아이템 상태 전이 및 재고 차감 정합성 통과                                                                                                                                                                             
  - 예외 경로: 각 실패 케이스에서 DB 상태가 예외 이전으로 유지됨을 확인                                                                                                                                                                           
  - 멱등성: 중복 요청 시 단 한 번의 상태 변경만 발생함을 동시성 테스트로 검증 

---

## Decisions & Trade-offs

> 개발중에 추가로 고려한 부분에 대해서 공유해주세요. 예를 들어,<br>
> `A 방식 대신 B 방식을 선택한 이유`나, `성능` 혹은 `사용자 경험`을 위해 고민한 흔적을 남겨주세요.

  - **`@BeforeEach` 대신 `@AfterEach`로 데이터 정리**                                                                                                                                                                                               
    Spring의 `@Sql`은 `@BeforeEach` 이전에 실행되기 때문에, `@BeforeEach`에서 데이터를 정리하면 픽스처가 삭제되는 역순 문제가 발생한다. 이를 `@AfterEach`로 전환해 각 테스트 종료 후 정리하도록 결정했다.
                                                                                                                                                                                                                                                    
  - **비동기 이벤트 검증에 Awaitility 사용**                                                                                                                                                                                                        
    `@ApplicationModuleListener` 기반 이벤트가 비동기로 처리되므로, 단순 단언문으로는 타이밍 이슈가 발생한다. Awaitility로 polling하여 비동기 결과를 안정적으로 검증했다.                                                                           
                                                                                                                                                                                                                                                    
  - **외부 연동 빈 MockitoBean 처리**                                                                                                                                                                                                               
    ES 연동(`ProductEsEventListener`, `ProductEsService`), 스케줄러(`FundingScheduler`, `ExpirationBatchScheduler`) 등 테스트 범위 외 빈은 `@MockitoBean`으로 격리해 테스트 환경의 복잡도를 낮췄다.                                                 
                                                                                                                                                                                                                                                    
  - **`SET REFERENTIAL_INTEGRITY FALSE`로 정리 순서 단순화**                                                                                                                                                                                        
    FK 제약 때문에 순서를 맞춘 DELETE 대신, H2의 참조 무결성 검사를 일시 해제하고 TRUNCATE로 전 테이블을 정리하는 방식을 선택했다. 테스트 격리성은 유지하면서 정리 코드의 복잡도를 줄였다.                                                          
                                                                                                                                                                                                                                                    
  - **이미 확정된 펀딩 재확정 시나리오의 try-catch 처리**                                                                                                                                                                                           
    `ALREADY_DECIDED` 예외는 의도된 동작이므로, 예외를 던지지 않고 무시한 뒤 DB 상태가 변하지 않았음을 검증하는 방식을 채택했다. 
---

## Future Improvements

> 이번 `PR`의 `범위`에는 포함되지 않았지만, 추후 `고도화`하거나 `보완`하고 싶은 점이 있다면 적어주세요.
> 예를 들어, 남겨둔 `기술 부채`나 `최적화` 계획, 혹은 `확장성`을 위해 다음 단계에서 `시도해 볼 만한 아이디어`를 공유해주세요.

  - **멱등성 시나리오 확장**
    현재는 2개의 동시 요청만 검증한다. 더 높은 동시성(N개 스레드)에서도 정합성이 보장되는지 확인하는 테스트로 확장할 수 있다.

  - **픽스처 관리 개선**
    SQL 파일이 시나리오마다 독립적으로 존재해 중복 데이터가 많다. 공통 기반 픽스처를 분리하고 시나리오별 차분만 추가하는 구조로 리팩토링하면 유지보수가 용이해진다.

---

### Linked Issues

- closes #
