### PR TITLE
Grafana Discord 알림 설정 

### DIFF
--- a/infra/k3s/base/apps/grafana/alerting-configmap.yaml
+++ b/infra/k3s/base/apps/grafana/alerting-configmap.yaml
@@ -1,0 +1,196 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-alerting
+data:
+  contactpoints.yaml: |
+    apiVersion: 1
+    contactPoints:
+      - orgId: 1
+        name: discord-alerts
+        receivers:
+          - uid: discord-webhook
+            type: discord
+            settings:
+              url: ${DISCORD_WEBHOOK_URL}
+              use_discord_username: true
+              avatar_url: https://grafana.com/static/assets/img/fav32.png
+            disableResolveMessage: false
+
+  policies.yaml: |
+    apiVersion: 1
+    policies:
+      - orgId: 1
+        receiver: discord-alerts
+        group_by:
+          - grafana_folder
+          - alertname
+        group_wait: 30s
+        group_interval: 5m
+        repeat_interval: 4h
+        routes:
+          - receiver: discord-alerts
+            object_matchers:
+              - ["severity", "=", "critical"]
+            group_wait: 10s
+            repeat_interval: 1h
+          - receiver: discord-alerts
+            object_matchers:
+              - ["severity", "=", "warning"]
+            repeat_interval: 4h
+
+  rules.yaml: |
+    apiVersion: 1
+    groups:
+      - orgId: 1
+        name: giftify-infra
+        folder: Giftify Alerts
+        interval: 1m
+        rules:
+          - uid: cpu-high
+            title: "System CPU > 80%"
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: system_cpu_usage{application="giftify-be"} * 100
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params: [80]
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "System CPU 사용률 80% 초과"
+              description: "System CPU 사용률이 {{ $value }}%입니다. (Spring Boot actuator 기준)"
+
+          - uid: error-rate-high
+            title: "5xx Error Rate > 5%"
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: |
+                    100 * sum(rate(http_server_requests_seconds_count{application="giftify-be", status=~"5.."}[5m]))
+                    / sum(rate(http_server_requests_seconds_count{application="giftify-be"}[5m]))
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params: [5]
+                  refId: C
+            for: 2m
+            labels:
+              severity: critical
+            annotations:
+              summary: "5xx 에러율 5% 초과"
+              description: "5xx 에러율이 {{ $value }}%입니다. 즉시 확인 필요."
+
+          - uid: heap-high
+            title: "JVM Heap > 90%"
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: |
+                    100 * jvm_memory_used_bytes{application="giftify-be", area="heap"}
+                    / jvm_memory_max_bytes{application="giftify-be", area="heap"}
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params: [90]
+                  refId: C
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "JVM Heap 사용률 90% 초과"
+              description: "Heap 사용률이 {{ $value }}%입니다. OOM 위험."
+
+          - uid: hikaricp-pending
+            title: "HikariCP Pending > 10"
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange:
+                  from: 300
+                  to: 0
+                datasourceUid: prometheus
+                model:
+                  expr: hikaricp_connections_pending{application="giftify-be"}
+                  refId: A
+              - refId: B
+                datasourceUid: __expr__
+                model:
+                  type: reduce
+                  expression: A
+                  reducer: last
+                  refId: B
+              - refId: C
+                datasourceUid: __expr__
+                model:
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator:
+                        type: gt
+                        params: [10]
+                  refId: C
+            for: 2m
+            labels:
+              severity: warning
+            annotations:
+              summary: "DB 커넥션 대기 10건 초과"
+              description: "HikariCP pending 커넥션이 {{ $value }}건입니다. 커넥션 풀 고갈 위험."

--- a/infra/k3s/base/apps/grafana/deployment.yaml
+++ b/infra/k3s/base/apps/grafana/deployment.yaml
@@ -38,6 +38,11 @@ spec:
                   key: GF_SECURITY_ADMIN_PASSWORD
             - name: GF_USERS_ALLOW_SIGN_UP
               value: "false"
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-secrets
+                  key: DISCORD_WEBHOOK_URL
           resources:
             requests:
               memory: "128Mi"
@@ -64,6 +69,8 @@ spec:
               mountPath: /etc/grafana/provisioning/dashboards
             - name: dashboards-json
               mountPath: /etc/grafana/provisioning/dashboards/json
+            - name: provisioning-alerting
+              mountPath: /etc/grafana/provisioning/alerting
       volumes:
         - name: provisioning-datasources
           configMap:
@@ -80,3 +87,6 @@ spec:
         - name: dashboards-json
           configMap:
             name: grafana-dashboards
+        - name: provisioning-alerting
+          configMap:
+            name: grafana-alerting

--- a/infra/k3s/base/kustomization.yaml
+++ b/infra/k3s/base/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - apps/prometheus/ingress.yaml
   # Grafana
   - apps/grafana/configmap.yaml
+  - apps/grafana/alerting-configmap.yaml
   - apps/grafana/deployment.yaml
   - apps/grafana/service.yaml
   - apps/grafana/ingress.yaml

--- a/infra/k3s/overlays/prod/grafana-secrets.enc.yaml
+++ b/infra/k3s/overlays/prod/grafana-secrets.enc.yaml
@@ -7,6 +7,7 @@ type: ENC[AES256_GCM,data:ikGX8vOG,iv:0HG5yQS1Y0SKm6JWVpRYv9xq8NQL/yNEqCkulBI+Ps
 stringData:
     GF_SECURITY_ADMIN_USER: ENC[AES256_GCM,data:cB3PKkGyEWRDyutIStvbQA==,iv:C7dXNSytEvrCO7gvOjQBX8h0gKZmvrOEbhfrCmJO9CM=,tag:B2UJ1/xWDryBmlGNMNNHoQ==,type:str]
     GF_SECURITY_ADMIN_PASSWORD: ENC[AES256_GCM,data:JOCsewIn3q4aZ7SpVKXFVQ==,iv:Id2kB67L3g4QXp97+o76L7MNuqbGzCElhgCwziYQFZE=,tag:UaA1bRaBurvqj/fN2MI3fA==,type:str]
+    DISCORD_WEBHOOK_URL: ENC[AES256_GCM,data:/yBpIr44AYAq9+cEV1KQxRzGbQ6reAzPYqs4CTbEpGAwKo/sqyqL46B8Se4d5nkKFPeiGjqO5J5E0ipSI5c1x4rGNeIvu8HnkTzsbaXwkfHc4Ax+KB+htH1SZ9FBKwJ4R3PV7y7lgegM03M5wegqtXszGbNr+ZV46A==,iv:lZX+CxpcERo1i2W6RqvQmDR3b4/FRRLvVmGy3rxvPe4=,tag:eS94AokfUVPF2y0zJQUZxA==,type:str]
 sops:
     age:
         - recipient: age1vxtgy82n4vprjft3pp34hnwcneu6ltf5fe2k0xwzxuddf3w8ksss8xw830
@@ -27,7 +28,7 @@ sops:
             QUpEWS83cnNMQ1ZpbTJidUhJcHRKUWMKXCnFyEY4bULcOLOfg15Qbd8jod0Dt1gM
             9cC0s/7Ed87FFWVm+re272NBN+L/9q94ixk2VTfhxRXq0s/uwyY09Q==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-18T08:40:12Z"
-    mac: ENC[AES256_GCM,data:FhEJWQrlAApDIq4MHJ6LOu+npqZ4Kh2sbzmp0R5rdgBoaSNwv4CdrtU/QTNwDUpfQTKY8FAcZPRvgf5EtJPpC7x//xah8X+MgZ9v5Tgu++TxeApQChQ9A7epAynjBWW4JY4xR+h7uqQ07ZuViY/I2l7HoqJ1yOqoNRHmk+sBQlc=,iv:iw07GyE8mHgkJqxSxtEqABeE4fAHGXO5gDV9gXEEc2c=,tag:2oSC+ZJsMCucCBtvHT/FwQ==,type:str]
+    lastmodified: "2026-03-24T08:18:06Z"
+    mac: ENC[AES256_GCM,data:6EszM6yhwVt+Fs+f01nRPZPrN9AdqejEYeQ8BVoCevmESjo1DZhbdu2eMyjm673pA5a7rxmTGNiRv0NkuT/T3t2giBkijeY++q/q+yG6fNQ11Sl7ZPvRHBDetWl1UIk3hE64HDaztxF+MZm9Qeo6MahcPGoUMYxEUbInnP116L8=,iv:v+cL7mhrKO3eejqPvqXZ0HXMrEZOdskmA18fKF5+/1c=,tag:LlbROBP/4lsJrZoItUo+1g==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.1


### PR DESCRIPTION
## Summary

Grafana unified alerting을 프로비저닝 파일로 구성. Discord #alrams 채널로 알림 전송.

## What's Changed

### Contact Point
- Discord Webhook (`DISCORD_WEBHOOK_URL` → SOPS 암호화 Secret → 환경변수 주입)
- Grafana provisioning YAML로 코드 관리

### Notification Policy
| Severity | Group Wait | Repeat |
|----------|-----------|--------|
| critical | 10s | 1h |
| warning | 30s | 4h |

### Alert Rules (4개)
| Rule | Metric | Threshold | Severity |
|------|--------|-----------|----------|
| System CPU > 80% | `system_cpu_usage` (actuator) | 5분 지속 | warning |
| 5xx Error Rate > 5% | `http_server_requests_seconds_count{status=~"5.."}` | 2분 지속 | critical |
| JVM Heap > 90% | `jvm_memory_used/max_bytes` | 5분 지속 | warning |
| HikariCP Pending > 10 | `hikaricp_connections_pending` | 2분 지속 | warning |

### Infrastructure
- `alerting-configmap.yaml`: contact point + policies + rules (단일 ConfigMap)
- `deployment.yaml`: `DISCORD_WEBHOOK_URL` env + alerting provisioning volume mount
- `kustomization.yaml`: alerting-configmap 리소스 추가
- `grafana-secrets.enc.yaml`: `DISCORD_WEBHOOK_URL` 추가 (SOPS 암호화)

## Decisions & Trade-offs
- **모든 메트릭을 Spring Boot actuator 기준으로 작성**: node_exporter/kube-state-metrics 미배포 상태이므로 `node_*`, `kube_*` 메트릭 사용 불가. Pod Restart, System Memory 규칙은 해당 exporter 배포 시 별도 추가
- **Grafana provisioning (file-based)**: UI에서 수정 불가하지만 Git 관리 + ArgoCD 자동 배포 가능
- **SOPS 암호화**: Webhook URL을 기존 grafana-secrets에 통합. 별도 Secret 불필요

## Verification (배포 후)
1. ArgoCD sync → Grafana Pod 재시작
2. Grafana UI → Alerting → Contact Points에서 discord-alerts 확인
3. Alerting → Alert Rules에서 4개 규칙 확인
4. T3.5에서 부하 유발 후 실제 Discord 알림 수신 테스트

## Future Improvements
- `kube-state-metrics` 배포 후 Pod Restart 규칙 추가
- `node_exporter` 배포 후 System Memory 규칙 추가

## Linked Issues

