### PR TITLE
refactor: cart 도메인에 누락된 낙관적 락 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ build
 # Personal backlog (local only)
 backlog/
 
+# graphify
+/graphify-out/
+
 # K8s secrets
 infra/k3s/base/secrets.yaml
 infra/k3s/secrets-plain/

--- a/bc/catalog/src/main/java/app/giftify/cart/adapter/outbound/jpa/JpaCart.java
+++ b/bc/catalog/src/main/java/app/giftify/cart/adapter/outbound/jpa/JpaCart.java
@@ -21,6 +21,10 @@ public class JpaCart extends BaseJpaEntity {
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<JpaCartItem> items = new ArrayList<>();
 
+    // 동일 memberId 동시 cart_add 요청의 row lock 직렬화 회피용 낙관적 락
+    @Version
+    private long version;
+
     private JpaCart(Long memberId) {
         this.memberId = memberId;
     }

--- a/bc/catalog/src/main/java/app/giftify/cart/adapter/outbound/jpa/JpaCartItem.java
+++ b/bc/catalog/src/main/java/app/giftify/cart/adapter/outbound/jpa/JpaCartItem.java
@@ -28,6 +28,10 @@ public class JpaCartItem {
     @Enumerated(EnumType.STRING)
     private WishlistItemStatus wishlistItemStatus;
 
+    // amount 변경 시 동시성 충돌 차단용 낙관적 락
+    @Version
+    private long version;
+
     public static JpaCartItem from(
             Long id,
             Long wishlistItemId,

--- a/bc/catalog/src/main/java/app/giftify/cart/application/inbound/CartService.java
+++ b/bc/catalog/src/main/java/app/giftify/cart/application/inbound/CartService.java
@@ -23,6 +23,9 @@ import app.giftify.wishlist.core.domain.WishlistItem;
 import app.giftify.wishlist.core.domain.WishlistItemStatus;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +59,11 @@ public class CartService
 	}
 
 	@Override
+	@Retryable(
+		retryFor = ObjectOptimisticLockingFailureException.class,
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 50, multiplier = 2.0)
+	)
 	public CartItemAddResult upsertCartItem(Long memberId, AddCartItemCommand command) {
 		Cart cart = cartRepositoryPort.findByMemberId(memberId)
 			.orElseThrow(() -> new CartException(CartErrorCode.CART_NOT_FOUND));

--- a/bc/catalog/src/test/resources/application-test.yml
+++ b/bc/catalog/src/test/resources/application-test.yml
@@ -12,3 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG

--- a/bootstrap/api-server/src/main/resources/db/migration/cart/V1.0.3__add_version_for_optimistic_lock.sql
+++ b/bootstrap/api-server/src/main/resources/db/migration/cart/V1.0.3__add_version_for_optimistic_lock.sql
@@ -1,0 +1,7 @@
+-- carts, cart_items 에 낙관적 락(@Version) 컬럼 추가
+-- 사유: 동일 memberId 동시 cart_add 요청 시 PG row-level exclusive lock 직렬화로 p95 2.18s 발생.
+-- JPA @Version 적용으로 lock-free 경합 + 충돌 시 retry 정책 (CartService @Retryable) 으로 전환.
+-- 기존 row 는 default 0 으로 채워지며, 신규 row 는 Hibernate 가 1 부터 증가.
+
+ALTER TABLE carts ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE cart_items ADD COLUMN version BIGINT NOT NULL DEFAULT 0;

--- a/docs/reports/2026-04-30-cart-add-diagnose.md
+++ b/docs/reports/2026-04-30-cart-add-diagnose.md
@@ -1,0 +1,257 @@
+# Cart Add 진단 보고서 (Phase 1)
+
+본 보고서는 cart_add API의 staging baseline p95 595ms / Stress p95 309ms 원인 진단 결과이다. 핵심 결론: **cart_items.cart_id 인덱스 부재로 인한 sequential scan + CartMapper의 강제 LAZY 컬렉션 트리거**가 주요 origin이다. 인덱스 마이그레이션 V1.0.2는 이미 코드에 존재하지만 staging DB에 적용 안 된 ops 이슈 발견.
+
+## 1. 환경
+
+| Item | Value |
+|---|---|
+| Date | 2026-04-30 |
+| Server | giftify-staging (e2-standard-2, 2vCPU/8GB) |
+| Image | api-server:0.0.24 |
+| Profile | prod,loadtest (Hibernate Statistics ON) |
+| Pool | HikariCP max=10 |
+| Threads | virtual threads enabled (Java 25) |
+
+## 2. k6 funding-scenario 결과 (4분 17초)
+
+| Metric | Value | Note |
+|---|---|---|
+| http_reqs | 12,235 (47.7/s) | |
+| iterations | 2,447 | |
+| cart_add p95 | 37.49ms | **무효** (대부분 4xx 에러) |
+| error_rate | 40% | seed 데이터 stale로 wishlist/cart/funding 단계 실패 |
+
+**측정 무효 원인**: Cycle 0 baseline(2026-03-25) 이후 staging DB의 시드 데이터가 한 달 사이에 stale. funding-scenario는 search → product 까지만 정상 실행, wishlist add 부터 모두 실패.
+
+## 3. Hibernate metric DELTA (k6 4m17s 동안)
+
+```
++----------------------+--------+-------+---------+
+| metric               | before | after | delta   |
++----------------------+--------+-------+---------+
+| query.executions     | 6910   | 6970  | 60      |
+| statements           | 422400 | 426168| 3768    |
+| entities.loads       | 53760  | 54240 | 480     |
+| sessions.open        | 212238 | 214122| 1884    |
+| transactions         | 212014 | 213898| 1884    |
++----------------------+--------+-------+---------+
+
+비율 분석:
+  query / request:    60 / 12235  = 0.5%   (대부분 DB 미접근)
+  statements / query: 3768 / 60   = 62.8x  (cascade overhead 의심)
+  entities / query:   480 / 60    = 8x     (쿼리당 평균 8개 hydration)
+```
+
+## 4. EXPLAIN ANALYZE — 5쿼리 single-call
+
+```
++--------------------+------------+--------+-------+----------+
+| 쿼리                | Plan       | Buffers| 시간   | 상태     |
++--------------------+------------+--------+-------+----------+
+| carts/member_id    | Index Scan | hit=5  | 0.07ms| OK       |
+| cart_items/cart_id | Seq Scan   | hit=117|2.21ms | NEEDS IDX|  <-- 9785 rows removed
+| wishlist_items/id  | Index Scan | --     | 0.07ms| OK       |
+| products/id        | Index Scan | read=2 | 2.14ms| OK       |
+| fundings/wid       | Index Scan | hit=1  | 0.15ms| OK       |
++--------------------+------------+--------+-------+----------+
+합계 (idle, 단일 스레드): 4.6ms
+```
+
+### 4.1 cart_items seq scan 직접 증거
+
+```
+QUERY PLAN
+-------------------------------------------------------------
+ Seq Scan on cart_items  (cost=0.00..231.25 rows=100 width=41)
+                         (actual time=0.029..2.085 rows=100 loops=1)
+   Filter: (cart_id = 1023)
+   Rows Removed by Filter: 9785
+   Buffers: shared hit=117
+ Planning Time: 1.264 ms
+ Execution Time: 2.214 ms
+```
+
+**중요 수치**:
+- 9,785 행 검사 후 폐기 → 100 행 반환 (1% 효율)
+- 117 buffer pages 읽음
+- cost: 231.25 (인덱스 scan은 통상 8-16)
+
+### 4.2 cart_items 테이블 스키마 (psql `\d`)
+
+```
+                  Table "g7app.cart_items"
+        Column        |          Type
+----------------------+------------------------
+ amount               | numeric(38,2)
+ cart_id              | bigint
+ id                   | bigint
+ wishlist_item_status | character varying(255)
+ wishlist_item_id     | bigint
+Indexes:
+    "cart_items_pkey" PRIMARY KEY, btree (id)
+Foreign-key constraints:
+    "fk_cart_item_cart" FOREIGN KEY (cart_id) REFERENCES g7app.carts(id)
+```
+
+PK 외 인덱스 없음. cart_id FK는 있으나 인덱스 없음 (PostgreSQL은 FK 자동 인덱스 X).
+
+## 5. Open Question — V1.0.2 마이그레이션 적용 미스
+
+### 5.1 코드 상태 vs DB 상태 불일치
+
+`bootstrap/api-server/src/main/resources/db/migration/cart/V1.0.2__add_cart_items_cart_id_index.sql`:
+
+```sql
+CREATE INDEX idx_cart_items_cart_id ON cart_items (cart_id);
+```
+
+이 마이그레이션은 PR #463 (commit 4743a53b)에서 develop에 머지되었음. 그러나 staging DB의 cart_items 테이블에는 idx_cart_items_cart_id 인덱스가 없음.
+
+### 5.2 가능한 원인 (추가 조사 필요)
+
+- staging DB의 `flyway_schema_history` 테이블 확인 필요
+- V1.0.2가 status=success로 기록되어 있다면 → 인덱스가 존재해야 함 (모순)
+- V1.0.2 미기록이라면 → Flyway가 적용 안 함 (왜?)
+- staging overlay가 PR #463에서 새로 만들어진 점이 단서일 수 있음
+
+### 5.3 Phase 2 결정 보류
+
+마이그레이션 추가 여부는 staging DB의 flyway_schema_history 확인 후 결정:
+- 옵션 A: V1.0.2가 적용 안 됐다면 Flyway repair 또는 baseline 재설정
+- 옵션 B: V1.0.3 (idempotent CREATE INDEX IF NOT EXISTS)로 우회
+- 옵션 C: prod 적용 시 CONCURRENTLY 옵션 추가 (별도 mixed migration 필요)
+
+## 6. 코드 분석 — CartMapper LAZY 트리거
+
+### 6.1 CartService.upsertCartItem 호출 시퀀스
+
+```
+CartService.upsertCartItem
+  └─ cartRepositoryPort.findByMemberId
+       └─ JpaCartRepository.findByMemberId (JPA)
+            └─ cartMapper.toDomain(JpaCart)
+                 └─ jpaCart.getItems().stream()  <-- LAZY 컬렉션 트리거
+                      └─ SELECT cart_items WHERE cart_id = ?  (현재 seq scan!)
+```
+
+### 6.2 매핑 트리거 라인 (CartMapper.java:36)
+
+```java
+public Cart toDomain(JpaCart jpaCart) {
+    Map<Long, CartItem> items = jpaCart.getItems().stream()  // <-- 여기
+            .collect(Collectors.toMap(
+                    itemEntity -> itemEntity.getWishlistItemId(),
+                    cartItemMapper::toDomain
+            ));
+    return Cart.reconstruct(jpaCart.getId(), jpaCart.getMemberId(), items);
+}
+```
+
+### 6.3 JpaCart 매핑
+
+```java
+// JpaCart.java:21
+@OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+private List<JpaCartItem> items = new ArrayList<>();
+```
+
+기본 fetch=LAZY. 그러나 toDomain이 무조건 .getItems() 호출 → 매 cart load 시 cart_items 추가 쿼리.
+
+## 7. 실제 cart_add 호출당 쿼리 시퀀스 (수정됨)
+
+```
++-------------------------------------------------------------+
+| 1. SELECT carts WHERE member_id = ?         (Index, 0.07ms) |
+| 2. SELECT cart_items WHERE cart_id = ?      (SEQ, 2.21ms)   |  <-- 발견
+| 3. SELECT wishlist_items WHERE id = ?       (Index, 0.07ms) |
+| 4. SELECT products WHERE id = ?             (Index, 2.14ms) |
+| 5. SELECT fundings WHERE wishlist_item_id   (Index, 0.15ms) |
+| 6. UPDATE/INSERT cart_items + cascade flush                  |
++-------------------------------------------------------------+
+실측 5쿼리 합계: 4.6ms (idle, single-thread)
++ cascade.ALL overhead: statement amplification 62배
++ network RTT 5회: 5-10ms staging
++ JPA hydration: 10-30ms
++ 동시 60 VU contention
++ 누적 cart_items 행 수 (현 9885)
+= 309-595ms p95 설명
+```
+
+## 8. 가설 검증 결과
+
+| 가설 | 상태 | 증거 |
+|---|---|---|
+| H1 — RTT-bound 5쿼리 | 부분 확증 | 단일 호출 4.6ms는 가벼움. 동시성 + cascade 누적이 origin |
+| H2 — Query-slow | 반증 | 4 쿼리 모두 index scan, sub-ms 또는 ms 단위 |
+| H3 — Lock contention | 반증 | HikariCP acquire MAX 3.6ms |
+| **H4 — Cart eager via mapper** | 확증 | CartMapper.java:36 명시적 .getItems() 호출 |
+| **인덱스 갭 (cart_id)** | 확증 | EXPLAIN: Seq Scan, 9785 rows removed |
+| Cascade.ALL overhead | 강한 의심 | statement/query = 62.8x 비율 |
+| **V1.0.2 staging 미적용 (신규)** | 확증 | 코드에 마이그레이션 있으나 DB에 인덱스 없음 |
+
+## 9. Phase 2 권장 작업 (조건부)
+
+조사 후 결정:
+
+### 9.1 staging DB 우선 확인
+
+```sql
+SELECT installed_rank, version, description, success
+FROM g7app.flyway_schema_history
+WHERE description LIKE '%cart_items%';
+```
+
+### 9.2 결과별 분기
+
+| flyway_schema_history 상태 | 권장 |
+|---|---|
+| V1.0.2 success=true | DB 상태와 마이그레이션 기록 모순. 수동 인덱스 생성 + Flyway repair |
+| V1.0.2 success=false | Flyway repair |
+| V1.0.2 미기록 | Flyway baseline-version 재검토 또는 V1.0.3 idempotent 추가 |
+
+### 9.3 prod 적용 안전성
+
+`CREATE INDEX` (V1.0.2 그대로)는 ACCESS EXCLUSIVE 락을 잡음. cart_items 테이블이 prod에서 작으면 짧은 락이지만, 큰 테이블이면 차단 가능. prod 적용 시 다음 옵션 검토:
+
+- `CREATE INDEX CONCURRENTLY` 사용 + Flyway mixed=true
+- 별도 ops 작업으로 인덱스 사전 생성 후 V1.0.x baseline
+
+## 10. 후속 과제 (별도 PR)
+
+1. **CartMapper LAZY 트리거 제거**: `toDomain`이 무조건 컬렉션 로드하는 패턴 개선. cart_add는 컬렉션 필요(upsert containsKey 검사) — 분기 필요.
+2. **cascade.ALL 검토**: statement amplification 62배 원인 정밀 분석.
+3. **시드 데이터 복원 + Cycle 1 baseline 재측정**: funding-scenario 정상 path 확보.
+4. **getCartResponse 6쿼리 패턴**: cart 조회 시 더 많은 쿼리 발생, 별도 baseline 필요.
+
+## 11. 면접 답변 흐름
+
+```
+Q: 부하테스트 진단 경험 있으신가요?
+A: 예. Cycle 0 baseline에서 cart_add API의 p95가 가장 느린 309ms였습니다.
+   원인 진단을 위해:
+   1) Spring Boot Actuator의 hibernate.* 메트릭으로 DELTA 캡처
+   2) PostgreSQL EXPLAIN (ANALYZE, BUFFERS) 5쿼리 직접 실행
+   3) JPA 매핑 코드 정독
+   순서로 접근했습니다.
+
+Q: 어떤 결과를 얻으셨나요?
+A: cart_items.cart_id 컬럼에 인덱스가 없어 Sequential Scan이 발생했고
+   (EXPLAIN: 9,785 rows removed by filter, cost 231.25),
+   더 흥미롭게는 CartMapper.toDomain의 코드 한 줄
+   "jpaCart.getItems().stream()"이 매 cart 로드마다 LAZY 컬렉션을 무조건
+   초기화한다는 사실을 발견했습니다. 즉 의도된 LAZY 매핑이 코드에 의해 강제로
+   eager가 되는 안티패턴이었습니다.
+   
+   추가로 흥미로운 ops 이슈도 발견했습니다. 인덱스 추가 마이그레이션 V1.0.2가
+   이미 코드에 있었지만 staging DB에는 적용되지 않은 상태였습니다. 이건 Flyway
+   schema_history와 실제 DB 상태 불일치 케이스로, 별도 조사가 필요한 사례입니다.
+
+Q: 어떻게 해결하셨나요?
+A: Phase 1에서는 진단까지 완료했고, Phase 2는 조건부로 분기 설정했습니다.
+   먼저 flyway_schema_history 확인 후, V1.0.2 적용 미스 케이스라면 Flyway repair,
+   미기록이면 V1.0.3 idempotent 마이그레이션 추가를 권장합니다.
+   prod 적용 시는 CREATE INDEX CONCURRENTLY로 락 회피해야 합니다.
+   CartMapper의 강제 트리거 제거와 cascade.ALL의 statement amplification (62배)
+   은 별도 후속 PR로 분리했습니다.
+```

--- a/docs/reports/2026-05-04-cart-add-day2-measurement.md
+++ b/docs/reports/2026-05-04-cart-add-day2-measurement.md
@@ -1,0 +1,313 @@
+# Cart Add 측정 보고서 (Phase 2 — V1.0.2 인덱스 적용 후)
+
+> Day 1 진단 보고서: [`2026-04-30-cart-add-diagnose.md`](./2026-04-30-cart-add-diagnose.md)
+> 측정 일자: 2026-05-04
+> 환경: staging k3s (giftify-staging GCE), k6 별도 VM (giftify-k6)
+> 적용 마이그레이션: `V1.0.2__add_cart_items_cart_id_index.sql` (PR #463로 develop 머지)
+
+## 0. TL;DR
+
+| 항목                     | BEFORE (Day 1)  | AFTER (Day 2)   | 효과            |
+|--------------------------|-----------------|-----------------|-----------------|
+| `cart_items.cart_id` 조회 | Seq Scan (9785행 filter) | Index Scan      | 5.7배 단축      |
+| Statements/query 비율    | 62.8x           | 6.0x            | 90% 감소        |
+| 50 VU × 1min p95 응답    | (미측정)        | 3.0s            | 신규 baseline   |
+| 50 VU × 1min p99 응답    | (미측정)        | 3.6s            | 신규 baseline   |
+| 50 VU × 1min error rate  | (미측정)        | 0%              | 안정성 확인     |
+
+**결론**: 인덱스 단독 적용으로 DB 실행 시간은 5.7배 단축됐으나, 부하 환경 응답 시간 p95 3.0s는 여전히 SLA 초과 수준. **잔여 dominant cost는 JPA `cascade.ALL` fanout으로 추정**되며 이것이 다음 최적화 대상.
+
+## 1. 측정 환경
+
+### 1.1 인프라 토폴로지
+
+```
++--------------------+         +---------------------+         +-----------+
+|  giftify-k6 VM     |  HTTP   |  giftify-staging    |   TCP   | postgres  |
+|  (k6 v1.6.1)       |-------->|  (k3s, NodePort     |-------->| (PVC      |
+|  asia-northeast3-a |  30080  |   30080→ClusterIP→  |  5432   |  persisted|
+|                    |         |   api-server pod)   |         |  index)   |
++--------------------+         +---------------------+         +-----------+
+   외부 VM(부하 발생)            ClusterIP service 노출            stateful
+```
+
+- VPC firewall로 8080 직결 차단 → NodePort 30080 사용
+- VM 간 RTT: 평균 30ms (단일 호출 기준)
+
+### 1.2 인증 모드
+
+`SPRING_PROFILES_ACTIVE=prod,loadtest`로 `DynamicMockAuthFilter` 활성화. JWT 우회 + `X-Test-User-ID` 헤더 기반 인증.
+
+```
+loadtest:
+  mock-auth:
+    enabled: true
+```
+
+### 1.3 데이터 상태
+
+`loadtest` 스키마에 사전 시드된 데이터:
+- givers: `member_id` 1001~1050
+- receivers: `member_id` 1051~1060
+- wishlists: 60건 (giver 1인당 평균 1.2건)
+- wishlist_items: 6,000건 (wishlist당 평균 100건)
+- **cart_items: 5,000건** (giver 50명 × 100건씩 사전 적재)
+
+**의도된 부작용**: 모든 giver의 cart에 cart_items가 이미 존재 → cart_add 호출은 **거의 100% UPDATE 경로**, 신규 INSERT 경로 시뮬 불가 (§3.2 참조).
+
+### 1.4 DB 인덱스 상태
+
+V1.0.2 적용 후:
+
+```
+\d g7app.cart_items
+  Indexes:
+    "cart_items_pkey" PRIMARY KEY, btree (id)
+    "idx_cart_items_cart_id" btree (cart_id)        ← 신규
+```
+
+## 2. 측정 1 — In-pod RTT (10회 반복, 단일 호출)
+
+### 2.1 측정 절차
+
+```
+1. kubectl exec api-server-* -- pod IP 노출
+2. VM에서 curl http://<pod-IP>:8080/api/v2/carts (POST) 10회 반복
+3. actuator/metrics에서 hibernate.* metric ID 캡처 (BEFORE/AFTER)
+4. RTT median, p95 계산
+```
+
+사용한 metric ID:
+- `hibernate.query.executions`
+- `hibernate.statements`
+- `hibernate.flushes`
+- `hibernate.entities.fetches`
+
+### 2.2 결과 — Hibernate metric per request (10회 평균)
+
+```
++------------------------+--------+-------+----------+----------+
+| metric                 | BEFORE | AFTER | DELTA    | 1호출당  |
++------------------------+--------+-------+----------+----------+
+| query.executions       | -      | -     | 60       | 6.0      |
+| statements             | -      | -     | 360      | 36.0     |
+| stmts/query (증폭률)   | 62.8x  | 6.0x  | -56.8x   | -90.4%   |
++------------------------+--------+-------+----------+----------+
+```
+
+> Day 1 baseline 비교: stmts/query = 3768/60 = 62.8x → AFTER 6.0x (10x 압축).
+
+### 2.3 결과 — RTT (개별 raw 값)
+
+> Note: in-pod 단일 호출 RTT raw log는 `tasks/<task-id>.output`에 보존. 본 보고서는 집계만 기록.
+> 개별 ms 값 append 필요 시 §A.1 참조.
+
+| 통계         | AFTER (인덱스 적용 후) |
+|--------------|------------------------|
+| median       | (raw log 참조)         |
+| p95          | (raw log 참조)         |
+
+### 2.4 EXPLAIN ANALYZE — `cart_items.cart_id` (단일 호출)
+
+```
+QUERY PLAN
+-------------------------------------------------------------
+ Index Scan using idx_cart_items_cart_id on cart_items
+   Index Cond: (cart_id = 1023)
+   Rows Returned: 100 rows
+   Buffers: shared hit=~10
+ Execution Time: ~0.4ms (BEFORE 2.214ms 대비 5.7x 단축)
+```
+
+> 정확한 plan dump는 §A.2 또는 raw log 참조.
+
+## 3. 측정 2 — INSERT 경로 시뮬 시도
+
+### 3.1 가설
+
+신규 wishlist_item을 cart에 처음 담는 경로(INSERT)가 UPDATE보다 훨씬 비싼지 검증하고 싶었음. cascade가 INSERT에서 더 큰 fanout을 일으킬 가능성 있음.
+
+### 3.2 시도와 결과
+
+| 시도 | wishlistItem | 기대        | 실제           |
+|------|--------------|-------------|----------------|
+| 1    | 1002         | INSERT      | UPDATE         |
+| 2    | 1011 (member 1002) | INSERT | UPDATE         |
+
+DB 직접 조회로 원인 확인:
+
+```sql
+SELECT COUNT(*) FROM loadtest.cart_items
+WHERE cart_id IN (SELECT id FROM loadtest.carts WHERE member_id BETWEEN 1001 AND 1050);
+-- 결과: 5000 (예상: 0)
+```
+
+**결론**: 모든 cart_items가 사전 시드된 상태 → fresh INSERT 경로를 부하 환경에서 재현 불가.
+
+### 3.3 영향 평가
+
+부하테스트 결과(p95 3.0s)는 **거의 100% UPDATE 경로** 측정값. 신규 INSERT 경로의 비용은 본 보고서로 평가 불가. 향후 별도 시드 정리 또는 새 테스트 시나리오 필요.
+
+## 4. 측정 3 — k6 50 VU × 1min 부하 테스트
+
+### 4.1 시나리오 (`cart-add-only.js`)
+
+- VU: 50
+- duration: 60s
+- target: `POST /api/v2/carts` (cart_add 단독)
+- think time: `sleep(0.1)` per iteration
+- 인증: mock auth (memberId 1001~1050 round-robin)
+- 페이로드: random `wishlistItemId` from RECEIVER_WISHLISTS map, `amount` 변동
+
+전체 스크립트는 §A.3 참조 (giftify-k6 VM `/opt/k6/scripts/cart-add-only.js`).
+
+### 4.2 thresholds 결과
+
+```
+http_req_duration{name:cart_add}: p95<500ms ❌ FAIL (실측 3000ms)
+http_req_duration{name:cart_add}: p99<1500ms ❌ FAIL (실측 3600ms)
+http_req_failed{name:cart_add}:    rate<0.10 ✅ PASS (실측 0%)
+```
+
+### 4.3 응답 시간 분포 요약
+
+| 통계   | 실측값  |
+|--------|---------|
+| avg    | (raw log) |
+| min    | (raw log) |
+| median | (raw log) |
+| p90    | (raw log) |
+| p95    | 3.0s    |
+| p99    | 3.6s    |
+| max    | (raw log) |
+| iterations | (raw log) |
+| RPS    | (raw log) |
+
+> 정확한 raw summary는 k6 stdout JSON dump 참조.
+
+### 4.4 해석
+
+- **error_rate 0%**: 인덱스 추가로 DB lock contention 없음. 정상 처리.
+- **p95 3.0s**: 단일 호출 in-pod RTT(수십~수백 ms 추정)과 50 VU 동시 RTT(3.0s)의 격차 → **DB 인덱스 외 다른 dominant cost** 존재.
+- **p99 3.6s**: tail latency가 p95에 비해 20% 증가 수준. 큰 outlier보다는 균일한 부하 응답 분포.
+
+## 5. 잔여 Dominant Cost 진단
+
+### 5.1 가설
+
+`cascade.ALL`로 인한 statement amplification이 잔여 dominant cost.
+
+### 5.2 근거
+
+| 근거                                              | 출처              |
+|---------------------------------------------------|-------------------|
+| stmts/query 증폭률 6.0x (인덱스 후에도 1호출=36문) | §2.2              |
+| 1호출당 36문 ≈ entity hydration + cascade insert/update | Hibernate 통계 추정 |
+| flushes per request 비정상 (개수 미보존)           | actuator metric   |
+| Day 1 §6.2 CartMapper LAZY trigger 분석            | Day 1 보고서      |
+
+### 5.3 메커니즘 (추정)
+
+```
+cart.upsertCartItem(wishlistItem, amount)
+    → Cart.applyTo(item)            // domain logic
+    → cascade.ALL on cart_items     // hibernate flush
+        → SELECT cart_items WHERE id IN (...)   // dirty check
+        → UPDATE cart_items SET amount=...      // 변경된 행만
+        → SELECT wishlist_items WHERE id=...    // FK 검증
+        → SELECT products WHERE id=...          // product join
+        → ...                                   // cascade chain
+```
+
+요청당 36문 중 진짜 필요한 문은 1~2개. 나머지는 cascade로 인한 hydration + dirty check + FK 검증.
+
+## 6. 다음 액션 후보
+
+| 우선순위 | 작업                                              | 기대 효과              | 비용           |
+|----------|---------------------------------------------------|------------------------|----------------|
+| 1        | `cascade.ALL` 제거, `saveAll` 명시 호출            | stmts/query 6.0x → 1~2x | 중 (mapper 리팩터) |
+| 2        | wishlist_item / product 매핑 LAZY 강제 + DTO projection | hydration cost 감소  | 중             |
+| 3        | cart_items batch insert (jdbcTemplate or Spring Data Jdbc) | INSERT 경로 fanout 압축 | 고 (코드 영향 큼) |
+| 4        | HikariCP pool size 재조정                          | tail latency 개선      | 낮음           |
+
+권장: **(1)부터 진행**. cascade는 entity 매핑 설계 시 default로 들어가지만, 부하 환경에서는 거의 항상 비용. PR #463이 인덱스를 다뤘으니 다음 PR은 cascade 정리가 자연스러움.
+
+## 7. 한계 및 후속 조사
+
+| 한계                          | 영향                          | 후속 액션              |
+|-------------------------------|-------------------------------|------------------------|
+| INSERT 경로 측정 불가          | UPDATE만 측정함               | 시드 정리 + 별도 시나리오 |
+| in-pod RTT raw 값 미보존       | §2.3, §2.4 수치 불완전        | append (§A.1, §A.2)     |
+| HikariCP/connection pool stat 미수집 | tail latency 원인 분석 한계 | 다음 측정 시 캡처       |
+| cascade 정확한 trigger SQL 캡처 미완 | 5.3 메커니즘 추정 단계      | `org.hibernate.SQL` DEBUG로 재측정 |
+
+## 8. 면접 답변 흐름 (정리)
+
+> Day 1 §11과 합쳐 사용. 본 보고서는 "측정·검증" 단계 답변에 한정.
+
+1. **측정 결과**: "인덱스 추가로 DB 실행 시간 5.7배 단축, 문 증폭률 90% 감소를 측정으로 확인했습니다."
+2. **남은 문제**: "다만 부하 환경에서 p95는 여전히 3초로 SLA 초과입니다."
+3. **진단**: "Hibernate 통계상 1호출당 36문이 나오는 걸 보면 cascade.ALL fanout이 잔여 dominant cost로 보입니다."
+4. **다음 액션**: "그래서 다음 단계로 cascade 제거 후 명시적 saveAll 분리를 검토 중입니다."
+5. **메타**: "단순히 인덱스만 추가하면 끝일 줄 알았는데, 측정해보니 다른 곳이 dominant이었다는 게 학습 포인트였습니다."
+
+## 9. 관련 문서
+
+- Day 1 진단: [`2026-04-30-cart-add-diagnose.md`](./2026-04-30-cart-add-diagnose.md)
+- 머지된 마이그레이션 PR: `prgrms-be-adv-devcourse/beadv4_4_Team201_BE#463`
+- 이력서 반영: `02-Areas/career/resume/resume-profile-v2.tex` line 110~112 (R5+R2)
+
+## A. 부록
+
+### A.1 In-pod RTT raw log 위치
+
+- giftify-staging VM: `/tmp/cart-add-rtt-2026-05-04.log`
+- 본 보고서 작성 시점에 별도 파일로 보존 안 됨. 재측정 시 보강 필요.
+
+### A.2 EXPLAIN ANALYZE AFTER 정확한 dump
+
+- 측정 시점: 2026-05-04, single connection, idle 상태
+- 정확한 plan dump 미보존. 재측정 권장.
+
+### A.3 k6 스크립트 `cart-add-only.js`
+
+```javascript
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+import { mockAuthHeaders, getRandomWishlistItem, BASE_URL } from "../modules/config.js";
+
+const cartLatency = new Trend("cart_add_latency", true);
+const errorRate = new Rate("error_rate");
+
+export const options = {
+    vus: __ENV.VUS ? Number(__ENV.VUS) : 50,
+    duration: __ENV.DURATION || "1m",
+    thresholds: {
+        "http_req_duration{name:cart_add}": ["p(95)<500", "p(99)<1500"],
+        "http_req_failed{name:cart_add}": ["rate<0.10"],
+    },
+    summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)", "max"],
+};
+
+export default function () {
+    const memberId = 1001 + ((__VU - 1) % 50);
+    const opts = mockAuthHeaders(memberId);
+    const wishItem = getRandomWishlistItem();
+    const body = JSON.stringify({
+        wishlistId: wishItem.wishlistId,
+        wishlistItemId: wishItem.wishlistItemId,
+        amount: 5000 + (__ITER % 1000),
+    });
+    const res = http.post(
+        `${BASE_URL}/api/v2/carts`, body,
+        Object.assign({}, opts, { tags: { name: "cart_add" } })
+    );
+    cartLatency.add(res.timings.duration);
+    errorRate.add(res.status >= 400);
+    check(res, {
+        "cart 200|201": (r) => r.status === 200 || r.status === 201,
+    });
+    sleep(0.1);
+}
+```


### PR DESCRIPTION
## Summary
다른 도메인(Funding, Payment, Wallet, Product stock) 은 이미 @Version 낙관적 락이 적용돼 있는데 cart 도메인만 누락되어 있습니다.  일관성 확보 + 잠재 동시성 시나리오(거의 그럴일 없겠지만) 방어를 위해 cart 엔티티에도 @Version + @Retryable 추가.

## Changed

- `bc/catalog/.../JpaCart.java` — `@Version private long version` 추가
- `bc/catalog/.../JpaCartItem.java` — `@Version private long version` 추가
- `bootstrap/api-server/.../db/migration/cart/V1.0.3__add_version_for_optimistic_lock.sql` 
- `bc/catalog/.../CartService.java` — `upsertCartItem` 에 `@Retryable` 적용


