### PR TITLE
복합결제(예치금+PG) API 레이어 활성화

### DIFF
--- a/bc/core/src/main/java/app/giftify/facade/CoreFacade.java
+++ b/bc/core/src/main/java/app/giftify/facade/CoreFacade.java
@@ -12,6 +12,7 @@ import app.giftify.payment.application.inbound.CreatePaymentCommand;
 import app.giftify.payment.application.inbound.PaymentCreatedResult;
 import app.giftify.shared.domain.type.PaymentType;
 import app.giftify.shared.domain.vo.FundingSnapshot;
+import app.giftify.shared.domain.vo.Money;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Component;
@@ -36,7 +37,7 @@ public class CoreFacade {
     public PlaceOrderResult participateFunding(ParticipateFundingCommand command) {
         OrderSnapshot orderSnapshot = orderService.createOrder(PlaceOrderCommand.of(command));
 
-        CreatePaymentCommand paymentCommand = generatePaymentCommand(orderSnapshot);
+        CreatePaymentCommand paymentCommand = generatePaymentCommand(orderSnapshot, command.walletDeductAmount());
         PaymentCreatedResult paymentResult = createPaymentService.create(paymentCommand);
 
         MarkOrderAsPaidCommand markOrderAsPaidCommand = new MarkOrderAsPaidCommand(
@@ -54,7 +55,20 @@ public class CoreFacade {
 
     // FIXME: PaymentType을 OrderSnapshot의 주문 항목 타입(OrderItemType)으로부터 결정하도록 변경 필요
     //        현재는 participateFunding() 전용이라 FUNDING 하드코딩. 일반 상품 구매 추가 시 수정.
-    private static @NonNull CreatePaymentCommand generatePaymentCommand(OrderSnapshot orderSnapshot) {
+    private static @NonNull CreatePaymentCommand generatePaymentCommand(
+            OrderSnapshot orderSnapshot, Money walletDeductAmount
+    ) {
+        if (walletDeductAmount.isGreaterThan(Money.zero())) {
+            return CreatePaymentCommand.withWalletDeduct(
+                    orderSnapshot.buyerId(),
+                    orderSnapshot.orderId(),
+                    orderSnapshot.orderNumber(),
+                    PaymentType.FUNDING,
+                    orderSnapshot.paymentMethod(),
+                    orderSnapshot.totalAmount(),
+                    walletDeductAmount
+            );
+        }
         return CreatePaymentCommand.of(
                 orderSnapshot.buyerId(),
                 orderSnapshot.orderId(),

--- a/bc/core/src/main/java/app/giftify/facade/command/ParticipateFundingCommand.java
+++ b/bc/core/src/main/java/app/giftify/facade/command/ParticipateFundingCommand.java
@@ -2,12 +2,14 @@ package app.giftify.facade.command;
 
 import app.giftify.order.application.inbound.command.PlaceOrderItemCommand;
 import app.giftify.shared.domain.type.PaymentMethod;
+import app.giftify.shared.domain.vo.Money;
 
 import java.util.List;
 
 public record ParticipateFundingCommand(
         Long buyerId,
         PaymentMethod method,
+        Money walletDeductAmount,
         List<ParticipateFundingItemCommand> items
 ) {
     public List<PlaceOrderItemCommand> getPlaceOrderItemCommands() {

--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderController.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/controller/OrderController.java
@@ -49,6 +49,7 @@ public class OrderController implements OrderV2ApiSpec {
         ParticipateFundingCommand command = new ParticipateFundingCommand(
                 memberId,
                 orderRequest.method(),
+                orderRequest.walletDeductAmount(),
                 getFundingItemCommands(orderRequest)
         );
 

--- a/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/dto/request/PlaceOrderRequest.java
+++ b/bc/core/src/main/java/app/giftify/order/adapter/inbound/web/dto/request/PlaceOrderRequest.java
@@ -1,20 +1,21 @@
 package app.giftify.order.adapter.inbound.web.dto.request;
 
 import app.giftify.shared.domain.type.PaymentMethod;
+import app.giftify.shared.domain.vo.Money;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-/**
- * 복수 주문 항목
- * @param items
- */
 public record PlaceOrderRequest(
         @NotNull
         @Size(min = 1)
         List<PlaceOrderItemRequest> items,
         @NotNull
-        PaymentMethod method
+        PaymentMethod method,
+        Money walletDeductAmount
 ) {
+    public Money walletDeductAmount() {
+        return walletDeductAmount != null ? walletDeductAmount : Money.zero();
+    }
 }

--- a/bc/core/src/test/java/app/giftify/facade/CoreFacadeTest.java
+++ b/bc/core/src/test/java/app/giftify/facade/CoreFacadeTest.java
@@ -10,6 +10,7 @@ import app.giftify.order.domain.OrderItemStatus;
 import app.giftify.order.domain.OrderSnapshot;
 import app.giftify.order.domain.OrderStatus;
 import app.giftify.payment.application.CreatePaymentService;
+import app.giftify.payment.application.inbound.CreatePaymentCommand;
 import app.giftify.payment.application.inbound.PaymentCreatedResult;
 import app.giftify.payment.domain.PaymentStatus;
 import app.giftify.shared.domain.type.OrderItemType;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -32,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.inOrder;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CoreFacade 테스트")
@@ -138,6 +141,109 @@ class CoreFacadeTest {
 
 			// then
 			assertThat(result.orderId()).isEqualTo(42L);
+		}
+
+		@Test
+		@DisplayName("walletDeductAmount=0이면 CreatePaymentCommand.of()로 생성한다")
+		void placeOrder_PurePG_CreatesCommandWithZeroWalletDeduct() {
+			// given
+			ParticipateFundingCommand command = createCommand(
+				PaymentMethod.CARD, Money.zero(), Money.of(10000));
+			OrderSnapshot orderSnapshot = createOrderSnapshot(
+				1L, "ORD-001", PaymentMethod.CARD, Money.of(10000));
+			given(orderService.createOrder(any())).willReturn(orderSnapshot);
+			given(createPaymentService.create(any())).willReturn(defaultPaymentResult("ORD-001"));
+
+			// when
+			coreFacade.participateFunding(command);
+
+			// then
+			ArgumentCaptor<CreatePaymentCommand> captor = ArgumentCaptor.forClass(CreatePaymentCommand.class);
+			verify(createPaymentService).create(captor.capture());
+
+			CreatePaymentCommand captured = captor.getValue();
+			assertThat(captured.walletDeductAmount()).isEqualTo(Money.zero());
+			assertThat(captured.expectedAmount()).isEqualTo(Money.of(10000));
+		}
+
+		@Test
+		@DisplayName("walletDeductAmount > 0이면 CreatePaymentCommand.withWalletDeduct()로 생성한다")
+		void placeOrder_Composite_CreatesCommandWithWalletDeduct() {
+			// given
+			Money walletDeduct = Money.of(3000);
+			Money totalAmount = Money.of(10000);
+			ParticipateFundingCommand command = createCommand(
+				PaymentMethod.CARD, walletDeduct, totalAmount);
+			OrderSnapshot orderSnapshot = createOrderSnapshot(
+				1L, "ORD-001", PaymentMethod.CARD, totalAmount);
+			given(orderService.createOrder(any())).willReturn(orderSnapshot);
+			given(createPaymentService.create(any())).willReturn(defaultPaymentResult("ORD-001"));
+
+			// when
+			coreFacade.participateFunding(command);
+
+			// then
+			ArgumentCaptor<CreatePaymentCommand> captor = ArgumentCaptor.forClass(CreatePaymentCommand.class);
+			verify(createPaymentService).create(captor.capture());
+
+			CreatePaymentCommand captured = captor.getValue();
+			assertThat(captured.walletDeductAmount()).isEqualTo(walletDeduct);
+			assertThat(captured.expectedAmount()).isEqualTo(totalAmount);
+		}
+
+		@Test
+		@DisplayName("walletDeductAmount = totalAmount이면 전액 예치금 결제 Command를 생성한다")
+		void placeOrder_FullWallet_CreatesCommandWithFullWalletDeduct() {
+			// given
+			Money totalAmount = Money.of(10000);
+			ParticipateFundingCommand command = createCommand(
+				PaymentMethod.CARD, totalAmount, totalAmount);
+			OrderSnapshot orderSnapshot = createOrderSnapshot(
+				1L, "ORD-001", PaymentMethod.CARD, totalAmount);
+			given(orderService.createOrder(any())).willReturn(orderSnapshot);
+			given(createPaymentService.create(any())).willReturn(defaultPaymentResult("ORD-001"));
+
+			// when
+			coreFacade.participateFunding(command);
+
+			// then
+			ArgumentCaptor<CreatePaymentCommand> captor = ArgumentCaptor.forClass(CreatePaymentCommand.class);
+			verify(createPaymentService).create(captor.capture());
+
+			CreatePaymentCommand captured = captor.getValue();
+			assertThat(captured.walletDeductAmount()).isEqualTo(totalAmount);
+			assertThat(captured.expectedAmount()).isEqualTo(totalAmount);
+		}
+
+		private ParticipateFundingCommand createCommand(
+				PaymentMethod method, Money walletDeductAmount, Money itemAmount) {
+			ParticipateFundingItemCommand item = new ParticipateFundingItemCommand(
+				1L, 10L, null, 200L, itemAmount, OrderItemType.FUNDING_GIFT);
+			return new ParticipateFundingCommand(100L, method, walletDeductAmount, List.of(item));
+		}
+
+		private OrderSnapshot createOrderSnapshot(
+				Long orderId, String orderNumber, PaymentMethod method, Money totalAmount) {
+			OrderItemSnapshot orderItem = OrderItemSnapshot.builder()
+				.orderItemId(1L).orderId(orderId).targetId(10L)
+				.targetType(TargetType.FUNDING).orderItemType(OrderItemType.FUNDING_GIFT)
+				.sellerId(200L).receiverId(200L)
+				.price(totalAmount).amount(totalAmount)
+				.status(OrderItemStatus.CREATED)
+				.build();
+			return OrderSnapshot.builder()
+				.orderId(orderId).orderNumber(orderNumber).buyerId(100L)
+				.orderItemSnapshots(List.of(orderItem))
+				.totalAmount(totalAmount).paymentMethod(method)
+				.status(OrderStatus.CREATED)
+				.createdAt(LocalDateTime.of(2026, 2, 18, 10, 0))
+				.build();
+		}
+
+		private PaymentCreatedResult defaultPaymentResult(String orderNumber) {
+			return new PaymentCreatedResult(
+				1L, orderNumber, PaymentStatus.PAID, "pay-key", "txn-key",
+				LocalDateTime.of(2026, 2, 18, 10, 0));
 		}
 	}
 }

--- a/bc/core/src/test/java/app/giftify/facade/CoreFacadeTest.java
+++ b/bc/core/src/test/java/app/giftify/facade/CoreFacadeTest.java
@@ -60,7 +60,7 @@ class CoreFacadeTest {
 			ParticipateFundingItemCommand itemCommand = new ParticipateFundingItemCommand(
 				1L, 10L, null,  200L, Money.of(10000), OrderItemType.FUNDING_GIFT);
 			ParticipateFundingCommand command = new ParticipateFundingCommand(
-				100L, PaymentMethod.CARD, List.of(itemCommand));
+				100L, PaymentMethod.CARD, Money.zero(), List.of(itemCommand));
 
 			OrderItemSnapshot orderItemSnapshot = OrderItemSnapshot.builder()
 				.orderItemId(1L).orderId(1L).targetId(10L)
@@ -106,7 +106,7 @@ class CoreFacadeTest {
 			ParticipateFundingItemCommand itemRequest = new ParticipateFundingItemCommand(
 					1L, 10L, null, 200L, Money.of(10000), OrderItemType.FUNDING_GIFT);
 			ParticipateFundingCommand command = new ParticipateFundingCommand(
-				100L, PaymentMethod.CARD, List.of(itemRequest));
+				100L, PaymentMethod.CARD, Money.zero(), List.of(itemRequest));
 
 			OrderItemSnapshot orderItemSnapshot = OrderItemSnapshot.builder()
 				.orderItemId(1L).orderId(42L).targetId(10L)


### PR DESCRIPTION
## Summary
- PR #461에서 구현된 CompositePaymentCreateStrategy를 API 레이어에서 트리거할 수 있도록 연결
- 기존 클라이언트는 walletDeductAmount 미전송 시 Money.zero()로 처리되어 하위 호환 유지

## What's Changed
- PlaceOrderRequest에 walletDeductAmount 필드 추가 (nullable, null→zero 변환)
- ParticipateFundingCommand에 walletDeductAmount 전달 경로 추가
- CoreFacade.generatePaymentCommand()에서 walletDeductAmount > 0일 때 withWalletDeduct() 사용
- CoreFacadeTest에 복합결제 분기 검증 테스트 3건 추가 (ArgumentCaptor)

## Decisions & Trade-offs
- walletDeductAmount를 @NotNull 미적용하여 기존 프론트엔드 호환성 유지
- Strategy 코드 자체는 변경 없음 — API 진입점 연결만 수행

## Future Improvements
- Payment.walletDeductedAmount 필드 제거 + EventHandler 전환 (Step 2, 별도 PR)