### PR TITLE
deploy job 수정: kubectl exec 방식 전환 및 sync retry 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,14 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              argocd login localhost:8080 --username=admin \
-                --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_STAGING }}' --insecure
-              argocd app set giftify --kustomize-image \
+              export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+              POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}')
+              sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
+                --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_STAGING }}' --insecure --plaintext
+              sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }}
-              argocd app sync giftify --prune
-              argocd app wait giftify --health --timeout 300
+              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune
+              sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 
       - name: Deploy to Prod
@@ -163,12 +165,14 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              argocd login localhost:8080 --username=admin \
-                --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_PROD }}' --insecure
-              argocd app set giftify --kustomize-image \
+              export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+              POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}')
+              sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
+                --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_PROD }}' --insecure --plaintext
+              sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }}
-              argocd app sync giftify --prune
-              argocd app wait giftify --health --timeout 300
+              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune
+              sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 
       - name: Discord Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_STAGING }}' --insecure --plaintext
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }}
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune
+              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 
@@ -171,7 +171,7 @@ jobs:
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_PROD }}' --insecure --plaintext
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }}
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune
+              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 


### PR DESCRIPTION
## Summary

#455에서 머지한 deploy job이 두 가지 문제로 실패:
1. VM 호스트에 argocd CLI가 없음 → `kubectl exec`으로 argocd-server pod 내부에서 실행하도록 변경
2. selfHeal 자동 싱크와 충돌 → `--retry-limit 3` 추가

staging VM에서 수동 테스트 완료: login → app set → sync(retry) → Pod 이미지 0.0.22 확인.

---

## What's Changed

- `argocd` 직접 호출 → `sudo kubectl exec -n argocd $POD -- argocd ...`로 변경
- `argocd app sync`에 `--retry-limit 3` 추가
- prod/staging ArgoCD 비밀번호 분리 (`ARGOCD_ADMIN_PASSWORD_PROD`, `ARGOCD_ADMIN_PASSWORD_STAGING`)

---

## Decisions & Trade-offs

- argocd-server가 ClusterIP 타입이라 VM 호스트에서 localhost:8080 접근 불가
- NodePort 변경 대신 kubectl exec 사용 — 기존 서비스 설정을 건드리지 않음
- sync retry는 selfHeal과의 race condition 대응 — 근본 해결이 아닌 우회

---

## Future Improvements

- argocd-server를 NodePort로 변경하면 kubectl exec 없이 직접 접근 가능
- selfHeal과 CI sync 충돌을 없애려면 sync 전 selfHeal 일시 비활성화 검토