### PR TITLE
 부하테스트 Staging 환경 구축 및 설정 버그 수정

### DIFF
--- a/bc/core/src/main/resources/application-core-prod.yml
+++ b/bc/core/src/main/resources/application-core-prod.yml
@@ -9,7 +9,7 @@ tosspayments:
     base-url: ${TOSSPAYMENTS_API_BASE_URL}
 
 internal-api:
-  base-url: http://api-server
+  base-url: http://api-server:8080
 
 batch:
   order-expiration:

--- a/bootstrap/api-server/src/main/resources/application-loadtest.yml
+++ b/bootstrap/api-server/src/main/resources/application-loadtest.yml
@@ -1,21 +1,11 @@
 # 부하테스트용 오버레이 — 부하테스트 전용 설정
 # 활성화: SPRING_PROFILES_ACTIVE=prod,loadtest
-# prod 설정 위에 덮어쓰며, 스키마 격리 + 로그 최소화 + Mock Auth 활성화
+# prod 설정 위에 덮어쓰며, 로그 최소화 + Mock Auth 활성화
 spring:
-  datasource:
-    hikari:
-      connection-init-sql: SET search_path TO loadtest, public
-
   jpa:
     properties:
       hibernate:
-        default_schema: loadtest
         generate_statistics: true
-
-  flyway:
-    schemas: loadtest
-    default-schema: loadtest
-    create-schemas: true
 
 loadtest:
   mock-auth:

--- a/bootstrap/api-server/src/main/resources/application-loadtest.yml
+++ b/bootstrap/api-server/src/main/resources/application-loadtest.yml
@@ -6,6 +6,9 @@ spring:
     properties:
       hibernate:
         generate_statistics: true
+  flyway:
+    placeholders:
+      is_staging: "true"
 
 loadtest:
   mock-auth:

--- a/bootstrap/api-server/src/main/resources/application-prod.yml
+++ b/bootstrap/api-server/src/main/resources/application-prod.yml
@@ -29,6 +29,8 @@ spring:
     schemas: g7app
     default-schema: g7app
     create-schemas: true
+    placeholders:
+      is_staging: "false"
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}

--- a/bootstrap/api-server/src/main/resources/db/migration/cart/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/cart/R__seed.sql
@@ -20,7 +20,7 @@ SELECT setval('cart_items_id_seq', 100, false);
 -- Loadtest carts (only in loadtest schema)
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO carts (id, member_id, created_at, updated_at, created_by, updated_by)
     VALUES
            (1001, 1001, NOW(), NOW(), 'SYSTEM', 'SYSTEM'),

--- a/bootstrap/api-server/src/main/resources/db/migration/friendship/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/friendship/R__seed.sql
@@ -17,7 +17,7 @@ DECLARE
   _recv_id   bigint;
   _seq       bigint := 1001;
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     FOR _giver_id IN 1001..1050 LOOP
       FOR _recv_id IN 1051..1060 LOOP
         INSERT INTO friendships (id, requester_id, receiver_id, status, accepted_at,

--- a/bootstrap/api-server/src/main/resources/db/migration/funding/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/funding/R__seed.sql
@@ -40,7 +40,7 @@ SELECT setval('funding_participant_members_id_seq', 100, false);
 -- Loadtest: Active funding for concurrency test
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO fundings (id, version, wishlist_item_id, product_id, product_name, image_key,
                           receiver_id, target_amount, current_amount, status, deadline,
                           created_at, updated_at, created_by, updated_by)

--- a/bootstrap/api-server/src/main/resources/db/migration/member/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/member/R__seed.sql
@@ -21,7 +21,7 @@ SELECT setval('members_id_seq', 100, false);
 -- Loadtest accounts (only in loadtest schema)
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO members (id, email, nickname, birthday, role, address, phone_num, name, status, auth_sub,
                          created_at, updated_at, created_by, updated_by)
     VALUES

--- a/bootstrap/api-server/src/main/resources/db/migration/order/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/order/R__seed.sql
@@ -62,7 +62,7 @@ DO $$
 DECLARE
   _id bigint;
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     -- Givers (1001-1050)
     FOR _id IN 1001..1050 LOOP
       INSERT INTO core_member_replicas (id, nickname)

--- a/bootstrap/api-server/src/main/resources/db/migration/product/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/product/R__seed.sql
@@ -215,7 +215,7 @@ SELECT setval('products_id_seq', 200, false);
 -- Loadtest: Seller replicas for SELLER accounts (1101-1110)
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO member_replicas (id, nickname)
     VALUES (1101, 'seller001'), (1102, 'seller002'), (1103, 'seller003'),
            (1104, 'seller004'), (1105, 'seller005'), (1106, 'seller006'),

--- a/bootstrap/api-server/src/main/resources/db/migration/wallet/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/wallet/R__seed.sql
@@ -33,7 +33,7 @@ SELECT setval('wallet_histories_id_seq', 100, false);
 -- Loadtest wallets (only in loadtest schema)
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO wallets (id, member_id, balance, version, created_at, updated_at, created_by, updated_by)
     VALUES
            (1001, 1001, 1000000.00, 0, NOW(), NOW(), 'SYSTEM', 'SYSTEM'),

--- a/bootstrap/api-server/src/main/resources/db/migration/wishlist/R__seed.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/wishlist/R__seed.sql
@@ -44,7 +44,7 @@ SELECT setval('wishlist_items_id_seq', 100, false);
 -- Loadtest wishlists (only in loadtest schema)
 DO $$
 BEGIN
-  IF current_schema() = 'loadtest' THEN
+  IF '${is_staging}' = 'true' THEN
     INSERT INTO wishlists (id, member_id, visibility, created_at, updated_at, created_by, updated_by)
     VALUES
            (1001, 1001, 'PUBLIC', NOW(), NOW(), 'SYSTEM', 'SYSTEM'),

--- a/infra/k3s/base/apps/api-server/hpa.yaml
+++ b/infra/k3s/base/apps/api-server/hpa.yaml
@@ -1,0 +1,31 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-server
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-server
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120

--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - apps/api-server/configmap.yaml
   - apps/api-server/deployment.yaml
   - apps/api-server/service.yaml
+  - apps/api-server/hpa.yaml
   - apps/api-server/ingress.yaml
   # PostgreSQL
   - apps/postgres/statefulset.yaml

--- a/infra/k3s/overlays/staging/kustomization.yaml
+++ b/infra/k3s/overlays/staging/kustomization.yaml
@@ -1,0 +1,65 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server
+    newTag: latest
+  - name: giftify-elasticsearch
+    newName: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/elasticsearch
+    newTag: 9.2.4-custom-v2
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: api-server-config
+    patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: api-server-config
+      data:
+        SPRING_PROFILES_ACTIVE: "prod,loadtest"
+
+  - target:
+      kind: Service
+      name: api-server
+    patch: |-
+      - op: add
+        path: /spec/type
+        value: NodePort
+      - op: add
+        path: /spec/ports/0/nodePort
+        value: 30080
+
+  - target:
+      kind: Deployment
+      name: api-server
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: api-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: api-server
+                startupProbe:
+                  httpGet:
+                    path: /actuator/health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 90
+
+  - target:
+      kind: StatefulSet
+      name: elasticsearch
+    patch: |-
+      - op: add
+        path: /spec/template/spec/imagePullSecrets
+        value:
+          - name: ghcr-secret

--- a/infra/k3s/overlays/staging/kustomization.yaml
+++ b/infra/k3s/overlays/staging/kustomization.yaml
@@ -22,6 +22,10 @@ patches:
         name: api-server-config
       data:
         SPRING_PROFILES_ACTIVE: "prod,loadtest"
+        INTERNAL_API_BASE_URL: "http://api-server:8080"
+        SPRING_THREADS_VIRTUAL_ENABLED: "true"
+        SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: "30"
+        SPRING_FLYWAY_PLACEHOLDERS_IS_STAGING: "true"
 
   - target:
       kind: Service

--- a/infra/k3s/overlays/staging/kustomization.yaml
+++ b/infra/k3s/overlays/staging/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 resources:
   - ../../base
 
+generators:
+  - ./secret-generator.yaml
+
 images:
   - name: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server
     newTag: latest

--- a/infra/k3s/overlays/staging/secret-generator.yaml
+++ b/infra/k3s/overlays/staging/secret-generator.yaml
@@ -1,0 +1,9 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: secret-generator
+files:
+  - ../prod/api-server-secrets.enc.yaml
+  - ../prod/postgres-secrets.enc.yaml
+  - ../prod/redis-secrets.enc.yaml
+  - ../prod/grafana-secrets.enc.yaml

--- a/infra/monitoring/k6/scripts/concurrency-test.js
+++ b/infra/monitoring/k6/scripts/concurrency-test.js
@@ -45,6 +45,7 @@ const errorRate = new Rate('error_rate');
 const TEST_FUNDING_ID = parseInt(__ENV.TEST_FUNDING_ID || '0');
 const TEST_WISHLIST_ITEM_ID = parseInt(__ENV.TEST_WISHLIST_ITEM_ID || '0');
 const TEST_RECEIVER_ID = parseInt(__ENV.TEST_RECEIVER_ID || '0');
+const TEST_PRODUCT_ID = parseInt(__ENV.TEST_PRODUCT_ID || '0');
 
 const accounts = new SharedArray('accounts', function () {
     return JSON.parse(open('../data/test-accounts.json'));
@@ -76,10 +77,10 @@ export const options = {
 };
 
 export function setup() {
-    if (TEST_FUNDING_ID === 0 || TEST_WISHLIST_ITEM_ID === 0 || TEST_RECEIVER_ID === 0) {
+    if (TEST_FUNDING_ID === 0 || TEST_WISHLIST_ITEM_ID === 0 || TEST_RECEIVER_ID === 0 || TEST_PRODUCT_ID === 0) {
         throw new Error(
             '필수 환경변수 누락. 다음을 모두 설정하세요:\n' +
-            '  TEST_FUNDING_ID, TEST_WISHLIST_ITEM_ID, TEST_RECEIVER_ID'
+            '  TEST_FUNDING_ID, TEST_WISHLIST_ITEM_ID, TEST_RECEIVER_ID, TEST_PRODUCT_ID'
         );
     }
 
@@ -117,6 +118,8 @@ export default function (data) {
     const body = JSON.stringify({
         items: [{
             wishlistItemId: TEST_WISHLIST_ITEM_ID,
+            productId: TEST_PRODUCT_ID,
+            fundingId: TEST_FUNDING_ID,
             receiverId: TEST_RECEIVER_ID,
             amount: 1000,
             orderItemType: 'FUNDING_GIFT',

--- a/infra/monitoring/k6/scripts/idempotency-test.js
+++ b/infra/monitoring/k6/scripts/idempotency-test.js
@@ -1,0 +1,156 @@
+/**
+ * 멱등성(Idempotency) 검증 테스트.
+ *
+ * concurrency-test.js와의 차이:
+ * - concurrency-test: 100명이 "서로 다른 키"로 동일 리소스에 동시 접근 → 동시성 제어 검증
+ * - idempotency-test: 100명이 "같은 키"로 동일 요청 동시 전송 → 멱등성 보장 검증
+ *
+ * 검증 대상:
+ * 1. 동일 Idempotency-Key로 N번 요청 시 1건만 처리
+ * 2. 나머지 N-1건은 첫 번째 응답과 동일한 결과 반환
+ * 3. DB에 주문 1건만 생성 (중복 없음)
+ *
+ * 멱등성 구현: Redis SETNX 기반 AOP (IdempotencyAspect)
+ *
+ * 실행:
+ *   k6 run --env BASE_URL=http://localhost:8080 --env MOCK_AUTH=true \
+ *          --env TEST_FUNDING_ID=1001 --env TEST_WISHLIST_ITEM_ID=1001 \
+ *          --env TEST_RECEIVER_ID=1051 --env TEST_PRODUCT_ID=11 \
+ *          scripts/idempotency-test.js
+ */
+import http from 'k6/http';
+import { check } from 'k6';
+import { Counter, Rate } from 'k6/metrics';
+import {
+    BASE_URL, MOCK_AUTH,
+    mockAuthHeaders, authHeaders,
+} from '../modules/config.js';
+import { SharedArray } from 'k6/data';
+import { getTokens } from '../modules/auth.js';
+import {
+    AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE,
+} from '../modules/config.js';
+
+const accepted = new Counter('idempotency_accepted');
+const rejected = new Counter('idempotency_rejected');
+const errorRate = new Rate('error_rate');
+
+const TEST_FUNDING_ID = parseInt(__ENV.TEST_FUNDING_ID || '0');
+const TEST_WISHLIST_ITEM_ID = parseInt(__ENV.TEST_WISHLIST_ITEM_ID || '0');
+const TEST_RECEIVER_ID = parseInt(__ENV.TEST_RECEIVER_ID || '0');
+const TEST_PRODUCT_ID = parseInt(__ENV.TEST_PRODUCT_ID || '0');
+
+const accounts = new SharedArray('accounts', function () {
+    return JSON.parse(open('../data/test-accounts.json'));
+});
+
+/**
+ * shared-iterations: 100 VU가 같은 Idempotency-Key로 동시 요청.
+ * 멱등성 제어가 정상이면 1건만 처리, 99건은 중복 응답.
+ */
+export const options = {
+    setupTimeout: '120s',
+    scenarios: {
+        idempotency_race: {
+            executor: 'shared-iterations',
+            vus: 100,
+            iterations: 100,
+            maxDuration: '60s',
+            gracefulStop: '10s',
+        },
+    },
+    thresholds: {
+        'http_req_duration{name:idempotent_order}': ['p(95)<5000'],
+        'http_req_failed': ['rate<0.05'],
+        'error_rate': ['rate<0.10'],
+    },
+};
+
+export function setup() {
+    if (TEST_FUNDING_ID === 0 || TEST_WISHLIST_ITEM_ID === 0
+        || TEST_RECEIVER_ID === 0 || TEST_PRODUCT_ID === 0) {
+        throw new Error(
+            '필수 환경변수 누락. 다음을 모두 설정하세요:\n' +
+            '  TEST_FUNDING_ID, TEST_WISHLIST_ITEM_ID, TEST_RECEIVER_ID, TEST_PRODUCT_ID'
+        );
+    }
+
+    // 모든 VU가 공유할 고정 Idempotency-Key 생성
+    const fixedKey = `idempotency-test-${Date.now()}`;
+
+    if (MOCK_AUTH) {
+        console.log(`멱등성 테스트: Mock Auth, 고정 키=${fixedKey}, VU=100`);
+        return { tokens: [], mockAuth: true, idempotencyKey: fixedKey };
+    }
+
+    const tokens = getTokens(
+        accounts, AUTH0_DOMAIN, AUTH0_CLIENT_ID,
+        AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE
+    );
+    console.log(`멱등성 테스트: Auth0 JWT, 고정 키=${fixedKey}, 토큰=${tokens.length}개`);
+    return { tokens, mockAuth: false, idempotencyKey: fixedKey };
+}
+
+/**
+ * 모든 VU가 동일한 사용자(1001)로, 동일한 Idempotency-Key로 주문 요청.
+ *
+ * 기대 결과:
+ * - 1건: 200/201 (최초 처리)
+ * - 99건: 200 (멱등성 캐시에서 동일 응답 반환) 또는 409 (중복 거절)
+ * - DB에 주문 1건만 존재
+ */
+export default function (data) {
+    // 모든 VU가 같은 사용자로 요청 (멱등성은 같은 사용자의 중복 요청을 방지)
+    const opts = data.mockAuth
+        ? mockAuthHeaders(1001)
+        : authHeaders(data.tokens[0]);
+
+    const body = JSON.stringify({
+        items: [{
+            wishlistItemId: TEST_WISHLIST_ITEM_ID,
+            productId: TEST_PRODUCT_ID,
+            fundingId: TEST_FUNDING_ID,
+            receiverId: TEST_RECEIVER_ID,
+            amount: 1000,
+            orderItemType: 'FUNDING_GIFT',
+        }],
+        method: 'DEPOSIT',
+    });
+
+    const res = http.post(
+        `${BASE_URL}/api/v2/orders`,
+        body,
+        Object.assign({}, opts, {
+            tags: { name: 'idempotent_order' },
+            headers: Object.assign({}, opts.headers, {
+                'X-Idempotency-Key': data.idempotencyKey,  // 모든 VU가 같은 키!
+            }),
+        })
+    );
+
+    const ok = check(res, {
+        'accepted or deduplicated': (r) =>
+            r.status === 200 || r.status === 201 || r.status === 202,
+    });
+
+    if (res.status === 200 || res.status === 201) {
+        accepted.add(1);
+    } else if (res.status === 409) {
+        rejected.add(1);
+    }
+    errorRate.add(res.status >= 500);
+}
+
+export function teardown(data) {
+    console.log('─────────────────────────────────────');
+    console.log('멱등성 테스트 완료');
+    console.log(`인증 모드: ${data.mockAuth ? 'Mock Auth' : 'Auth0 JWT'}`);
+    console.log(`Idempotency-Key: ${data.idempotencyKey}`);
+    console.log('');
+    console.log('DB 검증 (수동):');
+    console.log('  kubectl exec -n giftify statefulset/postgres --');
+    console.log('    psql -U giftify -d giftify_db -c');
+    console.log(`    "SELECT COUNT(*) FROM g7app.orders WHERE id >= 100;"`);
+    console.log('  기대값: 1건 (멱등성 보장 시)');
+    console.log('─────────────────────────────────────');
+}

--- a/infra/monitoring/k6/scripts/seller-scenario.js
+++ b/infra/monitoring/k6/scripts/seller-scenario.js
@@ -61,14 +61,20 @@ export function setup() {
         return { tokens: [], mockAuth: true };
     }
 
+    const sellerAccounts = accounts.filter(a => a.role === 'SELLER');
+    if (sellerAccounts.length === 0) {
+        throw new Error('SELLER 계정이 test-accounts.json에 없습니다.');
+    }
+
     const tokens = getTokens(
-        accounts, AUTH0_DOMAIN, AUTH0_CLIENT_ID,
+        sellerAccounts, AUTH0_DOMAIN, AUTH0_CLIENT_ID,
         AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE
     );
     if (tokens.length === 0) {
         throw new Error('토큰 발급 실패. Auth0 환경변수를 확인하세요.');
     }
 
+    console.log(`Phase 2: Auth0 JWT 모드 (SELLER). 토큰: ${tokens.length}개`);
     return { tokens, mockAuth: false };
 }
 


### PR DESCRIPTION
  ## Summary
 staging 전용 k3s overlay를 추가하여 prod와 분리된 부하테스트 환경을 구축합니다.

  ---

  ## What's Changed

  ### 설정 버그 수정
  - **Internal API 포트 불일치 해결**: `internal-api.base-url`에 포트 8080 명시 (`application-core-prod.yml`). K8s Service가 8080만 노출하는데 기본 포트 80으로 연결 시도하던 버그.
  - **Flyway 시드 격리 방식 전환**: `current_schema() = 'loadtest'` 조건을 `'${is_staging}' = 'true'` placeholder 방식으로 변경 (8개 R__seed.sql). Spring Modulith Module-Aware Flyway에서 locations 오버라이드는 불가하지만 placeholders는 `.configuration(configuration)`으로 상속되므로 정상 작동.
  - **k6 concurrency-test.js 필드 누락**: 주문 API가 요구하는 `productId`, `fundingId` 필드와 `TEST_PRODUCT_ID` 환경변수 추가.

  ### Staging 인프라
  - **staging overlay 신규 생성**: `infra/k3s/overlays/staging/kustomization.yaml`
    - `SPRING_PROFILES_ACTIVE=prod,loadtest`
    - `INTERNAL_API_BASE_URL=http://api-server:8080`
    - `SPRING_THREADS_VIRTUAL_ENABLED=true` (HTTP self-call 데드락 방지)
    - `SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE=30`
    - `SPRING_FLYWAY_PLACEHOLDERS_IS_STAGING=true`
    - NodePort 30080, startupProbe failureThreshold 90
  - **loadtest 프로파일 정리**: `application-loadtest.yml`에서 스키마 격리 설정 제거 (VM 분리로 불필요), Flyway placeholder 오버라이드 추가.

  ---

  ## Decisions & Trade-offs

  - **스키마 분리 → VM 분리**: 초기에는 `g7app`/`loadtest` 두 스키마로 데이터를 격리하려
    했으나, VM을 분리하면 DB 자체가 별도이므로 스키마 분리가 불필요. Flyway 조건문과
    Hibernate default_schema 설정의 복잡도를 제거하고, placeholder 기반 시드 격리로 단순화.
  - **Virtual Threads**: `CoreFacade.participateFunding()`이 `@Transactional` 안에서  HTTP self-call을 하는 구조적 문제가 있음. 근본 해결(Direct Bean Injection)이 아닌 Virtual Threads로 데드락을 완화하는 단기 대응. staging 전용 설정.
  - **HikariCP 30**: HTTP self-call 패턴으로 인해 기본값(10)으로는 커넥션 부족. PostgreSQL max_connections(100) 대비 안전한 수준으로 설정.

  ---

  ## Future Improvements

  - **Optimistic Lock → 409 Conflict**: `ObjectOptimisticLockingFailureException`이 현재 500으로 반환됨. GlobalExceptionHandler에서 409로 변환 필요.
  - **HTTP Self-Call → Direct Bean Injection**: `ProductPort`, `WishlistClient`를 `FundingQueryPort`처럼 직접 JPA adapter로 교체. 커넥션 이중 소비 근본 해결.
  - **Apache HC5 maxConnPerRoute 증가**: 기본값 5로 인한 직렬화 병목. RestClientCustomizer로 pool 설정 추가.
  - **es-secrets SOPS 통합**: 현재 수동 생성. SOPS 암호화 파일로 통합 관리.

  ---

  ### Linked Issues
