### PR TITLE
argocd sync retry shell 루프 및 prod kustomize 경로 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,16 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              set -e &&
               export KUBECONFIG=/etc/rancher/k3s/k3s.yaml &&
               POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}') &&
               sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_STAGING }}' --insecure --plaintext &&
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }} &&
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3 &&
+              for i in 1 2 3; do
+                sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune && break
+                echo \"Sync attempt \$i failed, retrying in 10s...\" && sleep 10
+              done &&
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 
@@ -166,14 +168,16 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              set -e &&
               export KUBECONFIG=/etc/rancher/k3s/k3s.yaml &&
               POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}') &&
               sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_PROD }}' --insecure --plaintext &&
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }} &&
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3 &&
+              for i in 1 2 3; do
+                sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune && break
+                echo \"Sync attempt \$i failed, retrying in 10s...\" && sleep 10
+              done &&
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 


### PR DESCRIPTION
## Summary

#455~#457 이후 CI deploy job 검증에서 발견된 2개 문제 수정.

## What's Changed

1. **sync retry**: `--retry-limit 3`이 `set -e` + `&&` 환경에서 작동하지 않아 shell for 루프 3회 + 10초 대기로 교체
2. **prod kustomize 경로**: `token-blacklist-security.json`이 `../../base/` 참조로 빌드 실패 → overlay 내부로 복사