### PR TITLE
예치금 + PG 복합결제 구현

### DIFF
--- a/bc/core/src/main/java/app/giftify/facade/CoreFacade.java
+++ b/bc/core/src/main/java/app/giftify/facade/CoreFacade.java
@@ -53,7 +53,7 @@ public class CoreFacade {
     }
 
     private static @NonNull CreateFundingPaymentCommand generatePaymentCommand(OrderSnapshot orderSnapshot) {
-        return new CreateFundingPaymentCommand(
+        return CreateFundingPaymentCommand.of(
                 orderSnapshot.buyerId(),
                 orderSnapshot.orderId(),
                 orderSnapshot.orderNumber(),

--- a/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/inbound/scheduler/PaymentTimeoutScheduler.java
@@ -1,65 +1,71 @@
 package app.giftify.payment.adapter.inbound.scheduler;
 
-import static app.giftify.payment.domain.SystemConstants.*;
-
-import java.time.LocalDateTime;
-
+import app.giftify.payment.application.inbound.CancelPaymentCommand;
+import app.giftify.payment.application.inbound.CancelPaymentUseCase;
+import app.giftify.payment.application.inbound.FailPaymentUseCase;
+import app.giftify.payment.application.outbound.PaymentRepository;
+import app.giftify.payment.domain.Payment;
+import app.giftify.shared.domain.vo.Money;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import app.giftify.payment.application.inbound.CancelPaymentCommand;
-import app.giftify.payment.application.inbound.CancelPaymentUseCase;
-import app.giftify.payment.application.outbound.PaymentRepository;
-import app.giftify.payment.domain.Payment;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.LocalDateTime;
+
+import static app.giftify.payment.domain.SystemConstants.SYSTEM_REQUESTER_ID;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentTimeoutScheduler {
 
-	private static final String TIMEOUT_REASON = "TIMEOUT";
-	private static final int BATCH_SIZE = 100;
+    private static final String TIMEOUT_REASON = "TIMEOUT";
+    private static final int BATCH_SIZE = 100;
 
-	private final CancelPaymentUseCase cancelPaymentUseCase;
-	private final PaymentRepository paymentRepository;
+    private final CancelPaymentUseCase cancelPaymentUseCase;
+    private final FailPaymentUseCase failPaymentUseCase;
+    private final PaymentRepository paymentRepository;
 
-	@Value("${payment.timeout.minutes:30}")
-	private int timeoutMinutes;
+    @Value("${payment.timeout.minutes:30}")
+    private int timeoutMinutes;
 
-	@Scheduled(fixedDelayString = "${payment.timeout.check-interval:600000}")
-	public void cancelExpiredPayments() {
-		LocalDateTime threshold = LocalDateTime.now().minusMinutes(timeoutMinutes);
-		int totalCanceled = 0;
+    @Scheduled(fixedDelayString = "${payment.timeout.check-interval:600000}")
+    public void cancelExpiredPayments() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(timeoutMinutes);
+        int totalCanceled = 0;
 
-		Slice<Payment> slice;
-		do {
-			slice = paymentRepository.findPendingPaymentsBefore(threshold, PageRequest.of(0,
-				BATCH_SIZE));
+        Slice<Payment> slice;
+        do {
+            slice = paymentRepository.findPendingPaymentsBefore(threshold, PageRequest.of(0,
+                    BATCH_SIZE));
 
-			for (Payment payment : slice.getContent()) {
-				try {
-					CancelPaymentCommand command = CancelPaymentCommand.full( // 스케쥴러에 의한 취소는 완료되지 못한 결제에 대한 전액 취소이므로
-						payment.getId(),
-						SYSTEM_REQUESTER_ID,
-						TIMEOUT_REASON
-					);
-					cancelPaymentUseCase.cancel(command);
-					totalCanceled++;
-				} catch (Exception e) {
-					log.error("[Payment] 결제 자동 취소 실패. paymentId={}", payment.getId(), e);
-				}
-			}
-		} while (slice.hasNext());
+            for (Payment payment : slice.getContent()) {
+                try {
+                    if (payment.getWalletDeductedAmount().isGreaterThan(Money.zero())) {
+                        failPaymentUseCase.fail(payment);
+                    } else {
+                        CancelPaymentCommand command = CancelPaymentCommand.full(
+                                payment.getId(),
+                                SYSTEM_REQUESTER_ID,
+                                TIMEOUT_REASON
+                        );
+                        cancelPaymentUseCase.cancel(command);
+                    }
+                    totalCanceled++;
+                } catch (Exception e) {
+                    log.error("[Payment] 결제 자동 처리 실패. paymentId={}", payment.getId(), e);
+                }
+            }
+        } while (slice.hasNext());
 
-		if (totalCanceled > 0) {
-			log.info("[Payment] 만료된 결제 {}건 자동 취소 완료. threshold={}", totalCanceled,
-				threshold);
-		}
-	}
+        if (totalCanceled > 0) {
+            log.info("[Payment] 만료된 결제 {}건 자동 처리 완료. threshold={}", totalCanceled,
+                    threshold);
+        }
+    }
 
 }

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/entity/JpaPayment.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/jpa/entity/JpaPayment.java
@@ -61,6 +61,9 @@ public class JpaPayment extends BaseJpaEntity {
 	@Column(name = "refunded_amount", nullable = false, precision = 19, scale = 2)
 	private BigDecimal refundedAmount;
 
+	@Column(name = "wallet_deducted_amount", nullable = false, precision = 19, scale = 2)
+	private BigDecimal walletDeductedAmount;
+
 	@Column(name = "order_items_json", nullable = false, columnDefinition = "TEXT")
 	private String orderItemsJson;
 
@@ -92,6 +95,7 @@ public class JpaPayment extends BaseJpaEntity {
 		BigDecimal originAmount,
 		BigDecimal paidAmount,
 		BigDecimal refundedAmount,
+		BigDecimal walletDeductedAmount,
 		String orderItemsJson,
 		PaymentStatus status,
 		String paymentKey,
@@ -107,6 +111,7 @@ public class JpaPayment extends BaseJpaEntity {
 		this.originAmount = originAmount;
 		this.paidAmount = paidAmount;
 		this.refundedAmount = refundedAmount;
+		this.walletDeductedAmount = walletDeductedAmount;
 		this.orderItemsJson = orderItemsJson;
 		this.status = status;
 		this.paymentKey = paymentKey;
@@ -133,6 +138,7 @@ public class JpaPayment extends BaseJpaEntity {
 			payment.getOriginAmount().amount(),
 			payment.getPaidAmount().amount(),
 			payment.getRefundedAmount().amount(),
+			payment.getWalletDeductedAmount().amount(),
 			orderItemsJson,
 			payment.getStatus(),
 			payment.getPaymentKey(),
@@ -161,6 +167,7 @@ public class JpaPayment extends BaseJpaEntity {
 			.originAmount(Money.of(originAmount))
 			.paidAmount(Money.of(paidAmount))
 			.refundedAmount(Money.of(refundedAmount))
+			.walletDeductedAmount(Money.of(walletDeductedAmount))
 			.orderItems(java.util.Arrays.asList(orderItems))
 			.status(status)
 			.paymentKey(paymentKey)
@@ -178,6 +185,7 @@ public class JpaPayment extends BaseJpaEntity {
 		this.approveCode = payment.getApproveCode();
 		this.paidAt = payment.getPaidAt();
 		this.refundedAmount = payment.getRefundedAmount().amount();
+		this.walletDeductedAmount = payment.getWalletDeductedAmount().amount();
 		this.orderItemsJson = orderItemsJson;
 	}
 }

--- a/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsClient.java
+++ b/bc/core/src/main/java/app/giftify/payment/adapter/outbound/pg/TossPaymentsClient.java
@@ -1,14 +1,14 @@
 package app.giftify.payment.adapter.outbound.pg;
 
-import java.math.BigDecimal;
-
+import app.giftify.payment.domain.PaymentErrorCode;
+import app.giftify.payment.domain.PaymentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 
-import app.giftify.payment.domain.PaymentErrorCode;
-import app.giftify.payment.domain.PaymentException;
+import java.math.BigDecimal;
 
 /**
  * Toss Payments API 클라이언트.
@@ -19,111 +19,115 @@ import app.giftify.payment.domain.PaymentException;
 @Component
 public class TossPaymentsClient {
 
-	private static final Logger log = LoggerFactory.getLogger(TossPaymentsClient.class);
+    private static final Logger log = LoggerFactory.getLogger(TossPaymentsClient.class);
 
-	private final TossPaymentsApi tossPaymentsApi;
+    private final TossPaymentsApi tossPaymentsApi;
 
-	public TossPaymentsClient(TossPaymentsApi tossPaymentsApi) {
-		this.tossPaymentsApi = tossPaymentsApi;
-	}
+    public TossPaymentsClient(TossPaymentsApi tossPaymentsApi) {
+        this.tossPaymentsApi = tossPaymentsApi;
+    }
 
-	/**
-	 * Toss Payments 결제 승인 API를 호출합니다.
-	 *
-	 * @param paymentKey Toss SDK에서 받은 결제 키
-	 * @param orderId    서버에서 생성한 주문 ID
-	 * @param amount     결제 금액
-	 * @return 승인 결과
-	 * @throws PaymentException PG사 연결 오류 또는 승인 실패 시
-	 */
-	public TossConfirmResult confirm(String paymentKey, String orderId, BigDecimal amount) {
-		try {
-			TossPaymentsApi.TossConfirmRequest request = new TossPaymentsApi.TossConfirmRequest(
-				paymentKey,
-				orderId,
-				amount.longValue()
-			);
+    /**
+     * Toss Payments 결제 승인 API를 호출합니다.
+     *
+     * @param paymentKey Toss SDK에서 받은 결제 키
+     * @param orderId    서버에서 생성한 주문 ID
+     * @param amount     결제 금액
+     * @return 승인 결과
+     * @throws PaymentException PG사 연결 오류 또는 승인 실패 시
+     */
+    @Retryable(
+            value = PaymentException.class,
+            maxRetries = 2
+    )
+    public TossConfirmResult confirm(String paymentKey, String orderId, BigDecimal amount) {
+        try {
+            TossPaymentsApi.TossConfirmRequest request = new TossPaymentsApi.TossConfirmRequest(
+                    paymentKey,
+                    orderId,
+                    amount.longValue()
+            );
 
-			TossPaymentsApi.TossPaymentResponse response = tossPaymentsApi.confirm(request);
+            TossPaymentsApi.TossPaymentResponse response = tossPaymentsApi.confirm(request);
 
-			if (response.isSuccess()) {
-				log.info("[TossPayments] 결제 승인 성공. paymentKey={}, orderId={}", paymentKey, orderId);
-				String approveNo = response.card() != null ? response.card().approveNo() : null;
-				return TossConfirmResult.success(paymentKey, response.lastTransactionKey(), approveNo);
-			} else {
-				log.warn("[TossPayments] 결제 승인 실패. paymentKey={}, orderId={}, errorCode={}, message={}",
-					paymentKey, orderId, response.code(), response.message());
-				return TossConfirmResult.failure(response.code(), response.message());
-			}
+            if (response.isSuccess()) {
+                log.info("[TossPayments] 결제 승인 성공. paymentKey={}, orderId={}", paymentKey, orderId);
+                String approveNo = response.card() != null ? response.card().approveNo() : null;
+                return TossConfirmResult.success(paymentKey, response.lastTransactionKey(), approveNo);
+            } else {
+                log.warn("[TossPayments] 결제 승인 실패. paymentKey={}, orderId={}, errorCode={}, message={}",
+                        paymentKey, orderId, response.code(), response.message());
+                return TossConfirmResult.failure(response.code(), response.message());
+            }
 
-		} catch (HttpClientErrorException e) {
-			return handleConfirmError(e, paymentKey, orderId);
-		} catch (Exception e) {
-			log.error("[TossPayments] 결제 승인 중 예외 발생. paymentKey={}, orderId={}", paymentKey, orderId, e);
-			throw new PaymentException(PaymentErrorCode.PG_CONNECTION_ERROR,
-				"PG사 연결 중 오류가 발생했습니다: " + e.getMessage());
-		}
-	}
+        } catch (HttpClientErrorException e) {
+            return handleConfirmError(e, paymentKey, orderId);
+        } catch (Exception e) {
+            log.error("[TossPayments] 결제 승인 중 예외 발생. paymentKey={}, orderId={}", paymentKey, orderId, e);
+            throw new PaymentException(PaymentErrorCode.PG_CONNECTION_ERROR,
+                    "PG사 연결 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
 
-	private TossConfirmResult handleConfirmError(HttpClientErrorException e, String paymentKey, String orderId) {
-		log.warn("[TossPayments] 결제 승인 HTTP 오류. paymentKey={}, orderId={}, status={}, body={}",
-			paymentKey, orderId, e.getStatusCode(), e.getResponseBodyAsString());
+    private TossConfirmResult handleConfirmError(HttpClientErrorException e, String paymentKey, String orderId) {
+        log.warn("[TossPayments] 결제 승인 HTTP 오류. paymentKey={}, orderId={}, status={}, body={}",
+                paymentKey, orderId, e.getStatusCode(), e.getResponseBodyAsString());
 
-		if (e.getStatusCode().is4xxClientError()) {
-			return TossConfirmResult.failure("CLIENT_ERROR", e.getResponseBodyAsString());
-		}
+        if (e.getStatusCode().is4xxClientError()) {
+            return TossConfirmResult.failure("CLIENT_ERROR", e.getResponseBodyAsString());
+        }
 
-		throw new PaymentException(PaymentErrorCode.PG_APPROVAL_FAILED,
-			"PG사 승인 실패: " + e.getMessage());
-	}
+        throw new PaymentException(PaymentErrorCode.PG_APPROVAL_FAILED,
+                "PG사 승인 실패: " + e.getMessage());
+    }
 
-	/**
-	 * Toss Payments 결제 취소 API를 호출합니다.
-	 *
-	 * @param paymentKey   취소할 결제의 paymentKey
-	 * @param cancelReason 취소 사유
-	 * @return 취소 결과
-	 * @throws PaymentException 서버 오류 또는 연결 실패 시
-	 */
-	public TossCancelResult cancelPayment(String paymentKey, String cancelReason, Long cancelAmount) {
-		try {
-			TossPaymentsApi.TossCancelRequest request = new TossPaymentsApi.TossCancelRequest(cancelReason, cancelAmount);
+    /**
+     * Toss Payments 결제 취소 API를 호출합니다.
+     *
+     * @param paymentKey   취소할 결제의 paymentKey
+     * @param cancelReason 취소 사유
+     * @return 취소 결과
+     * @throws PaymentException 서버 오류 또는 연결 실패 시
+     */
+    public TossCancelResult cancelPayment(String paymentKey, String cancelReason, Long cancelAmount) {
+        try {
+            TossPaymentsApi.TossCancelRequest request = new TossPaymentsApi.TossCancelRequest(cancelReason, cancelAmount);
 
-			TossPaymentsApi.TossPaymentResponse response = tossPaymentsApi.cancel(paymentKey, request);
+            TossPaymentsApi.TossPaymentResponse response = tossPaymentsApi.cancel(paymentKey, request);
 
-			if (response.isSuccess()) {
-				log.info("[TossPayments] 결제 취소 성공. paymentKey={}", paymentKey);
-				var cancels = response.cancels() != null
-					? response.cancels().stream()
-						.map(c -> new TossCancelResult.CancelDetail(
-							c.transactionKey(), c.cancelAmount(), c.canceledAt()))
-						.toList()
-					: java.util.List.<TossCancelResult.CancelDetail>of();
-				return TossCancelResult.success(paymentKey, response.lastTransactionKey(), cancels);
-			} else {
-				log.warn("[TossPayments] 결제 취소 실패. paymentKey={}, errorCode={}, message={}",
-					paymentKey, response.code(), response.message());
-				return TossCancelResult.failure(response.code(), response.message());
-			}
+            if (response.isSuccess()) {
+                log.info("[TossPayments] 결제 취소 성공. paymentKey={}", paymentKey);
+                var cancels = response.cancels() != null
+                        ? response.cancels().stream()
+                        .map(c -> new TossCancelResult.CancelDetail(
+                                c.transactionKey(), c.cancelAmount(), c.canceledAt()))
+                        .toList()
+                        : java.util.List.<TossCancelResult.CancelDetail>of();
+                return TossCancelResult.success(paymentKey, response.lastTransactionKey(), cancels);
+            } else {
+                log.warn("[TossPayments] 결제 취소 실패. paymentKey={}, errorCode={}, message={}",
+                        paymentKey, response.code(), response.message());
+                return TossCancelResult.failure(response.code(), response.message());
+            }
 
-		} catch (HttpClientErrorException e) {
-			return handleCancelError(e, paymentKey);
-		} catch (Exception e) {
-			log.error("[TossPayments] 결제 취소 중 예외 발생. paymentKey={}", paymentKey, e);
-			throw new PaymentException(PaymentErrorCode.PG_CONNECTION_ERROR,
-				"PG사 연결 중 오류가 발생했습니다: " + e.getMessage());
-		}
-	}
+        } catch (HttpClientErrorException e) {
+            return handleCancelError(e, paymentKey);
+        } catch (Exception e) {
+            log.error("[TossPayments] 결제 취소 중 예외 발생. paymentKey={}", paymentKey, e);
+            throw new PaymentException(PaymentErrorCode.PG_CONNECTION_ERROR,
+                    "PG사 연결 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
 
-	private TossCancelResult handleCancelError(HttpClientErrorException e, String paymentKey) {
-		log.warn("[TossPayments] 결제 취소 HTTP 오류. paymentKey={}, status={}, body={}",
-			paymentKey, e.getStatusCode(), e.getResponseBodyAsString());
+    private TossCancelResult handleCancelError(HttpClientErrorException e, String paymentKey) {
+        log.warn("[TossPayments] 결제 취소 HTTP 오류. paymentKey={}, status={}, body={}",
+                paymentKey, e.getStatusCode(), e.getResponseBodyAsString());
 
-		if (e.getStatusCode().is4xxClientError()) {
-			return TossCancelResult.failure("CLIENT_ERROR", e.getResponseBodyAsString());
-		}
+        if (e.getStatusCode().is4xxClientError()) {
+            return TossCancelResult.failure("CLIENT_ERROR", e.getResponseBodyAsString());
+        }
 
-		throw new PaymentException(PaymentErrorCode.PG_APPROVAL_FAILED,
-			"PG사 취소 실패: " + e.getMessage());
-	}
+        throw new PaymentException(PaymentErrorCode.PG_APPROVAL_FAILED,
+                "PG사 취소 실패: " + e.getMessage());
+    }
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/ConfirmPaymentService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/ConfirmPaymentService.java
@@ -1,10 +1,5 @@
 package app.giftify.payment.application;
 
-import java.time.LocalDateTime;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import app.giftify.payment.adapter.outbound.pg.TossConfirmResult;
 import app.giftify.payment.application.inbound.ConfirmPaymentCommand;
 import app.giftify.payment.application.inbound.ConfirmPaymentResult;
@@ -16,8 +11,11 @@ import app.giftify.payment.domain.Payment;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
 import app.giftify.shared.domain.event.EventPublisher;
-
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 /**
  * 결제 승인 UseCase 구현체.
@@ -75,8 +73,15 @@ public class ConfirmPaymentService implements ConfirmPaymentUseCase {
 		);
 
 		if (!pgResult.success()) {
-			log.warn("[ConfirmPaymentService] PG 승인 실패. errorCode={}, errorMessage={}",
-				pgResult.errorCode(), pgResult.errorMessage());
+			log.warn("[ConfirmPaymentService] PG 승인 실패. paymentId={}, errorCode={}, errorMessage={}",
+					payment.getId(), pgResult.errorCode(), pgResult.errorMessage());
+
+			payment.markAsFailed(LocalDateTime.now());
+
+			var domainEvents = payment.pullEvents();
+			paymentRepository.save(payment);
+			domainEvents.forEach(eventPublisher::publish);
+
 			return ConfirmPaymentResult.failure(pgResult.errorCode(), pgResult.errorMessage());
 		}
 

--- a/bc/core/src/main/java/app/giftify/payment/application/CreatePaymentService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/CreatePaymentService.java
@@ -1,171 +1,210 @@
 package app.giftify.payment.application;
 
-import java.util.Collections;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import app.giftify.payment.application.inbound.ChargeDepositCommand;
-import app.giftify.payment.application.inbound.ChargeDepositUseCase;
-import app.giftify.payment.application.inbound.CreateFundingPaymentCommand;
-import app.giftify.payment.application.inbound.CreateFundingPaymentUseCase;
-import app.giftify.payment.application.inbound.PaymentCreatedResult;
+import app.giftify.payment.application.inbound.*;
 import app.giftify.payment.application.outbound.PaymentRepository;
-import app.giftify.payment.domain.Payment;
-import app.giftify.payment.domain.PaymentCreateContext;
-import app.giftify.payment.domain.PaymentErrorCode;
-import app.giftify.payment.domain.PaymentException;
-import app.giftify.payment.domain.PaymentStatus;
+import app.giftify.payment.domain.*;
 import app.giftify.shared.domain.type.PaymentMethod;
 import app.giftify.shared.domain.type.PaymentType;
+import app.giftify.shared.domain.vo.Money;
 import app.giftify.wallet.application.inbound.DeductWalletCommand;
 import app.giftify.wallet.application.inbound.DeductWalletResult;
 import app.giftify.wallet.application.inbound.DeductWalletUseCase;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
 
 @Slf4j
 @Service
 @Transactional
 public class CreatePaymentService implements ChargeDepositUseCase, CreateFundingPaymentUseCase {
-	private final PaymentRepository paymentRepository;
-	private final DeductWalletUseCase deductWalletUseCase;
+    private final PaymentRepository paymentRepository;
+    private final DeductWalletUseCase deductWalletUseCase;
 
-	public CreatePaymentService(PaymentRepository paymentRepository, DeductWalletUseCase deductWalletUseCase) {
-		this.paymentRepository = paymentRepository;
-		this.deductWalletUseCase = deductWalletUseCase;
-	}
+    public CreatePaymentService(PaymentRepository paymentRepository, DeductWalletUseCase deductWalletUseCase) {
+        this.paymentRepository = paymentRepository;
+        this.deductWalletUseCase = deductWalletUseCase;
+    }
 
-	//--------- ChargeDepositUseCase 구현 - 예치금 충전 ----------//
+    //--------- ChargeDepositUseCase 구현 - 예치금 충전 ----------//
 
-	@Override
-	public PaymentCreatedResult charge(ChargeDepositCommand command) {
-		return paymentRepository.findByOrderNumber(command.orderNumber())
-			.map(existing -> new PaymentCreatedResult(
-				existing.getId(),
-				existing.getOrderNumber(),
-				existing.getStatus(),
-				existing.getPaymentKey(),
-				existing.getLastTransactionKey(),
-				existing.getCreatedAt()
-			))
-			.orElseGet(() -> createDepositChargePayment(command));
-	}
+    @Override
+    public PaymentCreatedResult charge(ChargeDepositCommand command) {
+        return paymentRepository.findByOrderNumber(command.orderNumber())
+                .map(existing -> new PaymentCreatedResult(
+                        existing.getId(),
+                        existing.getOrderNumber(),
+                        existing.getStatus(),
+                        existing.getPaymentKey(),
+                        existing.getLastTransactionKey(),
+                        existing.getCreatedAt()
+                ))
+                .orElseGet(() -> createDepositChargePayment(command));
+    }
 
-	private PaymentCreatedResult createDepositChargePayment(ChargeDepositCommand command) {
-		PaymentCreateContext context = new PaymentCreateContext(
-			command.memberId(),
-			null,
-			command.orderNumber(),
-			PaymentType.DEPOSIT_CHARGE,
-			PaymentMethod.CARD
-		);
+    private PaymentCreatedResult createDepositChargePayment(ChargeDepositCommand command) {
+        PaymentCreateContext context = new PaymentCreateContext(
+                command.memberId(),
+                null,
+                command.orderNumber(),
+                PaymentType.DEPOSIT_CHARGE,
+                PaymentMethod.CARD
+        );
 
-		Payment payment = Payment.create(
-			context,
-			command.amount(),
-			command.amount(),
-			Collections.emptyList()
-		);
+        Payment payment = Payment.create(
+                context,
+                command.amount(),
+                command.amount(),
+                Collections.emptyList()
+        );
 
-		Payment savedPayment = paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
 
-		log.info("[Payment] 예치금 충전 결제 생성. paymentId={}, orderId={}, amount={}",
-			savedPayment.getId(), savedPayment.getOrderNumber(), command.amount());
+        log.info("[Payment] 예치금 충전 결제 생성. paymentId={}, orderId={}, amount={}",
+                savedPayment.getId(), savedPayment.getOrderNumber(), command.amount());
 
-		return new PaymentCreatedResult(
-			savedPayment.getId(),
-			savedPayment.getOrderNumber(),
-			savedPayment.getStatus(),
-			savedPayment.getPaymentKey(),
-			savedPayment.getLastTransactionKey(),
-			savedPayment.getCreatedAt()
-		);
-	}
+        return new PaymentCreatedResult(
+                savedPayment.getId(),
+                savedPayment.getOrderNumber(),
+                savedPayment.getStatus(),
+                savedPayment.getPaymentKey(),
+                savedPayment.getLastTransactionKey(),
+                savedPayment.getCreatedAt()
+        );
+    }
 
-	//--------- CreateFundingPaymentUseCase 구현 - 펀딩 결제 ----------//
+    //--------- CreateFundingPaymentUseCase 구현 - 펀딩 결제 ----------//
 
-	@Override
-	public PaymentCreatedResult create(CreateFundingPaymentCommand command) {
-		return paymentRepository.findByOrderNumber(command.orderNumber())
-			.map(existing -> new PaymentCreatedResult(
-				existing.getId(),
-				existing.getOrderNumber(),
-				existing.getStatus(),
-				existing.getPaymentKey(),
-				existing.getLastTransactionKey(),
-				existing.getCreatedAt()
-			))
-			.orElseGet(() -> createFundingPayment(command));
-	}
+    @Override
+    public PaymentCreatedResult create(CreateFundingPaymentCommand command) {
+        return paymentRepository.findByOrderNumber(command.orderNumber())
+                .map(existing -> new PaymentCreatedResult(
+                        existing.getId(),
+                        existing.getOrderNumber(),
+                        existing.getStatus(),
+                        existing.getPaymentKey(),
+                        existing.getLastTransactionKey(),
+                        existing.getCreatedAt()
+                ))
+                .orElseGet(() -> createFundingPayment(command));
+    }
 
-	private PaymentCreatedResult createFundingPayment(CreateFundingPaymentCommand command) {
-		// PaymentCreateContext 생성
-		PaymentCreateContext context = new PaymentCreateContext(
-			command.memberId(),
-			command.orderId(),
-			command.orderNumber(),
-			command.getType(),
-			command.method()
-		);
+    private PaymentCreatedResult createFundingPayment(CreateFundingPaymentCommand command) {
+        // PaymentCreateContext 생성
+        PaymentCreateContext context = new PaymentCreateContext(
+                command.memberId(),
+                command.orderId(),
+                command.orderNumber(),
+                command.getType(),
+                command.method()
+        );
 
-		Payment payment = Payment.create(
-			context,
-			command.expectedAmount(),
-			command.expectedAmount(),
-			command.orderItems()
-		);
+        Payment payment = Payment.create(
+                context,
+                command.expectedAmount(),
+                command.expectedAmount(),
+                command.walletDeductAmount(),
+                command.orderItems()
+        );
 
-		Payment savedPayment = paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
 
-		// 내부 지갑 결제(예치금)면 즉시 처리
-		if (command.method().isWalletPayment()) {
-			return handleWalletPaymentForFunding(savedPayment, command);
-		}
+        // 내부 지갑 결제(예치금)면 즉시 처리
+        if (command.method().isWalletPayment()) {
+            return handleWalletPaymentForFunding(savedPayment, command);
+        }
 
-		log.info("[Payment] 펀딩 결제 생성. paymentId={}, orderId={}, amount={}",
-			savedPayment.getId(), savedPayment.getOrderNumber(), command.expectedAmount());
+        // 복합결제: walletDeductAmount > 0 이고 PG 결제 수단
+        if (command.walletDeductAmount().isGreaterThan(Money.zero())) {
+            // pgAmount==0이면 기존 Wallet 흐름으로 위임
+            if (command.walletDeductAmount().equals(command.expectedAmount())) {
+                return handleWalletPaymentForFunding(savedPayment, command);
+            }
+            return handleCompositePaymentForFunding(savedPayment, command);
+        }
 
-		return new PaymentCreatedResult(
-			savedPayment.getId(),
-			savedPayment.getOrderNumber(),
-			savedPayment.getStatus(),
-			savedPayment.getPaymentKey(),
-			savedPayment.getLastTransactionKey(),
-			savedPayment.getCreatedAt()
-		);
-	}
 
-	private PaymentCreatedResult handleWalletPaymentForFunding(Payment payment, CreateFundingPaymentCommand command) {
-		DeductWalletCommand deductCommand = new DeductWalletCommand(
-			command.memberId(),
-			payment.getId(),
-			command.orderNumber(),
-			command.expectedAmount()
-		);
+        log.info("[Payment] 펀딩 결제 생성. paymentId={}, orderId={}, amount={}",
+                savedPayment.getId(), savedPayment.getOrderNumber(), command.expectedAmount());
 
-		DeductWalletResult result = deductWalletUseCase.deductForPayment(deductCommand);
+        return new PaymentCreatedResult(
+                savedPayment.getId(),
+                savedPayment.getOrderNumber(),
+                savedPayment.getStatus(),
+                savedPayment.getPaymentKey(),
+                savedPayment.getLastTransactionKey(),
+                savedPayment.getCreatedAt()
+        );
+    }
 
-		if (!result.success()) {
-			log.warn("[Payment] 예치금 잔액 부족. paymentId={}, required={}, current={}",
-				payment.getId(), result.requiredAmount(), result.currentBalance());
+    private PaymentCreatedResult handleWalletPaymentForFunding(Payment payment, CreateFundingPaymentCommand command) {
+        DeductWalletCommand deductCommand = new DeductWalletCommand(
+                command.memberId(),
+                payment.getId(),
+                command.orderNumber(),
+                command.expectedAmount()
+        );
 
-			throw new PaymentException(
-				PaymentErrorCode.INSUFFICIENT_WALLET_BALANCE,
-				String.format("필요 금액: %s, 현재 잔액: %s",
-					result.requiredAmount(), result.currentBalance())
-			);
-		}
+        DeductWalletResult result = deductWalletUseCase.deductForPayment(deductCommand);
 
-		log.info("[Payment] 예치금 결제 요청 완료. paymentId={}, walletId={}",
-			payment.getId(), result.walletId());
+        if (!result.success()) {
+            log.warn("[Payment] 예치금 잔액 부족. paymentId={}, required={}, current={}",
+                    payment.getId(), result.requiredAmount(), result.currentBalance());
 
-		return new PaymentCreatedResult(
-			payment.getId(),
-			payment.getOrderNumber(),
-			PaymentStatus.PENDING,
-			payment.getPaymentKey(),
-			payment.getLastTransactionKey(),
-			payment.getCreatedAt()
-		);
-	}
+            throw new PaymentException(
+                    PaymentErrorCode.INSUFFICIENT_WALLET_BALANCE,
+                    String.format("필요 금액: %s, 현재 잔액: %s",
+                            result.requiredAmount(), result.currentBalance())
+            );
+        }
+
+        log.info("[Payment] 예치금 결제 요청 완료. paymentId={}, walletId={}",
+                payment.getId(), result.walletId());
+
+        return new PaymentCreatedResult(
+                payment.getId(),
+                payment.getOrderNumber(),
+                PaymentStatus.PENDING,
+                payment.getPaymentKey(),
+                payment.getLastTransactionKey(),
+                payment.getCreatedAt()
+        );
+    }
+
+    private PaymentCreatedResult handleCompositePaymentForFunding(Payment payment, CreateFundingPaymentCommand command) {
+        DeductWalletCommand deductCommand = new DeductWalletCommand(
+                command.memberId(),
+                payment.getId(),
+                command.orderNumber(),
+                command.walletDeductAmount()
+        );
+
+        DeductWalletResult result = deductWalletUseCase.deductForPayment(deductCommand);
+
+        if (!result.success()) {
+            log.warn("[Payment] 복합결제 예치금 잔액 부족. paymentId={}, required={}, current={}",
+                    payment.getId(), result.requiredAmount(), result.currentBalance());
+
+            throw new PaymentException(
+                    PaymentErrorCode.INSUFFICIENT_WALLET_BALANCE,
+                    String.format("필요 금액: %s, 현재 잔액: %s",
+                            result.requiredAmount(), result.currentBalance())
+            );
+        }
+
+        log.info("[Payment] 복합결제 예치금 차감 완료. paymentId={}, walletDeduct={}, pgAmount={}",
+                payment.getId(), command.walletDeductAmount(),
+                command.expectedAmount().minus(command.walletDeductAmount()));
+
+        return new PaymentCreatedResult(
+                payment.getId(),
+                payment.getOrderNumber(),
+                PaymentStatus.PENDING,
+                payment.getPaymentKey(),
+                payment.getLastTransactionKey(),
+                payment.getCreatedAt()
+        );
+    }
+
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/PaymentFailService.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/PaymentFailService.java
@@ -1,0 +1,29 @@
+package app.giftify.payment.application;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import app.giftify.payment.application.inbound.FailPaymentUseCase;
+import app.giftify.payment.application.outbound.PaymentRepository;
+import app.giftify.payment.domain.Payment;
+import app.giftify.shared.domain.event.EventPublisher;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFailService implements FailPaymentUseCase {
+
+	private final PaymentRepository paymentRepository;
+	private final EventPublisher eventPublisher;
+
+	@Override
+	@Transactional
+	public void fail(Payment payment) {
+		payment.markAsFailed(LocalDateTime.now());
+		var domainEvents = payment.pullEvents();
+		paymentRepository.save(payment);
+		domainEvents.forEach(eventPublisher::publish);
+	}
+}

--- a/bc/core/src/main/java/app/giftify/payment/application/inbound/CreateFundingPaymentCommand.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/inbound/CreateFundingPaymentCommand.java
@@ -1,7 +1,5 @@
 package app.giftify.payment.application.inbound;
 
-import java.util.List;
-
 import app.giftify.payment.domain.OrderItemSnapshot;
 import app.giftify.payment.domain.PaymentErrorCode;
 import app.giftify.payment.domain.PaymentException;
@@ -9,53 +7,84 @@ import app.giftify.shared.domain.type.PaymentMethod;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 
+import java.util.List;
+
 public record CreateFundingPaymentCommand(
-	Long memberId,
-	Long orderId,
-	String orderNumber,
-	PaymentMethod method,
-	Money expectedAmount,
-	List<OrderItemSnapshot> orderItems
+        Long memberId,
+        Long orderId,
+        String orderNumber,
+        PaymentMethod method,
+        Money expectedAmount,
+        Money walletDeductAmount,
+        List<OrderItemSnapshot> orderItems
 ) {
-	public CreateFundingPaymentCommand {
-		if (memberId == null) {
-			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-				"[CreateFundingPaymentCommand] memberId는 필수입니다.");
-		}
-		if (orderNumber == null || orderNumber.isBlank()) {
-			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-				"[CreateFundingPaymentCommand] orderNumber는 필수입니다.");
-		}
-		if (method == null) {
-			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-				"[CreateFundingPaymentCommand] method는 필수입니다.");
-		}
-		if (orderItems == null || orderItems.isEmpty()) {
-			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-				"[CreateFundingPaymentCommand] orderItems는 필수입니다.");
-		}
-		if (expectedAmount == null) {
-			throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-				"[CreateFundingPaymentCommand] expectedAmount는 필수입니다.");
-		}
+    public CreateFundingPaymentCommand {
+        if (memberId == null) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] memberId는 필수입니다.");
+        }
+        if (orderNumber == null || orderNumber.isBlank()) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] orderNumber는 필수입니다.");
+        }
+        if (method == null) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] method는 필수입니다.");
+        }
+        if (orderItems == null || orderItems.isEmpty()) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] orderItems는 필수입니다.");
+        }
+        if (expectedAmount == null) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] expectedAmount는 필수입니다.");
+        }
+        if (walletDeductAmount == null) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] walletDeductAmount는 필수입니다.");
+        }
+        if (walletDeductAmount.isGreaterThan(expectedAmount)) {
+            throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                    "[CreateFundingPaymentCommand] walletDeductAmount는 expectedAmount를 초과할 수 없습니다.");
+        }
 
-		// 실제 금액 계산 및 검증
-		Money itemsTotal = orderItems.stream()
-			.map(OrderItemSnapshot::amount)
-			.reduce(Money.zero(), Money::plus);
 
-		if (!itemsTotal.equals(expectedAmount)) {
-			throw new PaymentException(PaymentErrorCode.AMOUNT_MISMATCH,
-				String.format("[CreateFundingPaymentCommand] 주문 금액이 변경되었습니다. " +
-					"기대 금액: %s, 현재 금액: %s", expectedAmount, itemsTotal));
-		}
-	}
+        // 실제 금액 계산 및 검증
+        Money itemsTotal = orderItems.stream()
+                .map(OrderItemSnapshot::amount)
+                .reduce(Money.zero(), Money::plus);
 
-	/**
-	 * 펀딩 결제의 PaymentType은 항상 FUNDING
-	 */
-	public PaymentType getType() {
-		return PaymentType.FUNDING;
-	}
+        if (!itemsTotal.equals(expectedAmount)) {
+            throw new PaymentException(PaymentErrorCode.AMOUNT_MISMATCH,
+                    String.format("[CreateFundingPaymentCommand] 주문 금액이 변경되었습니다. " +
+                            "기대 금액: %s, 현재 금액: %s", expectedAmount, itemsTotal));
+        }
+    }
+
+    public static CreateFundingPaymentCommand of(
+            Long memberId, Long orderId, String orderNumber,
+            PaymentMethod method, Money expectedAmount, List<OrderItemSnapshot> orderItems
+    ) {
+        return new CreateFundingPaymentCommand(
+                memberId, orderId, orderNumber, method, expectedAmount,
+                Money.zero(), orderItems);
+    }
+
+    public static CreateFundingPaymentCommand withWalletDeduct(
+            Long memberId, Long orderId, String orderNumber,
+            PaymentMethod method, Money expectedAmount, Money walletDeductAmount,
+            List<OrderItemSnapshot> orderItems
+    ) {
+        return new CreateFundingPaymentCommand(
+                memberId, orderId, orderNumber, method, expectedAmount,
+                walletDeductAmount, orderItems);
+    }
+
+    /**
+     * 펀딩 결제의 PaymentType은 항상 FUNDING
+     */
+    public PaymentType getType() {
+        return PaymentType.FUNDING;
+    }
 
 }

--- a/bc/core/src/main/java/app/giftify/payment/application/inbound/FailPaymentUseCase.java
+++ b/bc/core/src/main/java/app/giftify/payment/application/inbound/FailPaymentUseCase.java
@@ -1,0 +1,7 @@
+package app.giftify.payment.application.inbound;
+
+import app.giftify.payment.domain.Payment;
+
+public interface FailPaymentUseCase {
+	void fail(Payment payment);
+}

--- a/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
+++ b/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
@@ -1,479 +1,510 @@
 package app.giftify.payment.domain;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Objects;
-
 import app.giftify.shared.domain.base.BaseDomainModel;
-import app.giftify.shared.domain.event.payment.PaymentCancelFailedEvent;
-import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
-import app.giftify.shared.domain.event.payment.PaymentEventData;
-import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
-import app.giftify.shared.domain.event.payment.PaymentSucceededEvent;
+import app.giftify.shared.domain.event.payment.*;
 import app.giftify.shared.domain.type.CancelType;
 import app.giftify.shared.domain.type.PaymentMethod;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
 public class Payment extends BaseDomainModel {
-	private final PaymentType type;
-	private final PaymentMethod method;
-	private final Long orderId;
-	private final String orderNumber;
-	private final Long memberId;
-	private final Money originAmount;
-	private final Money paidAmount;
-	private Money refundedAmount;
-	private final List<OrderItemSnapshot> orderItems;
-
-	private PaymentStatus status;
-	private String paymentKey;
-	private String lastTransactionKey;
-	private String approveCode;
-	// 도메인이 스냅샷으로 들고 있되, 생성은 JPA에 위임
-	private LocalDateTime paidAt;
-	private final LocalDateTime createdAt;
-
-	private Payment(Long id, PaymentType type, PaymentMethod method,
-		Long orderId, String orderNumber, Long memberId,
-		Money originAmount, Money paidAmount, Money refundedAmount, List<OrderItemSnapshot> orderItems,
-		PaymentStatus status, String paymentKey, String lastTransactionKey, String approveCode,
-		LocalDateTime paidAt, LocalDateTime createdAt
-	) {
-		super(id);
-		this.orderId = orderId;
-		this.orderNumber = orderNumber;
-		this.memberId = memberId;
-		this.type = type;
-		this.method = method;
-		this.originAmount = originAmount;
-		this.paidAmount = paidAmount;
-		this.refundedAmount = refundedAmount != null ? refundedAmount : Money.zero();
-		this.orderItems = List.copyOf(orderItems);
-		this.status = status;
-		this.paymentKey = paymentKey;
-		this.lastTransactionKey = lastTransactionKey;
-		this.approveCode = approveCode;
-		this.paidAt = paidAt;
-		this.createdAt = createdAt;
-	}
-
-	// ========== 정적 팩토리 메서드 ========== //
-
-	public static Builder builder() {
-		return new Builder();
-	}
-
-	// ========== 상태 변경 메서드 ========== //
-
-	public void markAsPaid(String paymentKey, String approveCode, String lastTransactionKey, LocalDateTime paidAt) {
-		if (!PaymentEventType.PAID.canApply(this.status)) {
-			throw new PaymentException(PaymentErrorCode.NOT_PAYABLE,
-				"[Payment] 결제 완료 불가능한 상태입니다: " + this.status);
-		}
-		this.status = PaymentEventType.PAID.getResultStatus();
-		this.paymentKey = paymentKey;
-		this.approveCode = approveCode;
-		this.lastTransactionKey = lastTransactionKey;
-		this.paidAt = paidAt;
-
-		registerEvent(PaymentSucceededEvent.create(
-			PaymentEventData.forSuccess(
-				getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
-				getMethod(), getType(), paymentKey, lastTransactionKey
-			)
-		));
-	}
-
-	// charged (PAID, PARTIALLY_CANCELED) -> REFUND, uncharged (PENDING) -> CANCEL
-	public CancelType resolveCancelType() {
-		return (this.status == PaymentStatus.PAID || this.status == PaymentStatus.PARTIALLY_CANCELED)
-			? CancelType.REFUND
-			: CancelType.CANCEL;
-	}
-
-	public void markAsCanceled(CancelType cancelType, String reason) {
-		PaymentEventType eventType = (cancelType == CancelType.REFUND)
-			? PaymentEventType.CANCEL_AFTER_PAID
-			: PaymentEventType.CANCELED;
-
-		if (!eventType.canApply(this.status)) {
-			throw new PaymentException(PaymentErrorCode.NOT_CANCELABLE,
-				"[Payment] 취소 불가능한 상태입니다: " + this.status);
-		}
-		this.status = eventType.getResultStatus();
-
-		registerEvent(PaymentCanceledEvent.create(
-			PaymentEventData.forCancel(
-				getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
-				getMethod(), getType(), cancelType, reason, this.lastTransactionKey
-			)
-		));
-	}
-
-	public void markAsPartiallyCanceled(String newTransactionKey, Money cancelAmount, CancelType cancelType, String reason) {
-		Money newRefundedTotal = this.refundedAmount.plus(cancelAmount);
-
-		PaymentEventType eventType = getCancelingEventType(newRefundedTotal);
-
-		if (!eventType.canApply(this.status)) {
-			throw new PaymentException(PaymentErrorCode.NOT_CANCELABLE,
-				"[Payment] 취소 불가능한 상태입니다: " + this.status);
-		}
-
-		this.status = eventType.getResultStatus();
-		this.refundedAmount = newRefundedTotal;
-		this.lastTransactionKey = newTransactionKey;
-
-		registerEvent(PaymentCanceledEvent.create(
-			PaymentEventData.forCancel(
-				getId(), getOrderId(), getMemberId(), getOrderNumber(),
-				cancelAmount,
-				getMethod(), getType(), cancelType, reason,
-				newTransactionKey
-			)
-		));
-	}
-
-	private PaymentEventType getCancelingEventType(Money money) {
-		PaymentEventType eventType;
-		if (money.equals(this.paidAmount)) {
-			eventType = (this.status == PaymentStatus.PARTIALLY_CANCELED)
-				? PaymentEventType.FINAL_CANCEL
-				: PaymentEventType.CANCEL_AFTER_PAID;
-		} else if (money.isLessThan(this.paidAmount)) {
-			eventType = (this.status == PaymentStatus.PARTIALLY_CANCELED)
-				? PaymentEventType.PARTIAL_CANCEL_AGAIN
-				: PaymentEventType.PARTIAL_CANCEL;
-		} else {
-			throw new PaymentException(PaymentErrorCode.CANCEL_AMOUNT_EXCEEDED,
-				"[Payment] 취소 금액이 결제 금액을 초과합니다.");
-		}
-		return eventType;
-	}
-
-	public void markAsFailed(LocalDateTime occurredAt) {
-		if (!PaymentEventType.FAILED.canApply(this.status)) {
-			throw new PaymentException(PaymentErrorCode.NOT_FAILABLE,
-				"[Payment] 대기 중인 결제만 실패 처리할 수 있습니다. 현재 상태: " + this.status);
-		}
-		this.status = PaymentEventType.FAILED.getResultStatus();
-
-		registerEvent(PaymentFailedEvent.create(
-			PaymentEventData.forFailure(
-				getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
-				getMethod(), getType()
-			)
-		));
-	}
-
-	public void recordCancelFailed(String errorMetadata, LocalDateTime occurredAt) {
-		if (!PaymentEventType.CANCEL_FAILED.canApply(this.status)) {
-			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_STATUS,
-				"[Payment] 취소 실패 기록은 PAID 상태에서만 가능합니다. 현재 상태: " + this.status);
-		}
-
-		registerEvent(PaymentCancelFailedEvent.create(
-			PaymentEventData.forCancelFailed(
-				getId(), getOrderId(), getMemberId(), getOrderNumber(),
-				getMethod(), getType(), errorMetadata
-			)
-		));
-	}
-
-	// ========== 상태 조회 메서드 ========== //
-
-	public boolean isCancelable() {
-		return PaymentEventType.CANCELED.canApply(this.status);
-	}
-
-	/**
-	 * 해당 회원이 이 결제의 소유자인지 확인합니다.
-	 *
-	 * @param requesterId 요청자 회원 ID
-	 * @return 소유자이면 true
-	 */
-	public boolean isOwnedBy(Long requesterId) {
-		return this.memberId != null && this.memberId.equals(requesterId);
-	}
-
-	// ========== Getter ========== //
-
-	public Long getOrderId() {
-		return orderId;
-	}
-
-	public String getOrderNumber() {
-		return orderNumber;
-	}
-
-	public Long getMemberId() {
-		return memberId;
-	}
-
-	public Money getOriginAmount() {
-		return originAmount;
-	}
-
-	public Money getPaidAmount() {
-		return paidAmount;
-	}
-
-	public Money getRefundedAmount() {
-		return refundedAmount;
-	}
-
-	public List<OrderItemSnapshot> getOrderItems() {
-		return orderItems;
-	}
-
-	public PaymentStatus getStatus() {
-		return status;
-	}
-
-	public PaymentType getType() {
-		return type;
-	}
-
-	public PaymentMethod getMethod() {
-		return method;
-	}
-
-	public String getPaymentKey() {
-		return paymentKey;
-	}
-
-	public String getLastTransactionKey() {
-		return lastTransactionKey;
-	}
-
-	public String getApproveCode() {
-		return approveCode;
-	}
-
-	public LocalDateTime getPaidAt() {
-		return paidAt;
-	}
-
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-
-	// ========== equals / hashCode ========== //
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (!(o instanceof Payment payment))
-			return false;
-		if (getId() != null && payment.getId() != null) {
-			return Objects.equals(getId(), payment.getId());
-		}
-		return Objects.equals(orderNumber, payment.orderNumber);
-	}
-
-	@Override
-	public int hashCode() {
-		if (getId() != null) {
-			return Objects.hash(getId());
-		}
-		return Objects.hash(orderNumber);
-	}
-
-	// ========== Builder ========== //
-
-	public static class Builder {
-		private Long id;
-		private Long orderId;
-		private String orderNumber;
-		private Long memberId;
-		private Money originAmount;
-		private Money paidAmount;
-		private Money refundedAmount;
-		private List<OrderItemSnapshot> orderItems;
-		private PaymentStatus status;
-		private PaymentType type;
-		private PaymentMethod method;
-		private String paymentKey;
-		private String lastTransactionKey;
-		private String approveCode;
-		private LocalDateTime paidAt;
-		private LocalDateTime createdAt;
-
-		public Builder id(Long id) {
-			this.id = id;
-			return this;
-		}
-
-		public Builder orderId(Long orderId) {
-			this.orderId = orderId;
-			return this;
-		}
-
-		public Builder orderNumber(String orderNumber) {
-			this.orderNumber = orderNumber;
-			return this;
-		}
-
-		public Builder memberId(Long memberId) {
-			this.memberId = memberId;
-			return this;
-		}
-
-		public Builder originAmount(Money originAmount) {
-			this.originAmount = originAmount;
-			return this;
-		}
-
-		public Builder paidAmount(Money paidAmount) {
-			this.paidAmount = paidAmount;
-			return this;
-		}
-
-		public Builder refundedAmount(Money refundedAmount) {
-			this.refundedAmount = refundedAmount;
-			return this;
-		}
-
-		public Builder orderItems(List<OrderItemSnapshot> orderItems) {
-			this.orderItems = orderItems;
-			return this;
-		}
-
-		public Builder status(PaymentStatus status) {
-			this.status = status;
-			return this;
-		}
-
-		public Builder type(PaymentType type) {
-			this.type = type;
-			return this;
-		}
-
-		public Builder method(PaymentMethod method) {
-			this.method = method;
-			return this;
-		}
-
-		public Builder paymentKey(String paymentKey) {
-			this.paymentKey = paymentKey;
-			return this;
-		}
-
-		public Builder lastTransactionKey(String lastTransactionKey) {
-			this.lastTransactionKey = lastTransactionKey;
-			return this;
-		}
-
-		public Builder approveCode(String approveCode) {
-			this.approveCode = approveCode;
-			return this;
-		}
-
-		public Builder paidAt(LocalDateTime paidAt) {
-			this.paidAt = paidAt;
-			return this;
-		}
-
-		public Builder createdAt(LocalDateTime createdAt) {
-			this.createdAt = createdAt;
-			return this;
-		}
-
-		public Payment build() {
-			validate();
-			return new Payment(
-				id,
-				type, method,
-				orderId, orderNumber, memberId,
-				originAmount, paidAmount, refundedAmount, orderItems,
-				status, paymentKey, lastTransactionKey, approveCode,
-				paidAt, createdAt
-			);
-		}
-
-		private void validate() {
-			validateRequiredFields();
-			validateAmountInvariant();
-			validateOrderItemsIfRequired();
-		}
-
-		private void validateRequiredFields() {
-			requireNonBlank(orderNumber, "orderNumber");
-			requireNonNull(memberId, "memberId");
-			requireNonNull(type, "type");
-			requireNonNull(method, "method");
-			requireNonNull(originAmount, "originAmount");
-			requireNonNull(paidAmount, "paidAmount");
-			requireNonNull(status, "status");
-		}
-
-		private void requireNonBlank(String value, String fieldName) {
-			if (value == null || value.isBlank()) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] " + fieldName + "는 필수입니다.");
-			}
-		}
-
-		private void requireNonNull(Object value, String fieldName) {
-			if (value == null) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] " + fieldName + "는 필수입니다.");
-			}
-		}
-
-		private void validateAmountInvariant() {
-			if (paidAmount.isGreaterThan(originAmount)) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] paidAmount는 originAmount를 초과할 수 없습니다.");
-			}
-			Money effectiveRefundedAmount = refundedAmount != null ? refundedAmount : Money.zero();
-			if (effectiveRefundedAmount.isGreaterThan(paidAmount)) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] refundedAmount는 paidAmount를 초과할 수 없습니다.");
-			}
-		}
-
-		private void validateOrderItemsIfRequired() {
-			if (type == PaymentType.DEPOSIT_CHARGE) {
-				return;
-			}
-
-			if (orderItems == null || orderItems.isEmpty()) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] orderItems는 필수입니다.");
-			}
-
-			Money itemsTotal = orderItems.stream()
-				.map(OrderItemSnapshot::amount)
-				.reduce(Money.zero(), Money::plus);
-
-			if (!itemsTotal.equals(originAmount)) {
-				throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
-					"[Payment] orderItems 합계와 originAmount가 일치하지 않습니다.");
-			}
-		}
-	}
-
-	// ========== 정적 팩토리 메서드  ========== //
-
-	public static Payment create(
-		PaymentCreateContext context,
-		Money originAmount,
-		Money paidAmount,
-		List<OrderItemSnapshot> orderItems
-	) {
-		return builder()
-			.orderId(context.orderId())
-			.orderNumber(context.orderNumber())
-			.memberId(context.memberId())
-			.type(context.type())
-			.method(context.method())
-			.originAmount(originAmount)
-			.paidAmount(paidAmount)
-			.orderItems(orderItems)
-			.status(PaymentStatus.PENDING)
-			.build();
-	}
+    private final PaymentType type;
+    private final PaymentMethod method;
+    private final Long orderId;
+    private final String orderNumber;
+    private final Long memberId;
+    private final Money originAmount;
+    private final Money paidAmount;
+    private Money refundedAmount;
+    private final Money walletDeductedAmount;
+    private final List<OrderItemSnapshot> orderItems;
+
+    private PaymentStatus status;
+    private String paymentKey;
+    private String lastTransactionKey;
+    private String approveCode;
+    // 도메인이 스냅샷으로 들고 있되, 생성은 JPA에 위임
+    private LocalDateTime paidAt;
+    private final LocalDateTime createdAt;
+
+    private Payment(Long id, PaymentType type, PaymentMethod method,
+                    Long orderId, String orderNumber, Long memberId,
+                    Money originAmount, Money paidAmount, Money refundedAmount, Money walletDeductedAmount, List<OrderItemSnapshot> orderItems,
+                    PaymentStatus status, String paymentKey, String lastTransactionKey, String approveCode,
+                    LocalDateTime paidAt, LocalDateTime createdAt
+    ) {
+        super(id);
+        this.orderId = orderId;
+        this.orderNumber = orderNumber;
+        this.memberId = memberId;
+        this.type = type;
+        this.method = method;
+        this.originAmount = originAmount;
+        this.paidAmount = paidAmount;
+        this.refundedAmount = refundedAmount != null ? refundedAmount : Money.zero();
+        this.walletDeductedAmount = walletDeductedAmount;
+        this.orderItems = List.copyOf(orderItems);
+        this.status = status;
+        this.paymentKey = paymentKey;
+        this.lastTransactionKey = lastTransactionKey;
+        this.approveCode = approveCode;
+        this.paidAt = paidAt;
+        this.createdAt = createdAt;
+    }
+
+    // ========== 정적 팩토리 메서드 ========== //
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    // ========== 상태 변경 메서드 ========== //
+
+    public void markAsPaid(String paymentKey, String approveCode, String lastTransactionKey, LocalDateTime paidAt) {
+        if (!PaymentEventType.PAID.canApply(this.status)) {
+            throw new PaymentException(PaymentErrorCode.NOT_PAYABLE,
+                    "[Payment] 결제 완료 불가능한 상태입니다: " + this.status);
+        }
+        this.status = PaymentEventType.PAID.getResultStatus();
+        this.paymentKey = paymentKey;
+        this.approveCode = approveCode;
+        this.lastTransactionKey = lastTransactionKey;
+        this.paidAt = paidAt;
+
+        registerEvent(PaymentSucceededEvent.create(
+                PaymentEventData.forSuccess(
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
+                        getMethod(), getType(), paymentKey, lastTransactionKey
+                )
+        ));
+    }
+
+    // charged (PAID, PARTIALLY_CANCELED) -> REFUND, uncharged (PENDING) -> CANCEL
+    public CancelType resolveCancelType() {
+        return (this.status == PaymentStatus.PAID || this.status == PaymentStatus.PARTIALLY_CANCELED)
+                ? CancelType.REFUND
+                : CancelType.CANCEL;
+    }
+
+    public void markAsCanceled(CancelType cancelType, String reason) {
+        PaymentEventType eventType = (cancelType == CancelType.REFUND)
+                ? PaymentEventType.CANCEL_AFTER_PAID
+                : PaymentEventType.CANCELED;
+
+        if (!eventType.canApply(this.status)) {
+            throw new PaymentException(PaymentErrorCode.NOT_CANCELABLE,
+                    "[Payment] 취소 불가능한 상태입니다: " + this.status);
+        }
+        this.status = eventType.getResultStatus();
+
+        registerEvent(PaymentCanceledEvent.create(
+                PaymentEventData.forCancel(
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
+                        getMethod(), getType(), cancelType, reason, this.lastTransactionKey
+                )
+        ));
+    }
+
+    public void markAsPartiallyCanceled(String newTransactionKey, Money cancelAmount, CancelType cancelType, String reason) {
+        Money newRefundedTotal = this.refundedAmount.plus(cancelAmount);
+
+        PaymentEventType eventType = getCancelingEventType(newRefundedTotal);
+
+        if (!eventType.canApply(this.status)) {
+            throw new PaymentException(PaymentErrorCode.NOT_CANCELABLE,
+                    "[Payment] 취소 불가능한 상태입니다: " + this.status);
+        }
+
+        this.status = eventType.getResultStatus();
+        this.refundedAmount = newRefundedTotal;
+        this.lastTransactionKey = newTransactionKey;
+
+        registerEvent(PaymentCanceledEvent.create(
+                PaymentEventData.forCancel(
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(),
+                        cancelAmount,
+                        getMethod(), getType(), cancelType, reason,
+                        newTransactionKey
+                )
+        ));
+    }
+
+    private PaymentEventType getCancelingEventType(Money money) {
+        PaymentEventType eventType;
+        if (money.equals(this.paidAmount)) {
+            eventType = (this.status == PaymentStatus.PARTIALLY_CANCELED)
+                    ? PaymentEventType.FINAL_CANCEL
+                    : PaymentEventType.CANCEL_AFTER_PAID;
+        } else if (money.isLessThan(this.paidAmount)) {
+            eventType = (this.status == PaymentStatus.PARTIALLY_CANCELED)
+                    ? PaymentEventType.PARTIAL_CANCEL_AGAIN
+                    : PaymentEventType.PARTIAL_CANCEL;
+        } else {
+            throw new PaymentException(PaymentErrorCode.CANCEL_AMOUNT_EXCEEDED,
+                    "[Payment] 취소 금액이 결제 금액을 초과합니다.");
+        }
+        return eventType;
+    }
+
+    public void markAsFailed(LocalDateTime occurredAt) {
+        if (!PaymentEventType.FAILED.canApply(this.status)) {
+            throw new PaymentException(PaymentErrorCode.NOT_FAILABLE,
+                    "[Payment] 대기 중인 결제만 실패 처리할 수 있습니다. 현재 상태: " + this.status);
+        }
+        this.status = PaymentEventType.FAILED.getResultStatus();
+
+        registerEvent(PaymentFailedEvent.create(
+                PaymentEventData.forFailure(
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(), getWalletDeductedAmount(),
+                        getMethod(), getType()
+                )
+        ));
+    }
+
+    public void recordCancelFailed(String errorMetadata, LocalDateTime occurredAt) {
+        if (!PaymentEventType.CANCEL_FAILED.canApply(this.status)) {
+            throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_STATUS,
+                    "[Payment] 취소 실패 기록은 PAID 상태에서만 가능합니다. 현재 상태: " + this.status);
+        }
+
+        registerEvent(PaymentCancelFailedEvent.create(
+                PaymentEventData.forCancelFailed(
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(),
+                        getMethod(), getType(), errorMetadata
+                )
+        ));
+    }
+
+    // ========== 상태 조회 메서드 ========== //
+
+    public boolean isCancelable() {
+        return PaymentEventType.CANCELED.canApply(this.status);
+    }
+
+    /**
+     * 해당 회원이 이 결제의 소유자인지 확인합니다.
+     *
+     * @param requesterId 요청자 회원 ID
+     * @return 소유자이면 true
+     */
+    public boolean isOwnedBy(Long requesterId) {
+        return this.memberId != null && this.memberId.equals(requesterId);
+    }
+
+    // ========== Getter ========== //
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public String getOrderNumber() {
+        return orderNumber;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Money getOriginAmount() {
+        return originAmount;
+    }
+
+    public Money getPaidAmount() {
+        return paidAmount;
+    }
+
+    public Money getRefundedAmount() {
+        return refundedAmount;
+    }
+
+    public Money getWalletDeductedAmount() {
+        return walletDeductedAmount;
+    }
+
+    public List<OrderItemSnapshot> getOrderItems() {
+        return orderItems;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public PaymentType getType() {
+        return type;
+    }
+
+    public PaymentMethod getMethod() {
+        return method;
+    }
+
+    public String getPaymentKey() {
+        return paymentKey;
+    }
+
+    public String getLastTransactionKey() {
+        return lastTransactionKey;
+    }
+
+    public String getApproveCode() {
+        return approveCode;
+    }
+
+    public LocalDateTime getPaidAt() {
+        return paidAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    // ========== equals / hashCode ========== //
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Payment payment))
+            return false;
+        if (getId() != null && payment.getId() != null) {
+            return Objects.equals(getId(), payment.getId());
+        }
+        return Objects.equals(orderNumber, payment.orderNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() != null) {
+            return Objects.hash(getId());
+        }
+        return Objects.hash(orderNumber);
+    }
+
+    // ========== Builder ========== //
+
+    public static class Builder {
+        private Long id;
+        private Long orderId;
+        private String orderNumber;
+        private Long memberId;
+        private Money originAmount;
+        private Money paidAmount;
+        private Money refundedAmount;
+        private Money walletDeductedAmount;
+        private List<OrderItemSnapshot> orderItems;
+        private PaymentStatus status;
+        private PaymentType type;
+        private PaymentMethod method;
+        private String paymentKey;
+        private String lastTransactionKey;
+        private String approveCode;
+        private LocalDateTime paidAt;
+        private LocalDateTime createdAt;
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder orderId(Long orderId) {
+            this.orderId = orderId;
+            return this;
+        }
+
+        public Builder orderNumber(String orderNumber) {
+            this.orderNumber = orderNumber;
+            return this;
+        }
+
+        public Builder memberId(Long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public Builder originAmount(Money originAmount) {
+            this.originAmount = originAmount;
+            return this;
+        }
+
+        public Builder paidAmount(Money paidAmount) {
+            this.paidAmount = paidAmount;
+            return this;
+        }
+
+        public Builder refundedAmount(Money refundedAmount) {
+            this.refundedAmount = refundedAmount;
+            return this;
+        }
+
+        public Builder walletDeductedAmount(Money walletDeductedAmount) {
+            this.walletDeductedAmount = walletDeductedAmount;
+            return this;
+        }
+
+
+        public Builder orderItems(List<OrderItemSnapshot> orderItems) {
+            this.orderItems = orderItems;
+            return this;
+        }
+
+        public Builder status(PaymentStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder type(PaymentType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder method(PaymentMethod method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder paymentKey(String paymentKey) {
+            this.paymentKey = paymentKey;
+            return this;
+        }
+
+        public Builder lastTransactionKey(String lastTransactionKey) {
+            this.lastTransactionKey = lastTransactionKey;
+            return this;
+        }
+
+        public Builder approveCode(String approveCode) {
+            this.approveCode = approveCode;
+            return this;
+        }
+
+        public Builder paidAt(LocalDateTime paidAt) {
+            this.paidAt = paidAt;
+            return this;
+        }
+
+        public Builder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Payment build() {
+            validate();
+            return new Payment(
+                    id,
+                    type, method,
+                    orderId, orderNumber, memberId,
+                    originAmount, paidAmount, refundedAmount, walletDeductedAmount,
+                    orderItems, status, paymentKey, lastTransactionKey, approveCode,
+                    paidAt, createdAt
+            );
+        }
+
+        private void validate() {
+            validateRequiredFields();
+            validateAmountInvariant();
+            validateOrderItemsIfRequired();
+        }
+
+        private void validateRequiredFields() {
+            requireNonBlank(orderNumber, "orderNumber");
+            requireNonNull(memberId, "memberId");
+            requireNonNull(type, "type");
+            requireNonNull(method, "method");
+            requireNonNull(originAmount, "originAmount");
+            requireNonNull(paidAmount, "paidAmount");
+            requireNonNull(status, "status");
+        }
+
+        private void requireNonBlank(String value, String fieldName) {
+            if (value == null || value.isBlank()) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] " + fieldName + "는 필수입니다.");
+            }
+        }
+
+        private void requireNonNull(Object value, String fieldName) {
+            if (value == null) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] " + fieldName + "는 필수입니다.");
+            }
+        }
+
+        private void validateAmountInvariant() {
+            if (paidAmount.isGreaterThan(originAmount)) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] paidAmount는 originAmount를 초과할 수 없습니다.");
+            }
+            Money effectiveRefundedAmount = refundedAmount != null ? refundedAmount : Money.zero();
+            if (effectiveRefundedAmount.isGreaterThan(paidAmount)) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] refundedAmount는 paidAmount를 초과할 수 없습니다.");
+            }
+        }
+
+        private void validateOrderItemsIfRequired() {
+            if (type == PaymentType.DEPOSIT_CHARGE) {
+                return;
+            }
+
+            if (orderItems == null || orderItems.isEmpty()) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] orderItems는 필수입니다.");
+            }
+
+            Money itemsTotal = orderItems.stream()
+                    .map(OrderItemSnapshot::amount)
+                    .reduce(Money.zero(), Money::plus);
+
+            if (!itemsTotal.equals(originAmount)) {
+                throw new PaymentException(PaymentErrorCode.INVALID_INPUT_VALUE,
+                        "[Payment] orderItems 합계와 originAmount가 일치하지 않습니다.");
+            }
+        }
+    }
+
+    // ========== 정적 팩토리 메서드  ========== //
+
+    public static Payment create(
+            PaymentCreateContext context,
+            Money originAmount,
+            Money paidAmount,
+            List<OrderItemSnapshot> orderItems
+    ) {
+        return builder()
+                .orderId(context.orderId())
+                .orderNumber(context.orderNumber())
+                .memberId(context.memberId())
+                .type(context.type())
+                .method(context.method())
+                .originAmount(originAmount)
+                .paidAmount(paidAmount)
+                .orderItems(orderItems)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
+    public static Payment create(
+            PaymentCreateContext context,
+            Money originAmount,
+            Money paidAmount,
+            Money walletDeductedAmount,
+            List<OrderItemSnapshot> orderItems
+    ) {
+        return builder()
+                .orderId(context.orderId())
+                .orderNumber(context.orderNumber())
+                .memberId(context.memberId())
+                .type(context.type())
+                .method(context.method())
+                .originAmount(originAmount)
+                .paidAmount(paidAmount)
+                .walletDeductedAmount(walletDeductedAmount)
+                .orderItems(orderItems)
+                .status(PaymentStatus.PENDING)
+                .build();
+    }
+
 }

--- a/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
+++ b/bc/core/src/main/java/app/giftify/payment/domain/Payment.java
@@ -46,7 +46,7 @@ public class Payment extends BaseDomainModel {
         this.originAmount = originAmount;
         this.paidAmount = paidAmount;
         this.refundedAmount = refundedAmount != null ? refundedAmount : Money.zero();
-        this.walletDeductedAmount = walletDeductedAmount;
+        this.walletDeductedAmount = walletDeductedAmount != null ? walletDeductedAmount : Money.zero();
         this.orderItems = List.copyOf(orderItems);
         this.status = status;
         this.paymentKey = paymentKey;
@@ -103,7 +103,7 @@ public class Payment extends BaseDomainModel {
 
         registerEvent(PaymentCanceledEvent.create(
                 PaymentEventData.forCancel(
-                        getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(),
+                        getId(), getOrderId(), getMemberId(), getOrderNumber(), getPaidAmount(), this.walletDeductedAmount,
                         getMethod(), getType(), cancelType, reason, this.lastTransactionKey
                 )
         ));
@@ -126,7 +126,7 @@ public class Payment extends BaseDomainModel {
         registerEvent(PaymentCanceledEvent.create(
                 PaymentEventData.forCancel(
                         getId(), getOrderId(), getMemberId(), getOrderNumber(),
-                        cancelAmount,
+                        cancelAmount, this.walletDeductedAmount,
                         getMethod(), getType(), cancelType, reason,
                         newTransactionKey
                 )

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandler.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandler.java
@@ -1,6 +1,7 @@
 package app.giftify.wallet.adapter.inbound.event;
 
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
+import app.giftify.shared.domain.vo.Money;
 import app.giftify.wallet.application.inbound.RestoreWalletCommand;
 import app.giftify.wallet.application.inbound.RestoreWalletUseCase;
 import app.giftify.wallet.domain.ReferenceType;
@@ -18,7 +19,7 @@ public class PaymentCanceledEventHandler {
 
     @ApplicationModuleListener
     public void handle(PaymentCanceledEvent event) {
-        if (!event.data().paymentMethod().isWalletPayment()) {
+        if (!event.data().walletDeductedAmount().isGreaterThan(Money.zero())) { //  walletDeductedAmount > 0이면 복원 (순수 CARD는 0이라 skip)
             return;
         }
 
@@ -27,7 +28,7 @@ public class PaymentCanceledEventHandler {
 
         restoreWalletUseCase.restore(new RestoreWalletCommand(
                 event.data().memberId(),
-                event.data().amount(),
+                event.data().walletDeductedAmount(),
                 event.data().transactionKey(),
                 TransactionType.CANCEL_REFUND,
                 ReferenceType.CANCEL

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandler.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandler.java
@@ -1,33 +1,36 @@
 package app.giftify.wallet.adapter.inbound.event;
 
-import org.springframework.modulith.events.ApplicationModuleListener;
-import org.springframework.stereotype.Component;
-
 import app.giftify.shared.domain.event.payment.PaymentCanceledEvent;
 import app.giftify.wallet.application.inbound.RestoreWalletCommand;
 import app.giftify.wallet.application.inbound.RestoreWalletUseCase;
+import app.giftify.wallet.domain.ReferenceType;
+import app.giftify.wallet.domain.TransactionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentCanceledEventHandler {
-	private final RestoreWalletUseCase restoreWalletUseCase;
+    private final RestoreWalletUseCase restoreWalletUseCase;
 
-	@ApplicationModuleListener
-	public void handle(PaymentCanceledEvent event) {
-		if (!event.data().paymentMethod().isWalletPayment()) {
-			return;
-		}
+    @ApplicationModuleListener
+    public void handle(PaymentCanceledEvent event) {
+        if (!event.data().paymentMethod().isWalletPayment()) {
+            return;
+        }
 
-		log.info("[PaymentCanceledEventHandler] Wallet 결제 취소 → 잔액 복원. memberId={}, cancelAmount={}",
-			event.data().memberId(), event.data().amount());
+        log.info("[PaymentCanceledEventHandler] Wallet 결제 취소 → 잔액 복원. memberId={}, cancelAmount={}",
+                event.data().memberId(), event.data().amount());
 
-		restoreWalletUseCase.restore(new RestoreWalletCommand(
-			event.data().memberId(),
-			event.data().amount(),
-			event.data().transactionKey()
-		));
-	}
+        restoreWalletUseCase.restore(new RestoreWalletCommand(
+                event.data().memberId(),
+                event.data().amount(),
+                event.data().transactionKey(),
+                TransactionType.CANCEL_REFUND,
+                ReferenceType.CANCEL
+        ));
+    }
 }

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentFailedEventHandler.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentFailedEventHandler.java
@@ -1,4 +1,38 @@
 package app.giftify.wallet.adapter.inbound.event;
 
+import app.giftify.shared.domain.event.payment.PaymentFailedEvent;
+import app.giftify.shared.domain.vo.Money;
+import app.giftify.wallet.application.inbound.RestoreWalletCommand;
+import app.giftify.wallet.application.inbound.RestoreWalletUseCase;
+import app.giftify.wallet.domain.ReferenceType;
+import app.giftify.wallet.domain.TransactionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class PaymentFailedEventHandler {
+    private final RestoreWalletUseCase restoreWalletUseCase;
+
+    @ApplicationModuleListener
+    public void handle(PaymentFailedEvent event) {
+        // 복합결제가 아닌 경우 (일반 CARD 결제) — 지갑 복원 불필요
+        if (!event.data().walletDeductedAmount().isGreaterThan(Money.zero())) {
+            return;
+        }
+
+        log.info("[PaymentFailedEventHandler] PG 실패 → Wallet 복원. memberId={}, amount={}",
+                event.data().memberId(), event.data().walletDeductedAmount());
+
+        restoreWalletUseCase.restore(new RestoreWalletCommand(
+                event.data().memberId(),
+                event.data().walletDeductedAmount(),
+                event.data().paymentId().toString(),
+                TransactionType.PAYMENT_DEDUCT_COMPENSATION,
+                ReferenceType.PAYMENT_COMPENSATION
+        ));
+    }
 }

--- a/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentFailedEventHandler.java
+++ b/bc/core/src/main/java/app/giftify/wallet/adapter/inbound/event/PaymentFailedEventHandler.java
@@ -1,0 +1,4 @@
+package app.giftify.wallet.adapter.inbound.event;
+
+public class PaymentFailedEventHandler {
+}

--- a/bc/core/src/main/java/app/giftify/wallet/application/WalletService.java
+++ b/bc/core/src/main/java/app/giftify/wallet/application/WalletService.java
@@ -1,38 +1,19 @@
 package app.giftify.wallet.application;
 
-import java.time.LocalDateTime;
-
+import app.giftify.shared.domain.event.EventPublisher;
+import app.giftify.shared.domain.vo.Money;
+import app.giftify.wallet.application.inbound.*;
+import app.giftify.wallet.application.outbound.WalletHistoryRepository;
+import app.giftify.wallet.application.outbound.WalletRepository;
+import app.giftify.wallet.domain.*;
+import app.giftify.wallet.domain.event.WalletChargedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import app.giftify.wallet.application.inbound.ChargeWalletCommand;
-import app.giftify.wallet.application.inbound.ChargeWalletResult;
-import app.giftify.wallet.application.inbound.ChargeWalletUseCase;
-import app.giftify.wallet.application.inbound.CreateWalletUseCase;
-import app.giftify.wallet.application.inbound.QueryWalletHistoryUseCase;
-import app.giftify.wallet.application.inbound.QueryWalletUseCase;
-import app.giftify.wallet.application.inbound.RestoreWalletCommand;
-import app.giftify.wallet.application.inbound.RestoreWalletUseCase;
-import app.giftify.wallet.application.inbound.WalletHistoryQuery;
-import app.giftify.wallet.application.inbound.WalletHistoryResult;
-import app.giftify.wallet.application.inbound.WalletBalanceResult;
-import app.giftify.wallet.application.inbound.WithdrawStatus;
-import app.giftify.wallet.application.inbound.WithdrawWalletCommand;
-import app.giftify.wallet.application.inbound.WithdrawWalletResult;
-import app.giftify.wallet.application.inbound.WithdrawWalletUseCase;
-import app.giftify.wallet.application.outbound.WalletHistoryRepository;
-import app.giftify.wallet.application.outbound.WalletRepository;
-import app.giftify.wallet.domain.ReferenceType;
-import app.giftify.wallet.domain.TransactionType;
-import app.giftify.wallet.domain.Wallet;
-import app.giftify.wallet.domain.WalletErrorCode;
-import app.giftify.wallet.domain.WalletException;
-import app.giftify.wallet.domain.event.WalletChargedEvent;
-import app.giftify.shared.domain.event.EventPublisher;
-import app.giftify.shared.domain.vo.Money;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.LocalDateTime;
 
 /**
  * 지갑 서비스.
@@ -43,213 +24,212 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class WalletService implements ChargeWalletUseCase, WithdrawWalletUseCase, QueryWalletUseCase, QueryWalletHistoryUseCase, CreateWalletUseCase, RestoreWalletUseCase {
 
-	private final WalletRepository walletRepository;
-	private final WalletHistoryRepository historyRepository;
-	private final EventPublisher eventPublisher;
+    private final WalletRepository walletRepository;
+    private final WalletHistoryRepository historyRepository;
+    private final EventPublisher eventPublisher;
 
-	/**
-	 * 지갑을 충전합니다.
-	 * PG 결제 완료 후 지갑에 금액을 추가합니다.
-	 *
-	 * @param command 충전 요청 정보
-	 * @return 충전 결과
-	 * @throws WalletException 중복 거래이거나 충전 금액이 유효하지 않은 경우
-	 */
-	@Override
-	@Transactional
-	public ChargeWalletResult charge(ChargeWalletCommand command) {
-		// 1. 중복 거래 확인
-		if (historyRepository.existsByReferenceIdAndReferenceType(
-			command.chargeOrderId(), ReferenceType.CHARGE)) {
-			throw new WalletException(
-				WalletErrorCode.DUPLICATED_TRANSACTION,
-				"[WalletService] 중복된 충전 거래입니다. chargeOrderId=" + command.chargeOrderId()
-			);
-		}
+    /**
+     * 지갑을 충전합니다.
+     * PG 결제 완료 후 지갑에 금액을 추가합니다.
+     *
+     * @param command 충전 요청 정보
+     * @return 충전 결과
+     * @throws WalletException 중복 거래이거나 충전 금액이 유효하지 않은 경우
+     */
+    @Override
+    @Transactional
+    public ChargeWalletResult charge(ChargeWalletCommand command) {
+        // 1. 중복 거래 확인
+        if (historyRepository.existsByReferenceIdAndReferenceType(
+                command.chargeOrderId(), ReferenceType.CHARGE)) {
+            throw new WalletException(
+                    WalletErrorCode.DUPLICATED_TRANSACTION,
+                    "[WalletService] 중복된 충전 거래입니다. chargeOrderId=" + command.chargeOrderId()
+            );
+        }
 
-		// 2. 지갑 조회 또는 생성
-		Wallet wallet = walletRepository.findByMemberId(command.memberId())
-			.orElseGet(() -> Wallet.create(command.memberId(), Money.zero()));
+        // 2. 지갑 조회 또는 생성
+        Wallet wallet = walletRepository.findByMemberId(command.memberId())
+                .orElseGet(() -> Wallet.create(command.memberId(), Money.zero()));
 
-		// 3. 충전
-		wallet.charge(command.amount());
-		Wallet savedWallet = walletRepository.save(wallet);
+        // 3. 충전
+        wallet.charge(command.amount());
+        Wallet savedWallet = walletRepository.save(wallet);
 
-		// 4. 이력 기록
-		historyRepository.recordTransaction(
-			savedWallet.getId(),
-			TransactionType.CHARGE,
-			command.amount(),
-			savedWallet.getBalance(),
-			ReferenceType.CHARGE,
-			command.chargeOrderId()
-		);
+        // 4. 이력 기록
+        historyRepository.recordTransaction(
+                savedWallet.getId(),
+                TransactionType.CHARGE,
+                command.amount(),
+                savedWallet.getBalance(),
+                ReferenceType.CHARGE,
+                command.chargeOrderId()
+        );
 
-		// 5. 이벤트 발행
-		eventPublisher.publish(new WalletChargedEvent(
-			savedWallet.getId(),
-			command.memberId(),
-			command.chargeOrderId(),
-			command.amount(),
-			savedWallet.getBalance(),
-			LocalDateTime.now()
-		));
+        // 5. 이벤트 발행
+        eventPublisher.publish(new WalletChargedEvent(
+                savedWallet.getId(),
+                command.memberId(),
+                command.chargeOrderId(),
+                command.amount(),
+                savedWallet.getBalance(),
+                LocalDateTime.now()
+        ));
 
-		log.info("[Wallet] 충전 완료. walletId={}, memberId={}, amount={}, balanceAfter={}",
-			savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance());
+        log.info("[Wallet] 충전 완료. walletId={}, memberId={}, amount={}, balanceAfter={}",
+                savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance());
 
-		return new ChargeWalletResult(
-			savedWallet.getId(),
-			command.memberId(),
-			savedWallet.getBalance(),
-			command.amount(),
-			command.chargeOrderId()
-		);
-	}
+        return new ChargeWalletResult(
+                savedWallet.getId(),
+                command.memberId(),
+                savedWallet.getBalance(),
+                command.amount(),
+                command.chargeOrderId()
+        );
+    }
 
-	/**
-	 * 지갑에서 금액을 출금합니다.
-	 * 출금 요청 시 잔액을 즉시 차감하고, 실제 은행 송금은 비동기로 처리됩니다.
-	 *
-	 * @param command 출금 요청 정보
-	 * @return 출금 결과 (PENDING 상태)
-	 * @throws WalletException 지갑을 찾을 수 없거나 잔액이 부족한 경우
-	 */
-	@Override
-	@Transactional
-	public WithdrawWalletResult withdraw(WithdrawWalletCommand command) {
-		// 1. 지갑 조회
-		Wallet wallet = walletRepository.findByMemberId(command.memberId())
-			.orElseThrow(() -> new WalletException(
-				WalletErrorCode.WALLET_NOT_FOUND,
-				"[WalletService] 지갑을 찾을 수 없습니다. memberId=" + command.memberId()
-			));
+    /**
+     * 지갑에서 금액을 출금합니다.
+     * 출금 요청 시 잔액을 즉시 차감하고, 실제 은행 송금은 비동기로 처리됩니다.
+     *
+     * @param command 출금 요청 정보
+     * @return 출금 결과 (PENDING 상태)
+     * @throws WalletException 지갑을 찾을 수 없거나 잔액이 부족한 경우
+     */
+    @Override
+    @Transactional
+    public WithdrawWalletResult withdraw(WithdrawWalletCommand command) {
+        // 1. 지갑 조회
+        Wallet wallet = walletRepository.findByMemberId(command.memberId())
+                .orElseThrow(() -> new WalletException(
+                        WalletErrorCode.WALLET_NOT_FOUND,
+                        "[WalletService] 지갑을 찾을 수 없습니다. memberId=" + command.memberId()
+                ));
 
-		// 2. 출금 (잔액 검증 포함)
-		wallet.withdraw(command.amount());
-		Wallet savedWallet = walletRepository.save(wallet);
+        // 2. 출금 (잔액 검증 포함)
+        wallet.withdraw(command.amount());
+        Wallet savedWallet = walletRepository.save(wallet);
 
-		// 3. 이력 기록
-		String transactionId = "WD-" + command.memberId() + "-" + System.currentTimeMillis();
-		historyRepository.recordTransaction(
-			savedWallet.getId(),
-			TransactionType.WITHDRAW,
-			command.amount(),
-			savedWallet.getBalance(),
-			ReferenceType.WITHDRAWAL,
-			transactionId
-		);
+        // 3. 이력 기록
+        String transactionId = "WD-" + command.memberId() + "-" + System.currentTimeMillis();
+        historyRepository.recordTransaction(
+                savedWallet.getId(),
+                TransactionType.WITHDRAW,
+                command.amount(),
+                savedWallet.getBalance(),
+                ReferenceType.WITHDRAWAL,
+                transactionId
+        );
 
-		log.info("[Wallet] 출금 요청. walletId={}, memberId={}, amount={}, balanceAfter={}, transactionId={}",
-			savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance(), transactionId);
+        log.info("[Wallet] 출금 요청. walletId={}, memberId={}, amount={}, balanceAfter={}, transactionId={}",
+                savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance(), transactionId);
 
-		// 4. 결과 반환 (실제 은행 송금은 비동기로 처리 - 현재는 PENDING 상태)
-		return new WithdrawWalletResult(
-			savedWallet.getId(),
-			command.memberId(),
-			savedWallet.getBalance(),
-			command.amount(),
-			transactionId,
-			WithdrawStatus.PENDING
-		);
-	}
+        // 4. 결과 반환 (실제 은행 송금은 비동기로 처리 - 현재는 PENDING 상태)
+        return new WithdrawWalletResult(
+                savedWallet.getId(),
+                command.memberId(),
+                savedWallet.getBalance(),
+                command.amount(),
+                transactionId,
+                WithdrawStatus.PENDING
+        );
+    }
 
-	/**
-	 * 회원의 지갑 잔액을 조회합니다.
-	 * 지갑이 없는 경우 잔액 0원의 새 지갑을 생성합니다.
-	 *
-	 * @param memberId 회원 ID
-	 * @return 지갑 잔액 정보
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public WalletBalanceResult getBalance(Long memberId) {
-		Wallet wallet = walletRepository.findByMemberId(memberId)
-			.orElseGet(() -> Wallet.create(memberId, Money.zero()));
+    /**
+     * 회원의 지갑 잔액을 조회합니다.
+     * 지갑이 없는 경우 잔액 0원의 새 지갑을 생성합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 지갑 잔액 정보
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public WalletBalanceResult getBalance(Long memberId) {
+        Wallet wallet = walletRepository.findByMemberId(memberId)
+                .orElseGet(() -> Wallet.create(memberId, Money.zero()));
 
-		return new WalletBalanceResult(
-			wallet.getId(),
-			memberId,
-			wallet.getBalance()
-		);
-	}
+        return new WalletBalanceResult(
+                wallet.getId(),
+                memberId,
+                wallet.getBalance()
+        );
+    }
 
 
-	/**
-	 * 회원의 지갑 거래 내역을 조회합니다.
-	 *
-	 * @param query 조회 조건 (memberId, type, page, size)
-	 * @return 페이징된 거래 내역
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Page<WalletHistoryResult> getHistory(WalletHistoryQuery query) {
-		Wallet wallet = walletRepository.findByMemberId(query.memberId())
-			.orElseGet(() -> Wallet.create(query.memberId(), Money.zero()));
+    /**
+     * 회원의 지갑 거래 내역을 조회합니다.
+     *
+     * @param query 조회 조건 (memberId, type, page, size)
+     * @return 페이징된 거래 내역
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<WalletHistoryResult> getHistory(WalletHistoryQuery query) {
+        Wallet wallet = walletRepository.findByMemberId(query.memberId())
+                .orElseGet(() -> Wallet.create(query.memberId(), Money.zero()));
 
-		if (wallet.getId() == null) {
-			// 지갑이 없으면 빈 결과 반환
-			return Page.empty(query.toPageable());
-		}
+        if (wallet.getId() == null) {
+            // 지갑이 없으면 빈 결과 반환
+            return Page.empty(query.toPageable());
+        }
 
-		return historyRepository.findByWalletId(
-			wallet.getId(),
-			query.type(),
-			query.toPageable()
-		).map(WalletHistoryResult::from);
-	}
+        return historyRepository.findByWalletId(
+                wallet.getId(),
+                query.type(),
+                query.toPageable()
+        ).map(WalletHistoryResult::from);
+    }
 
-	/**
-	 * 회원의 지갑을 생성합니다.
-	 * 이미 지갑이 존재하는 경우 기존 지갑 정보를 반환합니다.
-	 *
-	 * @param memberId 회원 ID
-	 * @return 생성 결과
-	 */
-	@Override
-	@Transactional
-	public CreateWalletResult createIfNotExists(Long memberId) {
-		return walletRepository.findByMemberId(memberId)
-			.map(wallet -> {
-				log.debug("[WalletService] 이미 지갑이 존재합니다. memberId={}, walletId={}", memberId, wallet.getId());
-				return CreateWalletResult.alreadyExists(wallet.getId(), memberId);
-			})
-			.orElseGet(() -> {
-				Wallet wallet = Wallet.create(memberId, Money.zero());
-				Wallet savedWallet = walletRepository.save(wallet);
-				log.info("[WalletService] 신규 지갑 생성 완료. memberId={}, walletId={}", memberId, savedWallet.getId());
-				return CreateWalletResult.created(savedWallet.getId(), memberId);
-			});
-	}
+    /**
+     * 회원의 지갑을 생성합니다.
+     * 이미 지갑이 존재하는 경우 기존 지갑 정보를 반환합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 생성 결과
+     */
+    @Override
+    @Transactional
+    public CreateWalletResult createIfNotExists(Long memberId) {
+        return walletRepository.findByMemberId(memberId)
+                .map(wallet -> {
+                    log.debug("[WalletService] 이미 지갑이 존재합니다. memberId={}, walletId={}", memberId, wallet.getId());
+                    return CreateWalletResult.alreadyExists(wallet.getId(), memberId);
+                })
+                .orElseGet(() -> {
+                    Wallet wallet = Wallet.create(memberId, Money.zero());
+                    Wallet savedWallet = walletRepository.save(wallet);
+                    log.info("[WalletService] 신규 지갑 생성 완료. memberId={}, walletId={}", memberId, savedWallet.getId());
+                    return CreateWalletResult.created(savedWallet.getId(), memberId);
+                });
+    }
 
-	@Override
-	@Transactional
-	public void restore(RestoreWalletCommand command) {
-		if (historyRepository.existsByReferenceIdAndReferenceType(
-			command.referenceId(), ReferenceType.CANCEL)) {
-			log.warn("[WalletService] 중복 취소 환불 요청. referenceId={}", command.referenceId());
-			return;
-		}
+    @Override
+    @Transactional
+    public void restore(RestoreWalletCommand command) {
+        if (historyRepository.existsByReferenceIdAndReferenceType(command.referenceId(), command.referenceType())) {
+            log.warn("[WalletService] 중복 취소 환불 요청. referenceId={}", command.referenceId());
+            return;
+        }
 
-		Wallet wallet = walletRepository.findByMemberId(command.memberId())
-			.orElseThrow(() -> new WalletException(
-				WalletErrorCode.WALLET_NOT_FOUND,
-				"[WalletService] 지갑을 찾을 수 없습니다. memberId=" + command.memberId()
-			));
+        Wallet wallet = walletRepository.findByMemberId(command.memberId())
+                .orElseThrow(() -> new WalletException(
+                        WalletErrorCode.WALLET_NOT_FOUND,
+                        "[WalletService] 지갑을 찾을 수 없습니다. memberId=" + command.memberId()
+                ));
 
-		wallet.restoreForCancel(command.amount());
-		Wallet savedWallet = walletRepository.save(wallet);
+        wallet.restoreForCancel(command.amount());
+        Wallet savedWallet = walletRepository.save(wallet);
 
-		historyRepository.recordTransaction(
-			savedWallet.getId(),
-			TransactionType.CANCEL_REFUND,
-			command.amount(),
-			savedWallet.getBalance(),
-			ReferenceType.CANCEL,
-			command.referenceId()
-		);
+        historyRepository.recordTransaction(
+                savedWallet.getId(),
+                command.transactionType(),
+                command.amount(),
+                savedWallet.getBalance(),
+                command.referenceType(),
+                command.referenceId()
+        );
 
-		log.info("[Wallet] 취소 환불 완료. walletId={}, memberId={}, amount={}, balanceAfter={}",
-			savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance());
-	}
+        log.info("[Wallet] 취소 환불 완료. walletId={}, memberId={}, amount={}, balanceAfter={}",
+                savedWallet.getId(), command.memberId(), command.amount(), savedWallet.getBalance());
+    }
 }

--- a/bc/core/src/main/java/app/giftify/wallet/application/inbound/RestoreWalletCommand.java
+++ b/bc/core/src/main/java/app/giftify/wallet/application/inbound/RestoreWalletCommand.java
@@ -1,9 +1,14 @@
 package app.giftify.wallet.application.inbound;
 
 import app.giftify.shared.domain.vo.Money;
+import app.giftify.wallet.domain.ReferenceType;
+import app.giftify.wallet.domain.TransactionType;
 
 public record RestoreWalletCommand(
-	Long memberId,
-	Money amount,
-	String referenceId
-) {}
+        Long memberId,
+        Money amount,
+        String referenceId,
+        TransactionType transactionType,
+        ReferenceType referenceType
+) {
+}

--- a/bc/core/src/main/java/app/giftify/wallet/domain/ReferenceType.java
+++ b/bc/core/src/main/java/app/giftify/wallet/domain/ReferenceType.java
@@ -9,7 +9,8 @@ public enum ReferenceType {
 	WITHDRAWAL("출금"),
 	PAYMENT("결제"),
 	SETTLEMENT("정산"),
-	CANCEL("취소");
+	CANCEL("취소"),
+	PAYMENT_COMPENSATION("결제 보상");
 
 	private final String description;
 

--- a/bc/core/src/main/java/app/giftify/wallet/domain/TransactionType.java
+++ b/bc/core/src/main/java/app/giftify/wallet/domain/TransactionType.java
@@ -5,20 +5,21 @@ package app.giftify.wallet.domain;
  * 지갑에 무슨 일이 일어났나
  */
 public enum TransactionType {
-	CHARGE("캐시 충전"),
-	WITHDRAW("출금"),
-	ORDER_DEDUCT("주문 차감"),
-	SETTLEMENT_PAYOUT("정산 입금"),
-	SETTLEMENT_CLAWBACK("정산 환수"),
-	CANCEL_REFUND("취소 환불");
+    CHARGE("캐시 충전"),
+    WITHDRAW("출금"),
+    ORDER_DEDUCT("주문 차감"),
+    SETTLEMENT_PAYOUT("정산 입금"),
+    SETTLEMENT_CLAWBACK("정산 환수"),
+    CANCEL_REFUND("취소 환불"),
+    PAYMENT_DEDUCT_COMPENSATION("결제 차감 보상");
 
-	private final String description;
+    private final String description;
 
-	TransactionType(String description) {
-		this.description = description;
-	}
+    TransactionType(String description) {
+        this.description = description;
+    }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 }

--- a/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListenerTest.java
@@ -95,7 +95,7 @@ class PaymentHistoryEventListenerTest {
 		void savesHistory() {
 			PaymentCanceledEvent event = PaymentCanceledEvent.create(
 				PaymentEventData.forCancel(PAYMENT_ID, 100L, 10L, ORDER_NUMBER,
-					Money.of(10000), PaymentMethod.CARD, PaymentType.FUNDING,
+					Money.of(10000), Money.zero(), PaymentMethod.CARD, PaymentType.FUNDING,
 					CancelType.CANCEL, "사용자 요청", "txn-cancel-001"));
 
 			listener.onPaymentCancelSucceeded(event);

--- a/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListenerTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/adapter/inbound/event/PaymentHistoryEventListenerTest.java
@@ -73,7 +73,7 @@ class PaymentHistoryEventListenerTest {
 		void savesHistory() {
 			PaymentFailedEvent event = PaymentFailedEvent.create(
 				PaymentEventData.forFailure(PAYMENT_ID, 100L, 10L, ORDER_NUMBER,
-					Money.of(10000), PaymentMethod.CARD, PaymentType.FUNDING));
+					Money.of(10000), Money.zero(), PaymentMethod.CARD, PaymentType.FUNDING));
 
 			listener.onPaymentFailed(event);
 

--- a/bc/core/src/test/java/app/giftify/payment/application/ConfirmPaymentServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/application/ConfirmPaymentServiceTest.java
@@ -226,8 +226,8 @@ class ConfirmPaymentServiceTest {
 			assertThat(result.errorCode()).isEqualTo("INVALID_CARD");
 			assertThat(result.errorMessage()).isEqualTo("카드 정보가 유효하지 않습니다");
 
-			verify(paymentRepository, never()).save(any());
-			verify(eventPublisher, never()).publish(any());
+			verify(paymentRepository).save(any());
+			verify(eventPublisher).publish(any());
 		}
 	}
 

--- a/bc/core/src/test/java/app/giftify/payment/application/CreatePaymentServiceTest.java
+++ b/bc/core/src/test/java/app/giftify/payment/application/CreatePaymentServiceTest.java
@@ -61,7 +61,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.CARD,
 				amount, orderItems
@@ -110,7 +110,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.CARD,
 				amount, orderItems
@@ -168,7 +168,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.DEPOSIT,
 				amount, orderItems
@@ -232,7 +232,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.DEPOSIT,
 				requiredAmount, orderItems
@@ -283,7 +283,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.DEPOSIT,
 				amount, orderItems
@@ -337,7 +337,7 @@ class CreatePaymentServiceTest {
 				new OrderItemSnapshot(1L, Money.of(10000), 100L)
 			);
 
-			CreateFundingPaymentCommand command = new CreateFundingPaymentCommand(
+			CreateFundingPaymentCommand command = CreateFundingPaymentCommand.of(
 				memberId, orderId, orderNumber,
 				PaymentMethod.CARD,
 				amount, orderItems

--- a/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandlerTest.java
+++ b/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandlerTest.java
@@ -33,13 +33,14 @@ class PaymentCanceledEventHandlerTest {
 	PaymentCanceledEventHandler handler;
 
 	@Test
-	@DisplayName("Wallet 결제(DEPOSIT) 취소 시 Wallet 복원 호출")
-	void handleWalletPaymentCancel() {
+	@DisplayName("walletDeductedAmount > 0 취소 시 Wallet 복원 호출")
+	void handleWalletDeductedCancel() {
 		PaymentEventData data = PaymentEventData.forCancel(
 			1L,
 			100L,
 			200L,
 			"ORD-001",
+			Money.of(5000),
 			Money.of(5000),
 			PaymentMethod.DEPOSIT,
 			PaymentType.FUNDING,
@@ -61,14 +62,15 @@ class PaymentCanceledEventHandlerTest {
 	}
 
 	@Test
-	@DisplayName("비-Wallet 결제(CARD) 취소 시 Wallet 복원 호출 안 함")
-	void skipNonWalletPaymentCancel() {
+	@DisplayName("walletDeductedAmount == 0 취소 시 Wallet 복원 호출 안 함")
+	void skipZeroWalletDeductedCancel() {
 		PaymentEventData data = PaymentEventData.forCancel(
 			2L,
 			101L,
 			201L,
 			"ORD-002",
 			Money.of(10000),
+			Money.zero(),
 			PaymentMethod.CARD,
 			PaymentType.FUNDING,
 			CancelType.CANCEL,

--- a/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandlerTest.java
+++ b/bc/core/src/test/java/app/giftify/wallet/adapter/inbound/event/PaymentCanceledEventHandlerTest.java
@@ -19,6 +19,8 @@ import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 import app.giftify.wallet.application.inbound.RestoreWalletCommand;
 import app.giftify.wallet.application.inbound.RestoreWalletUseCase;
+import app.giftify.wallet.domain.ReferenceType;
+import app.giftify.wallet.domain.TransactionType;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PaymentCanceledEventHandler 테스트")
@@ -52,7 +54,9 @@ class PaymentCanceledEventHandlerTest {
 		verify(restoreWalletUseCase).restore(new RestoreWalletCommand(
 			200L,
 			Money.of(5000),
-			"txKey-123"
+			"txKey-123",
+			TransactionType.CANCEL_REFUND,
+			ReferenceType.CANCEL
 		));
 	}
 

--- a/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
+++ b/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
@@ -100,7 +100,7 @@ class NotificationEventHandlerTest {
             Long memberId = 200L;
             PaymentFailedEvent event = PaymentFailedEvent.create(
                     PaymentEventData.forFailure(paymentId, 10L, memberId, "ORD-002",
-                            Money.of(5000), PaymentMethod.CARD, PaymentType.FUNDING));
+                            Money.of(5000), Money.zero(), PaymentMethod.CARD, PaymentType.FUNDING));
 
             CloudEventMeta meta = new CloudEventMeta(
                     "app.giftify.payment.failed", java.net.URI.create("/giftify/payment"),

--- a/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
+++ b/bc/notification/src/test/java/app/giftify/notification/adapter/inbound/event/NotificationEventHandlerTest.java
@@ -135,7 +135,7 @@ class NotificationEventHandlerTest {
             Long memberId = 300L;
             PaymentCanceledEvent event = PaymentCanceledEvent.create(
                     PaymentEventData.forCancel(paymentId, 10L, memberId, "ORD-003",
-                            Money.of(3000), PaymentMethod.CARD, PaymentType.FUNDING,
+                            Money.of(3000), Money.zero(), PaymentMethod.CARD, PaymentType.FUNDING,
                             CancelType.CANCEL, "사용자 요청", "txn-key-001"));
 
             CloudEventMeta meta = new CloudEventMeta(

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/payment/PaymentEventData.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/payment/PaymentEventData.java
@@ -6,59 +6,62 @@ import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.Money;
 
 public record PaymentEventData(
-	Long paymentId,
-	Long orderId,
-	Long memberId,
-	String orderNumber,
-	Money amount,
-	PaymentMethod paymentMethod,
-	PaymentType paymentType,
-	CancelType cancelType,
-	String reason,
-	String paymentKey,
-	String transactionKey
+        Long paymentId,
+        Long orderId,
+        Long memberId,
+        String orderNumber,
+        Money amount,
+        Money walletDeductedAmount,
+        PaymentMethod paymentMethod,
+        PaymentType paymentType,
+        CancelType cancelType,
+        String reason,
+        String paymentKey,
+        String transactionKey
 ) {
-	public static PaymentEventData forSuccess(
-		Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
-		PaymentMethod method, PaymentType type,
-		String paymentKey, String transactionKey
-	) {
-		return new PaymentEventData(
-			paymentId, orderId, memberId, orderNumber, amount,
-			method, type, null, null, paymentKey, transactionKey
-		);
-	}
+    public static PaymentEventData forSuccess(
+            Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
+            PaymentMethod method, PaymentType type,
+            String paymentKey, String transactionKey
+    ) {
+        return new PaymentEventData(
+                paymentId, orderId, memberId, orderNumber, amount, Money.zero(),
 
-	public static PaymentEventData forFailure(
-		Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
-		PaymentMethod method, PaymentType type
-	) {
-		return new PaymentEventData(
-			paymentId, orderId, memberId, orderNumber, amount,
-			method, type, null, null, null, null
-		);
-	}
+                method, type, null, null, paymentKey, transactionKey
+        );
+    }
 
-	public static PaymentEventData forCancel(
-		Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
-		PaymentMethod method, PaymentType type,
-		CancelType cancelType, String reason,
-		String transactionKey
-	) {
-		return new PaymentEventData(
-			paymentId, orderId, memberId, orderNumber, amount,
-			method, type, cancelType, reason, null, transactionKey
-		);
-	}
+    public static PaymentEventData forFailure(
+            Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount, Money walletDeductedAmount,
+            PaymentMethod method, PaymentType type
+    ) {
+        return new PaymentEventData(
+                paymentId, orderId, memberId, orderNumber, amount, walletDeductedAmount,
 
-	public static PaymentEventData forCancelFailed(
-		Long paymentId, Long orderId, Long memberId, String orderNumber,
-		PaymentMethod method, PaymentType type,
-		String errorMetadata
-	) {
-		return new PaymentEventData(
-			paymentId, orderId, memberId, orderNumber, null,
-			method, type, null, errorMetadata, null, null
-		);
-	}
+                method, type, null, null, null, null
+        );
+    }
+
+    public static PaymentEventData forCancel(
+            Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
+            PaymentMethod method, PaymentType type,
+            CancelType cancelType, String reason,
+            String transactionKey
+    ) {
+        return new PaymentEventData(
+                paymentId, orderId, memberId, orderNumber, amount, Money.zero(),
+                method, type, cancelType, reason, null, transactionKey
+        );
+    }
+
+    public static PaymentEventData forCancelFailed(
+            Long paymentId, Long orderId, Long memberId, String orderNumber,
+            PaymentMethod method, PaymentType type,
+            String errorMetadata
+    ) {
+        return new PaymentEventData(
+                paymentId, orderId, memberId, orderNumber, null, Money.zero(),
+                method, type, null, errorMetadata, null, null
+        );
+    }
 }

--- a/bc/shared/src/main/java/app/giftify/shared/domain/event/payment/PaymentEventData.java
+++ b/bc/shared/src/main/java/app/giftify/shared/domain/event/payment/PaymentEventData.java
@@ -43,13 +43,13 @@ public record PaymentEventData(
     }
 
     public static PaymentEventData forCancel(
-            Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount,
+            Long paymentId, Long orderId, Long memberId, String orderNumber, Money amount, Money walletDeductedAmount,
             PaymentMethod method, PaymentType type,
             CancelType cancelType, String reason,
             String transactionKey
     ) {
         return new PaymentEventData(
-                paymentId, orderId, memberId, orderNumber, amount, Money.zero(),
+                paymentId, orderId, memberId, orderNumber, amount, walletDeductedAmount,
                 method, type, cancelType, reason, null, transactionKey
         );
     }

--- a/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventDataTest.java
+++ b/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventDataTest.java
@@ -35,7 +35,7 @@ class PaymentEventDataTest {
 	@DisplayName("취소 데이터 생성 - cancelType 포함")
 	void forCancel() {
 		PaymentEventData data = PaymentEventData.forCancel(
-			1L, 100L, 10L, "ORD-001", Money.of(10000),
+			1L, 100L, 10L, "ORD-001", Money.of(10000), Money.zero(),
 			PaymentMethod.CARD, PaymentType.FUNDING,
 			CancelType.REFUND, "고객 요청", "txn-key-001"
 		);

--- a/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventTest.java
+++ b/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventTest.java
@@ -36,7 +36,7 @@ class PaymentEventTest {
 	@DisplayName("PaymentFailedEvent")
 	void failedEvent() {
 		PaymentEventData data = PaymentEventData.forFailure(
-			1L, 100L, 10L, "ORD-001", Money.of(10000),
+			1L, 100L, 10L, "ORD-001", Money.of(10000), Money.zero(),
 			PaymentMethod.CARD, PaymentType.FUNDING
 		);
 

--- a/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventTest.java
+++ b/bc/shared/src/test/java/app/giftify/shared/domain/event/payment/PaymentEventTest.java
@@ -50,7 +50,7 @@ class PaymentEventTest {
 	@DisplayName("PaymentCanceledEvent - cancelType 포함")
 	void cancelSucceededEvent() {
 		PaymentEventData data = PaymentEventData.forCancel(
-			1L, 100L, 10L, "ORD-001", Money.of(10000),
+			1L, 100L, 10L, "ORD-001", Money.of(10000), Money.zero(),
 			PaymentMethod.CARD, PaymentType.FUNDING,
 			CancelType.REFUND, "고객 요청", "txn-key-001"
 		);

--- a/bootstrap/api-server/src/main/java/app/giftify/GiftifyApplication.java
+++ b/bootstrap/api-server/src/main/java/app/giftify/GiftifyApplication.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.resilience.annotation.EnableResilientMethods;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -33,6 +34,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 })
 @EnableElasticsearchRepositories(basePackages = "app.giftify")
 @EnableRetry
+@EnableResilientMethods
 @EnableAsync
 @ConfigurationPropertiesScan
 public class GiftifyApplication {

--- a/bootstrap/api-server/src/main/resources/db/migration/payment/V1.1.0__add_wallet_deducted_amount.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/payment/V1.1.0__add_wallet_deducted_amount.sql
@@ -1,0 +1,2 @@
+ALTER TABLE payments
+    ADD COLUMN wallet_deducted_amount numeric(19,2) NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary

예치금 + PG 복합결제 구현. 
예치금을 지갑에서 먼저 차감하고 성공시에만 PG 승인 시도, PG 실패 시 예치금을 지갑에 자동 복원하는 흐름입니다.

리뷰 포인트: Wallet 차감 → PG 승인 → 실패 시 복원의 트랜잭션 경계와 이벤트 흐름

---

## What's Changed

**도메인**
- `Payment`에 `walletDeductedAmount` 필드 추가
- `ReferenceType.PAYMENT_COMPENSATION`, `TransactionType.PAYMENT_DEDUCT_COMPENSATION `추가
- `CreateFundingPaymentCommand`에 `walletDeductAmount` 필드 + 팩토리 메서드(of, withWalletDeduct)
- `PaymentEventData.forFailure()`에 `walletDeductedAmount` 파라미터 추가

**서비스**
- `CreatePaymentService`에 `handleCompositePaymentForFunding() `추가
- `ConfirmPaymentService`에서 PG 실패 시 `markAsFailed()` + `PaymentFailedEvent` 발행

**보상 처리**
- `RestoreWalletCommand`에 `TransactionType`, `ReferenceType` 파라미터 추가 (기존의 하드코딩을 제거하고 파라미터를 내부로직에 사용하도록 변경)
- `PaymentFailedEventHandler` 신규 — `walletDeductedAmount > 0`이면 Wallet 복원
- `FailPaymentUseCase` + `PaymentFailService` 신규
- `PaymentTimeoutScheduler` — 복합결제는 FAILED 전환, 일반결제는 기존 취소 유지

**영속화**
- `JpaPayment`에 `walletDeductedAmount` 매핑 추가
- V1.1.0 마이그레이션 — `payments` 테이블에 `wallet_deducted_amount` 컬럼 추가

**기타**
- `TossPaymentsClient` `@Retryable`을 Spring Framework 7 Resilience로 전환 -> spring 7 부터 기본 retryable 은 지원 종료되고 Resilience 의 retryable 을 사용하도록 권고함에 따라서 입니닷
- GiftifyApplication에 `@EnableResilientMethods` 추가

---

## Decisions & Trade-offs

- **Wallet-first**: PG 환불(외부 API)보다 Wallet 복원(내부 DB)이 안정적이라 Wallet 선차감 채택
- **PaymentFailedEvent 재사용**: 별도 이벤트 없이 walletDeductedAmount > 0 분기로 처리
- **기존 스케줄러 활용**: PendingPaymentScheduler 신규 생성 대신 PaymentTimeoutScheduler에 분기 추가
- **Spring Resilience 부분 전환**: TossPaymentsClient만 선 전환, 나머지는 별도 PR 예정

---

## Future Improvements

- Spring Retry → Resilience 일괄 전환
- Wallet 부분 차감 (잔액 < 요청 금액) 지원

---

### Linked Issues

- closes #