### PR TITLE
소스 코드 무변경시 PR 빌드/CodeQL 스킵 및 커스텀 CodeQL 워크플로우 추가

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Build for CodeQL
         # assemble: annotation processor 생성 코드 포함 (classes 태스크 대비)
         # -x test: 테스트 실행 제외
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
         run: ./gradlew assemble --parallel -x test --no-daemon
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,75 @@
+# CodeQL Security Analysis
+# GitHub Default Setup를 대체하는 커스텀 CodeQL 워크플로우
+# Default Setup(깃헙 웹에서 버튼 딸깍으로 활성화 시킨거)은 워크플로우 파일 생성 시 자동으로 비활성화됨
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths-ignore:
+      - 'infra/**'
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [ main, develop ]
+    paths-ignore:
+      - 'infra/**'
+      - 'docs/**'
+      - '**/*.md'
+  schedule:
+    # 매주 월요일 02:00 UTC (한국 시간 11:00) — schedule은 paths-ignore 미적용 (의도된 동작)
+    - cron: '0 2 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    # 첫 실행 후 실제 소요 시간 확인 뒤 조정 권장 (Actions 탭 → analyze job 소요 시간)
+    timeout-minutes: 60
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'java-kotlin' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # autobuild 방지, 명시적 빌드 제어
+          build-mode: manual
+          # 기본 쿼리 + 확장 보안 쿼리로 더 넓은 취약점 탐지
+          queries: +security-extended
+
+      # KT-77518: Kotlin 컴파일러가 Java 25 소스 파싱 불가
+      # Gradle은 JDK 21로 실행, 컴파일 toolchain만 JDK 25 사용
+      - name: Set up JDK 21 (Gradle runtime)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: gradle
+
+      - name: Set up JDK 25 (compilation toolchain)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+
+      - name: Build for CodeQL
+        # assemble: annotation processor 생성 코드 포함 (classes 태스크 대비)
+        # -x test: 테스트 실행 제외
+        run: ./gradlew assemble --parallel -x test --no-daemon
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pr-assistant.yml
+++ b/.github/workflows/pr-assistant.yml
@@ -14,9 +14,31 @@ on:
         default: false
 
 jobs:
-  # 1. 빌드 및 테스트
+  # 0. 변경 파일 감지
+  # paths-ignore 대신 job-level if를 사용하는 이유:
+  # paths-ignore로 워크플로우 전체가 스킵되면 required status check가 "skipped" 처리되어 브랜치 보호 규칙에서 PR 머지가 차단될 수 있음
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!infra/**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!.github/workflows/pr-labeler.yml'
+
+  # 1. 빌드 및 테스트 (소스 코드 변경 시만)
   build:
     name: Build & Test
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     uses: ./.github/workflows/_build.yml
     with:
       java-version: '25'
@@ -28,10 +50,11 @@ jobs:
       publish-build-scan: true
       verbose: ${{ inputs.verbose || false }}
 
-  # 2. 커버리지 리포트 PR 코멘트
+  # 2. 커버리지 리포트 PR 코멘트 (빌드 완료 시만)
   coverage-report:
     name: Coverage Report
     needs: [ build ]
+    if: needs.build.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

  문서·인프라만 변경된 PR에서도 빌드와 CodeQL이 항상 실행되는 문제를 해결합니다.

  예를 들어 README 한 줄을 수정했을 때도 전체 빌드 + 커버리지 리포트 + CodeQL 스캔이 돌아가고 있었습니다. 불필요한 Actions 사용량과 대기 시간이 발생하는 상황이었습니다.

  **리뷰 관점 요청:**
  - `dorny/paths-filter` 필터 패턴이 의도한 범위를 올바르게 감지하는지
  - `codeql.yml`의 `schedule` 트리거 주기(매주 월요일)가 적합한지

  ---

  ## What's Changed

  **pr-assistant.yml**
  - `changes` job 추가: `dorny/paths-filter`로 변경 파일 감지 후 `src: true/false` 출력
  - `build` job에 `if: needs.changes.outputs.src == 'true'` 조건 추가
  - `coverage-report` job 조건을 `needs.build.result == 'success'`로 명시

  **codeql.yml (신규)**
  - GitHub Default Setup을 대체하는 커스텀 CodeQL 워크플로우
  - `paths-ignore`로 문서·인프라 전용 변경 시 스캔 스킵
  - `queries: +security-extended`로 기본 쿼리 대비 넓은 취약점 탐지
  - 매주 월요일 정기 스캔(`schedule`) — 코드 변경 없이 새로 등록된 CVE 탐지 목적

  ---

  ## Decisions & Trade-offs

### **`paths-ignore` 대신 `dorny/paths-filter` + job-level `if` 채택**

  `paths-ignore`로 워크플로우 전체를 스킵하면 required status check가 `skipped`로 처리됩니다. 브랜치 보호 규칙 설정에 따라 PR 머지가 차단될 수 있어, 워크플로우는항상 실행하되 개별 job을 조건부로 스킵하는 방식을 선택했습니다.

  ### **CodeQL에는 `paths-ignore` 직접 적용**

  CodeQL은 required status check로 등록하지 않으므로 워크플로우 전체 스킵이 허용됩니다.  단순한 `paths-ignore`를 사용했습니다.

  ### **JDK 21 + JDK 25 dual setup 유지**

  KT-77518 이슈로 Kotlin 컴파일러가 Java 25 소스를 파싱하지 못합니다. Gradle은 JDK 21로 실행하고, 소스 컴파일 toolchain만 JDK 25를 사용하는 `_build.yml`의 기존 세팅을 `codeql.yml`에도 동일하게 적용했습니다.

  ---

  ## Future Improvements

  **모듈별 선택적 테스트 실행**

  현재는 소스 변경이 감지되면 전체 테스트가 실행됩니다. 변경된 모듈 범위의 테스트만 실행하도록 개선하면 CI 시간을 추가로 단축할 수 있습니다.

  전제 작업:
  - `@SpringBootTest` 테스트에 `@Tag("integration")` 일괄 추가
  - Gradle `unitTest` / `integrationTest` 태스크 분리
  - `dorny/paths-filter`에 모듈별 경로 필터 추가 (`bc/core/order/**` 등)

  전략: 변경된 모듈의 단위·MVC 슬라이스 테스트만 선택 실행 + 통합 테스트는 항상 실행

  ---

  ### Linked Issues

  - closes #
