### PR TITLE
fix: overlay api-server 이미지 태그 제거 및 sync retry 개선

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,14 +149,16 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              set -e &&
               export KUBECONFIG=/etc/rancher/k3s/k3s.yaml &&
               POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}') &&
               sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_STAGING }}' --insecure --plaintext &&
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }} &&
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3 &&
+              for i in 1 2 3; do
+                sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune && break
+                echo \"Sync attempt \$i failed, retrying in 10s...\" && sleep 10
+              done &&
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 
@@ -166,14 +168,16 @@ jobs:
             --zone=asia-northeast3-a \
             --tunnel-through-iap \
             --command="
-              set -e &&
               export KUBECONFIG=/etc/rancher/k3s/k3s.yaml &&
               POD=\$(sudo kubectl get pod -n argocd -l app.kubernetes.io/name=argocd-server -o jsonpath='{.items[0].metadata.name}') &&
               sudo kubectl exec -n argocd \$POD -- argocd login localhost:8080 \
                 --username=admin --password='${{ secrets.ARGOCD_ADMIN_PASSWORD_PROD }}' --insecure --plaintext &&
               sudo kubectl exec -n argocd \$POD -- argocd app set giftify --kustomize-image \
                 ${{ env.IMAGE }}:${{ steps.tag.outputs.version }} &&
-              sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune --retry-limit 3 &&
+              for i in 1 2 3; do
+                sudo kubectl exec -n argocd \$POD -- argocd app sync giftify --prune && break
+                echo \"Sync attempt \$i failed, retrying in 10s...\" && sleep 10
+              done &&
               sudo kubectl exec -n argocd \$POD -- argocd app wait giftify --health --timeout 300
             "
 

--- a/infra/k3s/overlays/prod/kustomization.yaml
+++ b/infra/k3s/overlays/prod/kustomization.yaml
@@ -17,8 +17,6 @@ configMapGenerator:
       disableNameSuffixHash: true
 
 images:
-  - name: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server
-    newTag: latest
   - name: giftify-elasticsearch
     newName: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/elasticsearch
     newTag: 9.2.4-custom-v2

--- a/infra/k3s/overlays/staging/kustomization.yaml
+++ b/infra/k3s/overlays/staging/kustomization.yaml
@@ -8,8 +8,6 @@ generators:
   - ./secret-generator.yaml
 
 images:
-  - name: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/api-server
-    newTag: latest
   - name: giftify-elasticsearch
     newName: ghcr.io/prgrms-be-adv-devcourse/beadv4_4_team201_be/elasticsearch
     newTag: 9.2.4-custom-v2


### PR DESCRIPTION
## Summary

ArgoCD selfHeal이 `argocd app set --kustomize-image`로 설정한 이미지 태그를 overlay의 `images.newTag: latest` 기준으로 되돌리는 문제 수정.

## What's Changed

- prod/staging overlay `kustomization.yaml`에서 api-server `images` 항목 제거
- 이미지 태그 관리를 ArgoCD Application parameter(`--kustomize-image`)에 일원화
- elasticsearch 이미지 항목은 유지 (CI deploy 대상 아님)
- sync retry를 shell for 루프로 변경 (selfHeal race condition 대응)

## Decisions & Trade-offs

- overlay에서 api-server 이미지 태그를 제거하면 Git에 배포 버전이 기록되지 않음
- 대신 ArgoCD Application 상태가 배포 버전의 source of truth
- 이 방식은 플랜의 "NOT in scope: Git에 배포 버전 자동 커밋"과 일관됨