### PR TITLE
Alert 설정 수정 및 Baseline 측정

### DIFF
--- a/docs/playbook/database/backup-recovery.md
+++ b/docs/playbook/database/backup-recovery.md
@@ -1,0 +1,209 @@
+# PostgreSQL Backup & Recovery Runbook
+
+## 1. Backup Architecture
+
+```
++-----------------------------------------------------------+
+|  Daily Automated Backup (CronJob: postgres-backup)        |
++-----------------------------------------------------------+
+|                                                           |
+|  Schedule: 09:30 KST (UTC 00:30)                         |
+|  Format:   pg_dump -Fc (Custom, zlib compressed)          |
+|  Storage:  gs://giftify-db-backups/{env}/                 |
+|  Retention: 14 days (GCS Lifecycle Policy)                |
+|                                                           |
+|  +-------+    pg_dump    +----------+   gsutil   +------+ |
+|  | PG DB | ------------> | /tmp/*.dump | -------> | GCS  | |
+|  +-------+               +----------+            +------+ |
+|                                                           |
+|  Image: google/cloud-sdk:alpine + postgresql16-client     |
+|  Schema: g7app (Module-Aware Flyway)                      |
++-----------------------------------------------------------+
+```
+
+| Item | Value |
+|------|-------|
+| CronJob | `postgres-backup` (`infra/k3s/base/apps/postgres/backup-cronjob.yaml`) |
+| Schedule | `30 0 * * *` (UTC) = 09:30 KST |
+| GCS Bucket | `gs://giftify-db-backups/` |
+| Path | `{env}/giftify_db_{YYYY-MM-DD_HHMMSS}.dump` |
+| Retention | 14 days (GCS Lifecycle) |
+| backoffLimit | 2 |
+| activeDeadlineSeconds | 900 (15min) |
+
+---
+
+## 2. Manual Backup (Emergency)
+
+prod VM에서 실행:
+
+```bash
+gcloud compute ssh giftify-app --zone=asia-northeast3-a --tunnel-through-iap
+
+# CronJob에서 수동 Job 생성 (가장 안전한 방법)
+kubectl create job --from=cronjob/postgres-backup manual-backup-$(date +%Y%m%d-%H%M) -n giftify
+
+# Job 완료 대기
+kubectl wait --for=condition=complete job/manual-backup-* -n giftify --timeout=300s
+
+# 결과 확인
+kubectl logs job/manual-backup-* -n giftify
+
+# Job 정리
+kubectl delete job manual-backup-* -n giftify
+```
+
+---
+
+## 3. Recovery Procedure
+
+### Stage 1: Test Recovery (non-production)
+
+staging VM에서 임시 Pod으로 복원하여 데이터 무결성 먼저 검증.
+
+```bash
+gcloud compute ssh giftify-staging --zone=asia-northeast3-a --tunnel-through-iap
+
+# 1. 임시 PostgreSQL Pod 생성
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: postgres-restore-test
+  namespace: giftify
+spec:
+  restartPolicy: Never
+  containers:
+    - name: postgres
+      image: postgres:16-alpine
+      env:
+        - name: POSTGRES_PASSWORD
+          value: "test-restore-password"
+        - name: POSTGRES_USER
+          value: "giftify"
+        - name: POSTGRES_DB
+          value: "giftify_restore_test"
+      resources:
+        limits:
+          memory: "512Mi"
+          cpu: "500m"
+EOF
+kubectl wait --for=condition=ready pod/postgres-restore-test -n giftify --timeout=60s
+
+# 2. 백업 다운로드 + Pod 복사 + 복원
+LATEST=$(gsutil ls gs://giftify-db-backups/prod/ | sort | tail -1)
+echo "Restoring from: $LATEST"
+gsutil cp $LATEST /tmp/backup.dump
+kubectl cp /tmp/backup.dump giftify/postgres-restore-test:/tmp/backup.dump
+
+kubectl exec postgres-restore-test -n giftify -- sh -c "
+  apk add --no-cache postgresql16-client &&
+  PGPASSWORD=test-restore-password pg_restore \
+    -h localhost -U giftify -d giftify_restore_test \
+    --no-owner --no-acl /tmp/backup.dump
+"
+
+# 3. 데이터 무결성 검증 (Verification Checklist 참조)
+
+# 4. 정리
+kubectl delete pod postgres-restore-test -n giftify
+rm -f /tmp/backup.dump
+```
+
+### Stage 2: Downtime Notification
+
+```
+Discord #alerts:
+  "[긴급 점검] 데이터베이스 복구 작업
+   시작: {시간}
+   예상 종료: {시간} (약 15분)
+   사유: {사유}"
+```
+
+### Stage 3: Production Recovery
+
+```bash
+gcloud compute ssh giftify-app --zone=asia-northeast3-a --tunnel-through-iap
+
+# 1. api-server scale down (DB connection 차단)
+kubectl scale deployment api-server --replicas=0 -n giftify
+
+# 2. 대상 백업 파일 다운로드
+TARGET="gs://giftify-db-backups/prod/giftify_db_YYYY-MM-DD_HHMMSS.dump"
+gsutil cp $TARGET /tmp/restore.dump
+
+# 3. Pod 내부에서 복원
+kubectl exec -it postgres-0 -n giftify -- sh -c "
+  apk add --no-cache postgresql16-client google-cloud-sdk
+"
+kubectl cp /tmp/restore.dump giftify/postgres-0:/tmp/restore.dump
+
+kubectl exec -it postgres-0 -n giftify -- sh -c "
+  pg_restore \
+    -h localhost -U giftify -d giftify_db \
+    --clean --if-exists \
+    --no-owner --no-acl \
+    /tmp/restore.dump &&
+  rm -f /tmp/restore.dump
+"
+
+# 4. api-server scale up
+kubectl scale deployment api-server --replicas=1 -n giftify
+kubectl wait --for=condition=ready pod -l app=api-server -n giftify --timeout=120s
+
+# 5. Health check
+kubectl exec -it deployment/api-server -n giftify -- \
+  curl -sf http://localhost:8080/actuator/health
+```
+
+---
+
+## 4. Verification Checklist
+
+Stage 1 (test) 및 Stage 3 (prod) 복원 후 반드시 확인:
+
+- [ ] pg_restore exit code = 0
+- [ ] 핵심 테이블 존재 (search_path = g7app):
+
+```sql
+SET search_path TO g7app;
+SELECT 'members' AS tbl, COUNT(*) FROM members
+UNION ALL SELECT 'products', COUNT(*) FROM products
+UNION ALL SELECT 'wishlists', COUNT(*) FROM wishlists
+UNION ALL SELECT 'fundings', COUNT(*) FROM fundings
+UNION ALL SELECT 'orders', COUNT(*) FROM orders
+UNION ALL SELECT 'payments', COUNT(*) FROM payments
+UNION ALL SELECT 'wallets', COUNT(*) FROM wallets
+ORDER BY tbl;
+```
+
+- [ ] 각 테이블 레코드 수 > 0
+- [ ] Flyway schema history 일관성:
+
+```sql
+SELECT installed_rank, version, description, success
+FROM g7app.flyway_schema_history
+ORDER BY installed_rank DESC LIMIT 5;
+```
+
+- [ ] (Stage 3 only) API health check 성공
+- [ ] (Stage 3 only) 주요 API 동작 확인 (상품 검색, 위시리스트 조회)
+
+---
+
+## 5. Emergency Contacts
+
+| Role | Name | GitHub |
+|------|------|--------|
+| Infra Lead | chan99 | @chan99k |
+| Team | team201.sy | - |
+| Team | team201.yk | - |
+| Team | satoru18704 | - |
+
+---
+
+## 6. Recovery History
+
+| Date | Operator | Reason | Downtime | Result |
+|------|----------|--------|----------|--------|
+| 2026-03-24 | chan99 | T2.4 Test recovery (staging) | 0min | Success - 254.7KB, 7 tables verified (members:6, products:91, wishlists:6, fundings:4, orders:5, payments:3, wallets:6). Schema: g7app |

--- a/docs/reports/2026-03-25-load-baseline.md
+++ b/docs/reports/2026-03-25-load-baseline.md
@@ -1,0 +1,95 @@
+# Cycle 0 Baseline Report
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| Date | 2026-03-24 (20:45 KST) |
+| Server | giftify-staging (e2-standard-2, 2vCPU/8GB) |
+| Scenario | funding-scenario.js (read-only, Mock Auth) |
+| VU | max 60, 5-stage ramp |
+| Duration | 4m17s |
+| Profile | prod,loadtest (Hibernate Statistics ON) |
+
+## Overall Results
+
+| Metric | Value |
+|--------|-------|
+| RPS | 39.2/s |
+| Total Requests | 10,080 |
+| Iterations | 2,016 |
+| **p(95) Response Time** | **454ms** |
+| Error Rate | 0.00% |
+| Checks Passed | 100% (10,080/10,080) |
+
+## Per-API Breakdown
+
+```
++------------------+--------+--------+--------+--------+--------+
+| API              |  avg   |  med   | p(90)  | p(95)  |  max   |
++------------------+--------+--------+--------+--------+--------+
+| product_search   | 166ms  | 124ms  | 350ms  | 424ms  | 4.89s  |
+| product_detail   | 122ms  | 83ms   | 283ms  | 370ms  | 4.96s  |
+| wishlist         | 141ms  | 96ms   | 321ms  | 425ms  | 4.38s  |
+| cart_add         | 225ms  | 177ms  | 471ms  | 595ms  | 5.15s  |
+| funding_list     | 130ms  | 89ms   | 300ms  | 382ms  | 5.15s  |
+| order_create     | 0ms    | 0ms    | 0ms    | 0ms    | 0ms    |
++------------------+--------+--------+--------+--------+--------+
+| TOTAL            | 157ms  | 109ms  | 354ms  | 454ms  | 5.15s  |
++------------------+--------+--------+--------+--------+--------+
+```
+
+Note: order_create는 read-only 모드(TEST_RECEIVER_ID 미설정)라 실행되지 않음.
+
+## SLO Compliance (Cycle 0 SLO: Read p95 < 500ms)
+
+| API | p(95) | SLO | Result |
+|-----|-------|-----|--------|
+| product_search | 424ms | < 200ms | FAIL |
+| product_detail | 370ms | < 200ms | FAIL |
+| wishlist | 425ms | < 200ms | FAIL |
+| cart_add | 595ms | < 500ms | FAIL |
+| funding_list | 382ms | < 200ms | FAIL |
+| **Overall** | **454ms** | **< 500ms** | **PASS** |
+
+Overall p(95)는 500ms SLO를 통과하지만, 개별 API threshold는 대부분 위반.
+
+## Bottleneck Analysis
+
+1. **cart_add** (p95=595ms) — 가장 느린 API. Cart + WishlistItem + Product JOIN 복합 쿼리
+2. **max latency 5.15s** — cold start 또는 GC pause 의심. JVM warming 후 안정화 필요
+3. **전체 avg 157ms, med 109ms** — median은 양호하나 tail latency가 높음 (p95/med = 4.2x)
+
+## Identified Optimization Targets (MS2)
+
+| Priority | Target | Approach | Expected Impact |
+|----------|--------|----------|-----------------|
+| 1 | cart_add latency | N+1 query 분석 (Hibernate Statistics) | p95 50%+ 개선 |
+| 2 | Tail latency (5s+) | JVM warm-up, GC tuning (Compact Headers 이미 적용) | max < 2s |
+| 3 | product_search | Elasticsearch query 최적화 또는 Redis 캐시 | p95 < 200ms |
+| 4 | HikariCP pool | Baseline에서 pending 확인 필요 (Grafana) | pool 고갈 방지 |
+
+## Hibernate Statistics
+
+Grafana "Hibernate Statistics" 패널에서 확인 필요:
+- [ ] hibernate_query_executions_total (rate) — N+1 의심 구간
+- [ ] hibernate_query_executions_max_seconds — slow query 후보
+- [ ] hibernate_sessions_open_total — 세션 수
+- [ ] hibernate_second_level_cache_requests_total — 2L cache (현재 0% 예상)
+- [ ] hibernate_statements_total — PreparedStatement 재사용
+
+## Comparison with Previous Results
+
+| Test | Date | VU | RPS | p(95) | Error |
+|------|------|----|-----|-------|-------|
+| Funding Scenario (local) | 2026-03-16 | 60 | 46.07 | 107ms | 0% |
+| Stress Test (staging) | 2026-03-23 | 120 | ~178 | SLO 초과 | 0% |
+| **Baseline (staging)** | **2026-03-24** | **60** | **39.2** | **454ms** | **0%** |
+
+Staging p(95)=454ms vs local p(95)=107ms — staging 환경이 더 느림 (VM 성능, 네트워크 홉).
+
+## Next Steps
+
+1. Grafana Hibernate Statistics 패널 스크린샷 확보
+2. MS2 Cycle 1: 가장 큰 병목(cart_add) 분석 및 최적화
+3. 최적화 후 재측정 → Before/After 비교

--- a/infra/k3s/base/apps/grafana/alerting-configmap.yaml
+++ b/infra/k3s/base/apps/grafana/alerting-configmap.yaml
@@ -76,6 +76,7 @@ data:
                         type: gt
                         params: [80]
                   refId: C
+            noDataState: OK
             for: 5m
             labels:
               severity: warning
@@ -95,7 +96,7 @@ data:
                 model:
                   expr: |
                     100 * sum(rate(http_server_requests_seconds_count{application="giftify-be", status=~"5.."}[5m]))
-                    / sum(rate(http_server_requests_seconds_count{application="giftify-be"}[5m]))
+                    / clamp_min(sum(rate(http_server_requests_seconds_count{application="giftify-be"}[5m])), 1e-10)
                   refId: A
               - refId: B
                 datasourceUid: __expr__
@@ -114,6 +115,7 @@ data:
                         type: gt
                         params: [5]
                   refId: C
+            noDataState: OK
             for: 2m
             labels:
               severity: critical
@@ -152,6 +154,7 @@ data:
                         type: gt
                         params: [90]
                   refId: C
+            noDataState: OK
             for: 5m
             labels:
               severity: warning
@@ -188,6 +191,7 @@ data:
                         type: gt
                         params: [10]
                   refId: C
+            noDataState: OK
             for: 2m
             labels:
               severity: warning

--- a/infra/k3s/base/apps/postgres/backup-cronjob.yaml
+++ b/infra/k3s/base/apps/postgres/backup-cronjob.yaml
@@ -33,7 +33,7 @@ spec:
                   notify_failure() {
                     if [ -n "$DISCORD_WEBHOOK_URL" ]; then
                       TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                      curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+                      curl -sf --max-time 10 -X POST "$DISCORD_WEBHOOK_URL" \
                         -H "Content-Type: application/json" \
                         -d "{\"embeds\":[{\"title\":\"PostgreSQL Backup Failed\",\"description\":\"**Env:** ${BACKUP_ENV:-unknown}\\n**Error:** Backup script exited with error\",\"color\":15158332,\"timestamp\":\"${TIMESTAMP}\"}]}" \
                         || true
@@ -72,6 +72,12 @@ spec:
                     exit 1
                   fi
 
+                  BACKUP_SIZE_BYTES=$(stat -c%s "$BACKUP_PATH" 2>/dev/null || stat -f%z "$BACKUP_PATH")
+                  if [ "$BACKUP_SIZE_BYTES" -lt 1024 ]; then
+                    echo "ERROR: Backup file suspiciously small (${BACKUP_SIZE_BYTES} bytes)"
+                    exit 1
+                  fi
+
                   BACKUP_SIZE=$(du -h "$BACKUP_PATH" | cut -f1)
                   echo "Backup created: ${BACKUP_FILE} (${BACKUP_SIZE})"
 
@@ -97,7 +103,7 @@ spec:
                   set +e
                   if [ -n "$DISCORD_WEBHOOK_URL" ]; then
                     TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-                    curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+                    curl -sf --max-time 10 -X POST "$DISCORD_WEBHOOK_URL" \
                       -H "Content-Type: application/json" \
                       -d "{\"embeds\":[{\"title\":\"PostgreSQL Backup Success\",\"description\":\"**Env:** ${BACKUP_ENV}\\n**File:** ${BACKUP_FILE}\\n**Size:** ${BACKUP_SIZE}\\n**Duration:** ${DURATION}s\\n**GCS:** ${GCS_PATH}\",\"color\":3066993,\"timestamp\":\"${TIMESTAMP}\"}]}" \
                       && echo "Discord notification sent" \

--- a/infra/k3s/base/apps/postgres/backup-cronjob.yaml
+++ b/infra/k3s/base/apps/postgres/backup-cronjob.yaml
@@ -30,6 +30,17 @@ spec:
                   set -e
                   START_TIME=$(date +%s)
 
+                  notify_failure() {
+                    if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+                      TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                      curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+                        -H "Content-Type: application/json" \
+                        -d "{\"embeds\":[{\"title\":\"PostgreSQL Backup Failed\",\"description\":\"**Env:** ${BACKUP_ENV:-unknown}\\n**Error:** Backup script exited with error\",\"color\":15158332,\"timestamp\":\"${TIMESTAMP}\"}]}" \
+                        || true
+                    fi
+                  }
+                  trap notify_failure ERR
+
                   apk add --no-cache --quiet postgresql16-client
 
                   if [ -z "$POSTGRES_HOST" ] || [ -z "$POSTGRES_DB" ]; then
@@ -77,9 +88,21 @@ spec:
                   rm -f "$BACKUP_PATH"
 
                   END_TIME=$(date +%s)
+                  DURATION=$((END_TIME - START_TIME))
                   echo "=== Backup Completed (${BACKUP_ENV}) ==="
                   echo "GCS: ${GCS_PATH}"
-                  echo "Duration: $((END_TIME - START_TIME))s"
+                  echo "Duration: ${DURATION}s"
+
+                  # Discord notification (non-blocking: curl failure must not fail the Job)
+                  set +e
+                  if [ -n "$DISCORD_WEBHOOK_URL" ]; then
+                    TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                    curl -sf -X POST "$DISCORD_WEBHOOK_URL" \
+                      -H "Content-Type: application/json" \
+                      -d "{\"embeds\":[{\"title\":\"PostgreSQL Backup Success\",\"description\":\"**Env:** ${BACKUP_ENV}\\n**File:** ${BACKUP_FILE}\\n**Size:** ${BACKUP_SIZE}\\n**Duration:** ${DURATION}s\\n**GCS:** ${GCS_PATH}\",\"color\":3066993,\"timestamp\":\"${TIMESTAMP}\"}]}" \
+                      && echo "Discord notification sent" \
+                      || echo "WARN: Discord notification failed (backup itself succeeded)"
+                  fi
               env:
                 - name: POSTGRES_HOST
                   value: "postgres"
@@ -100,6 +123,11 @@ spec:
                       key: POSTGRES_PASSWORD
                 - name: BACKUP_ENV
                   value: "prod"
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-secrets
+                      key: DISCORD_WEBHOOK_URL
               resources:
                 requests:
                   memory: "128Mi"

--- a/infra/monitoring/k6/scripts/smoke-test.js
+++ b/infra/monitoring/k6/scripts/smoke-test.js
@@ -4,18 +4,34 @@
  * 1 VU × 1 iteration으로 각 API를 한 번씩 호출.
  * 하나라도 실패하면 threshold 위반 → exit code 99.
  *
- * 사용법:
+ * 사용법 (Mock Auth):
  *   k6 run -e MOCK_AUTH=true -e BASE_URL=http://localhost:8080 \
+ *     ./scripts/smoke-test.js
+ *
+ * 사용법 (Real Auth):
+ *   k6 run -e BASE_URL=http://10.0.2.3:30080 \
+ *     -e AUTH0_DOMAIN=dev-qpuevxs5iduyblx4.us.auth0.com \
+ *     -e AUTH0_CLIENT_ID=<native-app-client-id> \
+ *     -e AUTH0_CLIENT_SECRET=<native-app-secret> \
+ *     -e AUTH0_AUDIENCE=https://api.giftify.app \
  *     ./scripts/smoke-test.js
  */
 import http from 'k6/http';
 import { check, group } from 'k6';
+import { SharedArray } from 'k6/data';
+import { getTokens } from '../modules/auth.js';
 import {
-    BASE_URL, authHeaders, mockAuthHeaders, MOCK_AUTH,
+    BASE_URL, MOCK_AUTH, mockAuthHeaders, authHeaders,
+    AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE,
     RECEIVER_WISHLISTS,
 } from '../modules/config.js';
 
+const accounts = new SharedArray('accounts', function () {
+    return JSON.parse(open('../data/test-accounts.json'));
+});
+
 export const options = {
+    setupTimeout: '60s',
     vus: 1,
     iterations: 1,
     thresholds: {
@@ -23,12 +39,26 @@ export const options = {
     },
 };
 
-export default function () {
-    // Mock Auth: loadtest member ID 1001 사용 (loadtest 스키마에 존재)
-    // Real Auth: 환경변수로 토큰을 직접 전달
-    const opts = MOCK_AUTH
+export function setup() {
+    if (MOCK_AUTH) {
+        return { token: null, mockAuth: true };
+    }
+
+    const tokens = getTokens(
+        [accounts[0]], AUTH0_DOMAIN, AUTH0_CLIENT_ID,
+        AUTH0_CLIENT_SECRET, AUTH0_AUDIENCE
+    );
+    if (tokens.length === 0) {
+        throw new Error('토큰 발급 실패. AUTH0_* 환경변수를 확인하세요.');
+    }
+
+    return { token: tokens[0], mockAuth: false };
+}
+
+export default function (data) {
+    const opts = data.mockAuth
         ? mockAuthHeaders(1001)
-        : authHeaders(__ENV.SMOKE_TOKEN || '');
+        : authHeaders(data.token);
 
     // ── 1. Health Check ──
     group('health', function () {


### PR DESCRIPTION
## Summary

W2-W3 로드맵 잔여 운영 태스크를 일괄 처리합니다.
PostgreSQL 백업 복구 검증, Grafana alert false positive 수정, 백업 CronJob Discord 알림 추가, Baseline 성능 측정을 포함합니다.


---

## What's Changed

### Grafana Alert False Positive 수정 
- 4개 alert rule에 `noDataState: OK` 추가 — VM 중지/트래픽 0 시 `DatasourceNoData` false firing 방지
- `error-rate-high` PromQL에 `clamp_min(..., 1e-10)` 적용 — 트래픽 0일 때 0/0 = NaN 방지
- 실제 Discord에서 false positive 수신 확인 후 수정

### Backup CronJob Discord 알림 
- `trap notify_failure ERR` — 백업 실패 시 빨간 embed 전송
- 백업 성공 시 `set +e` → 초록 embed 전송 (파일명, 크기, 소요시간 포함)
- curl 실패는 로그만 남기고 Job은 성공 처리 (백업 성공이 알림보다 우선)
- `DISCORD_WEBHOOK_URL`을 `grafana-secrets` secretKeyRef로 참조

### Smoke Test Real Auth 통일
- `SMOKE_TOKEN` 직접 전달 방식 → `auth.js` 모듈 + `test-accounts.json` 방식으로 통일
- Mock Auth / Real Auth 양쪽 모두 동작

### 문서
- `docs/playbook/database/backup-recovery.md` — 백업/복구 운영 Runbook (자동 백업, 수동 백업, 3단계 복구 절차, 검증 체크리스트)
- `docs/reports/2026-03-25-load-baseline.md` — Baseline 측정 보고서 (staging 60VU, RPS 39.2, p95 454ms, error 0%)

---

## Decisions & Trade-offs

### curl set +e 분리 
백업 성공 후 Discord curl이 실패하면 `set -e`에 의해 Job 전체가 실패 처리되고, `backoffLimit:2`로 pg_dump가 불필요하게 재실행되는 문제. `set +e`로 전환하여 curl 실패는 경고 로그만 남기고 Job은 성공 처리.

### noDataState: OK 전체 적용
`error-rate-high`만 아니라 cpu/heap/hikaricp 규칙에도 적용. Instance Schedule로 VM이 꺼지면 모든 actuator 메트릭이 사라지므로, 데이터 부재를 알림으로 처리하면 매일 같은 시간에 false positive가 발생.

### clamp_min vs or vector(0)
`or vector(0)` 대신 `clamp_min(분모, 1e-10)`을 사용. `or vector(0)`은 분자에만 적용되어 분모가 0일 때 여전히 NaN. `clamp_min`은 분모가 0이 되는 것을 직접 방지.

---

## Future Improvements

- Grafana Image Renderer sidecar 추가 (Optional — 알림에 대시보드 스크린샷 첨부)
- cart_add p95=595ms 병목 확인 (N+1 query, Hibernate Statistics 활용)
- Tail latency 5s+ 원인 분석 (JVM warm-up, GC pause)

---

### Linked Issues

