### PR TITLE
Cloudflare Tunnel Kustomize 리소스 복원

### DIFF
--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -38,6 +38,8 @@ resources:
   - apps/elasticsearch/statefulset.yaml
   - apps/elasticsearch/service.yaml
   - apps/elasticsearch/ingress.yaml
+  # Cloudflare Tunnel
+  - cloudflare/tunnel-deployment.yaml
   # Traefik
   - traefik/middleware/rate-limit.yaml
   - traefik/middleware/forwarded-proto.yaml

--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
   - apps/elasticsearch/ingress.yaml
   # Cloudflare Tunnel
   - cloudflare/tunnel-deployment.yaml
+  - cloudflare/tunnel-pdb.yaml
   # Traefik
   - traefik/middleware/rate-limit.yaml
   - traefik/middleware/forwarded-proto.yaml


### PR DESCRIPTION
## Summary
- 51c21883 커밋에서 MinIO와 함께 Cloudflare Tunnel이 `base/kustomization.yaml`에서 제거됨
- Cloudflare Tunnel은 활성 리소스였으나, 당시 수동 배포된 Pod이 살아있어 문제가 즉시 드러나지 않음
- ArgoCD sync + VM 재시작 후 Tunnel Pod 삭제 → 외부 접근 불가 (Cloudflare 1033 에러)

## What's Changed
- `infra/k3s/base/kustomization.yaml`에 `cloudflare/tunnel-deployment.yaml` 리소스 복원
- `cloudflare/tunnel-pdb.yaml` (PodDisruptionBudget) 추가 — 롤링 업데이트 시 최소 1 Pod 유지

## Decisions & Trade-offs
- 수동 `kubectl apply`로 긴급 복구 후 (2026-03-24), 영구 수정으로 Kustomize에 등록
- PDB는 k3s 단일 노드에서 실효성 낮으나 해가 없으므로 설정