### PR TITLE
api-server-secrets.enc.yaml 에 es 관련 변수 추가

### DIFF
--- a/infra/k3s/overlays/prod/api-server-secrets.enc.yaml
+++ b/infra/k3s/overlays/prod/api-server-secrets.enc.yaml
@@ -14,6 +14,8 @@ stringData:
     PAYMENT_ENCRYPTION_SALT: ENC[AES256_GCM,data:MojyUL8ehkwiO5YoeG5l3pkJT8NNnT/NvP6W3gSJ0RM=,iv:Z2YY7Tk0jfgR7hXG5YHoq2VCSDf65c+qhuuRNxH5Xo4=,tag:0l7ehT8YIYJW/zs8mQSBNw==,type:str]
     S3_ACCESS_KEY: ENC[AES256_GCM,data:XL+T2SZ/5lRiRQ==,iv:aTh5EG+9CjHyBJlrb7KRxUHYI5x/33fwl10uS+H4+rY=,tag:Rk3MOFH6TPyULgXSrJfWqA==,type:str]
     S3_SECRET_KEY: ENC[AES256_GCM,data:rq9EAg5oa/3hwA==,iv:ImliFxP037lSV+U3tBjO9zFLtfvNy2rqmqzuPbI9YPY=,tag:uFqH09KCaXPVmJdP7D3h/g==,type:str]
+    ES_URIS: ENC[AES256_GCM,data:FootmB06A03FO4x7E3y8mODLj73Z1eMsEA==,iv:SnnebiVcqyQca3tQGt25zJsjc3EVeIXo6yNVJWIL2ls=,tag:c9x21NF0Y4bwOIwXJvjz9Q==,type:str]
+    ES_PASSWORD: ENC[AES256_GCM,data:BhnnV2oqjU6xBdFqsQue8FwqATouhptB1IqsIn7y7aw=,iv:PTCaYa5sAARCdCA87E1UEftbl9PqFVson8uEHVS7Q0E=,tag:xnrgvYB6VFO6Zo8WPl7kew==,type:str]
 sops:
     age:
         - recipient: age1vxtgy82n4vprjft3pp34hnwcneu6ltf5fe2k0xwzxuddf3w8ksss8xw830
@@ -34,7 +36,7 @@ sops:
             Zk1jZ2EwY2ozMGdPTkU0Y2NFc2F0RVUKVOu9TgwrDPDXGCVZvp7014k6d1m/Qs7U
             j97JLbj/LIw7vw6bkOdIZ5LKia9omLhkc5zc/CzKoQBxRhSHozSk8Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-18T08:40:12Z"
-    mac: ENC[AES256_GCM,data:vO45zNh2qxwx1jB138VMWbpR3Vxxw4xiykWQumM16g59YiIDVmG/EYgrMT84nqpsCHkR+KMRAlQ8pmc+ooWgsi6cLqGAv/B5/yA5NvyWLtVeTvtcYZ3wUj5PwcXDR/8GC5Uj/1CHXLDEPK2e+ryota2Yi1FpdPwZSRaZgHdSFkI=,iv:dtBMXVrkFeok80U1uNxERv1izTghZluCd0QL9Q3Uhqc=,tag:OzpLNp9Jm7X4XIw+B2vb9g==,type:str]
+    lastmodified: "2026-03-21T08:11:17Z"
+    mac: ENC[AES256_GCM,data:EzbphqlaZcCb1kkrM877TwrMH3EJZrfH8hg5E5KjrBEmDcV3IOqqBiIRDcayXLqcFrxawlargSdSPpYcaphEKz6rKSlOSyNvg3JonX8nk4tv+tG/pb3R0aeQLJ+jFrC27+MrgbTgSVzbs5gRqkRG462yqGQlKZr5DZIXAEmNPw8=,iv:HgkpC0SIcOzKRULyBB5QDWp16Gq/JIIPPylirOBpW1o=,tag:qp2CiejeYqasXLels9BEsA==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.12.1
+    version: 3.12.2


### PR DESCRIPTION
## Summary

  api-server-secrets에 ES 연결 환경변수가 누락되어 prod 클러스터에서 api-server가 Elasticsearch 401 오류로
  기동 실패하는 문제를 수정합니다.

  PR #440(SOPS 마이그레이션) 머지 후 ArgoCD sync 과정에서 ES_URIS, ES_PASSWORD가 k8s Secret에 포함되지 않아
   Spring Boot 기동 시 ES 인증 실패로 이어졌습니다.

---

## What's Changed


  - api-server-secrets.enc.yaml에 ES_URIS, ES_PASSWORD 두 키 추가
    - ES_URIS: http://elasticsearch:9200
    - ES_PASSWORD: SOPS 암호화된 Elasticsearch elastic 계정 비밀번호

---

## Decisions & Trade-offs

  es-secrets(ES 파드 자체 비밀번호)와 api-server-secrets(앱 환경변수)가 분리되어 있어 마이그레이션 시 ES 인증 정보가 api-server에 전달되어야 한다는 점이 누락됐습니다. 별도 Secret 리소스로 분리하는 대신 api-server-secrets에 통합하였습니다.

---

## Future Improvements

  - application-prod.yml의 ES 관련 env var을 .env.sample에도 문서화하여 누락 방지해주세요.


---

### Linked Issues

- closes #


