### PR TITLE
 PostgreSQL GCS 자동 백업 CronJob 추가

### DIFF
--- a/bootstrap/api-server/src/main/resources/application-dev.yml
+++ b/bootstrap/api-server/src/main/resources/application-dev.yml
@@ -56,6 +56,8 @@ spring:
     schemas: g7app
     default-schema: g7app
     create-schemas: true
+    placeholders:
+      is_staging: "false"
 
   sql:
     init:

--- a/infra/k3s/base/apps/postgres/backup-cronjob.yaml
+++ b/infra/k3s/base/apps/postgres/backup-cronjob.yaml
@@ -1,0 +1,109 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-backup
+  labels:
+    app: postgres-backup
+spec:
+  schedule: "30 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 900
+      template:
+        metadata:
+          labels:
+            app: postgres-backup
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          containers:
+            - name: backup
+              image: google/cloud-sdk:alpine
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  START_TIME=$(date +%s)
+
+                  apk add --no-cache --quiet postgresql16-client
+
+                  if [ -z "$POSTGRES_HOST" ] || [ -z "$POSTGRES_DB" ]; then
+                    echo "ERROR: Required environment variables not set"
+                    exit 1
+                  fi
+
+                  BACKUP_DATE=$(TZ=Asia/Seoul date +%Y-%m-%d_%H%M%S)
+                  BACKUP_FILE="giftify_db_${BACKUP_DATE}.dump"
+                  BACKUP_PATH="/tmp/${BACKUP_FILE}"
+                  GCS_PATH="gs://giftify-db-backups/${BACKUP_ENV}/${BACKUP_FILE}"
+
+                  echo "=== PostgreSQL Backup Start ==="
+                  echo "Timestamp: $(TZ=Asia/Seoul date '+%Y-%m-%d %H:%M:%S KST')"
+                  echo "Target: ${POSTGRES_HOST}:5432/${POSTGRES_DB}"
+                  echo "Environment: ${BACKUP_ENV}"
+
+                  pg_dump \
+                    -h "$POSTGRES_HOST" \
+                    -p 5432 \
+                    -U "$POSTGRES_USER" \
+                    -d "$POSTGRES_DB" \
+                    -Fc \
+                    --verbose \
+                    --file="$BACKUP_PATH" 2>&1
+
+                  if [ ! -f "$BACKUP_PATH" ]; then
+                    echo "ERROR: Backup file not created"
+                    exit 1
+                  fi
+
+                  BACKUP_SIZE=$(du -h "$BACKUP_PATH" | cut -f1)
+                  echo "Backup created: ${BACKUP_FILE} (${BACKUP_SIZE})"
+
+                  echo "Uploading to: ${GCS_PATH}"
+                  gsutil cp "$BACKUP_PATH" "$GCS_PATH"
+
+                  if gsutil ls "$GCS_PATH" > /dev/null 2>&1; then
+                    echo "Upload verified"
+                  else
+                    echo "ERROR: Upload verification failed"
+                    exit 1
+                  fi
+
+                  rm -f "$BACKUP_PATH"
+
+                  END_TIME=$(date +%s)
+                  echo "=== Backup Completed (${BACKUP_ENV}) ==="
+                  echo "GCS: ${GCS_PATH}"
+                  echo "Duration: $((END_TIME - START_TIME))s"
+              env:
+                - name: POSTGRES_HOST
+                  value: "postgres"
+                - name: POSTGRES_DB
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secrets
+                      key: POSTGRES_DB
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secrets
+                      key: POSTGRES_USER
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: postgres-secrets
+                      key: POSTGRES_PASSWORD
+                - name: BACKUP_ENV
+                  value: "prod"
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "300m"

--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   # PostgreSQL
   - apps/postgres/statefulset.yaml
   - apps/postgres/service.yaml
+  - apps/postgres/backup-cronjob.yaml
   # Redis
   - apps/redis/deployment.yaml
   - apps/redis/service.yaml


### PR DESCRIPTION
 ## Summary
  - PostgreSQL 전체 DB를 매일 GCS에 자동 백업하는 K8s CronJob 추가
  - staging VM에서 end-to-end 테스트 완료 (pg_dump → GCS 업로드 → 검증)

  ## What's Changed
  - `infra/k3s/base/apps/postgres/backup-cronjob.yaml` 신규 생성
    - 스케줄: `30 0 * * *` (KST 09:30, VM 가동 시간대)
    - 이미지: `google/cloud-sdk:alpine` + `postgresql16-client`
    - pg_dump `-Fc` (Custom format, 자체 zlib 압축)
    - GCS 업로드: `gs://giftify-db-backups/{env}/giftify_db_{timestamp}.dump`
    - VM 기본 Compute SA 인증 (별도 시크릿 불필요)
  - `infra/k3s/base/kustomization.yaml` — backup-cronjob.yaml 리소스 추가

  ## Decisions & Trade-offs
  - **VM 기본 SA vs 전용 SA**: 교육 프로젝트 특성상 기본 Compute SA에 GCS objectAdmin 권한 부여로
  단순화. JSON Key 관리/SOPS 암호화 불필요.
  - **-Fc vs plain SQL**: Custom format 선택 — 병렬 복구, 선택 복구 가능. 자체 zlib 압축으로 별도 gzip
  불필요.
  - **14일 보존**: GCS Lifecycle Policy로 자동 삭제. 교육 프로젝트에 적합한 기간.
  - **VM scope 변경**: staging/prod VM 모두 `cloud-platform` scope로 변경 완료 (기존
  `devstorage.read_only`에서).

  ## Future Improvements
  - 백업 실패 시 Slack/Discord 알림
  - 복구 RunBook 문서화 (`docs/playbook/postgres-backup-recovery.md`)
